### PR TITLE
feat(lsp): forward did-save to bridge servers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,8 +120,8 @@ nix = { version = "0.31", features = ["signal", "process", "fs"] }
 [features]
 e2e = []
 
-# Unix-only dev dependencies: pipe() for deterministic broken-pipe tests,
-# Signal::SIGPIPE for asserting the termination signal.
+# Unix-only dev dependencies: pipe2()/pipe() for deterministic broken-pipe
+# tests, Signal::SIGPIPE for asserting the termination signal.
 [target.'cfg(unix)'.dev-dependencies]
 nix = { version = "0.31", features = ["fs", "signal"] }
 

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -82,15 +82,14 @@ Partially implemented:
   - **`willSave`** goes to host servers that already have the host document
     open *and* to every open virtual document (URI rewritten to the virtual
     one, reason verbatim);
-  - **`didSave`** goes to every open virtual document (URI rewritten); it is
-    not forwarded to host servers today (the host `didSave` handler drives the
-    synthetic-diagnostic pull instead).
+  - **`didSave`** goes to host servers that already have the real document open
+    and to every open virtual document (URI rewritten for the latter).
 
   Each recipient is **gated per-server** on the relevant capability —
   `willSave` on `textDocumentSync.willSave`, `didSave` on `textDocumentSync.save`
   — which is also the safety valve: a virt server only hears about a fragment
   "save" if it opted into save hooks; one that didn't never sees it. The
-  `didSave` gate additionally **excludes servers that demand
+  `didSave` gate on both layers additionally **excludes servers that demand
   `save.includeText = true`**: kakehashi advertises `includeText = false`
   upstream and so never receives the editor's saved bytes, so rather than send a
   contract-violating textless didSave it declines (the server still has current
@@ -98,7 +97,8 @@ Partially implemented:
   *dynamic* didSave registration is not honored for forwarding, since the
   method-name-only dynamic registry cannot carry `includeText` and could
   otherwise smuggle an `includeText = true` server past the filter. Both are
-  fire-and-forget (no lazy spawn). `willSave` is advertised whenever a runnable
+  fire-and-forget (no lazy spawn). Host recipients receive the real URI
+  verbatim; virtual recipients receive their projected URI. `willSave` is advertised whenever a runnable
   bridge server (host or virt) is configured; `didSave` is always advertised to
   the editor (`save.includeText = false`).
 

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -87,9 +87,13 @@ Partially implemented:
     an eligible host server receives the textless notification, kakehashi
     queues any pending full-text `didChange` and `didSave` under the same
     connection/document lock, so save hooks observe the editor's latest text.
-    Virtual forwarding first waits for the current parse snapshot and runs the
-    injection `didChange` pass; if that bounded settle cannot complete, it drops
-    the virtual `didSave` instead of running a save hook on stale fragment text.
+    Virtual forwarding binds the parse snapshot and projected content to the
+    exact incarnation/content version observed at save time, revalidates that
+    version under the edit lock, and queues a required injection `didChange`
+    before `didSave` under the virtual document's transition lock. If the 200ms
+    settle expires, the document advances, or the `didChange` enqueue fails, it
+    drops the virtual `didSave` instead of running a save hook on stale or later
+    unsaved fragment text.
 
   Each recipient is **gated per-server** on the relevant capability —
   `willSave` on `textDocumentSync.willSave`, `didSave` on `textDocumentSync.save`

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -98,7 +98,19 @@ Partially implemented:
     Synthetic diagnostic collection registers an abortable background waiter
     for that exact saved incarnation/version and snapshots only after its tree
     is ready; parse or parser-install latency therefore neither blocks the
-    writer nor silently loses the save trigger.
+    writer nor silently loses the save trigger. Snapshot preparation repeats
+    that lineage check atomically with the snapshot read. A later `didChange`
+    aborts the saved pull before mutating the document, and the completed pull
+    revalidates and publishes under the same edit lock, so neither the
+    wait-to-snapshot window nor an in-flight downstream request can commit
+    diagnostics for an obsolete saved version. Background diagnostic ownership
+    is ordered by `(incarnation, content version, settings generation, trigger)`, with
+    `didSave > didChange > didOpen` at an equal version and settings generation;
+    a late parse/debounce registration therefore cannot cancel the
+    already-registered save trigger, while a newer configuration generation
+    can legitimately supersede it.
+    Tasks remain behind a start gate until that ownership registration wins;
+    shutdown permanently closes registration before aborting current tasks.
 
   Each recipient is **gated per-server** on the relevant capability —
   `willSave` on `textDocumentSync.willSave`, `didSave` on `textDocumentSync.save`

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -83,7 +83,10 @@ Partially implemented:
     open *and* to every open virtual document (URI rewritten to the virtual
     one, reason verbatim);
   - **`didSave`** goes to host servers that already have the real document open
-    and to every open virtual document (URI rewritten for the latter).
+    and to every open virtual document (URI rewritten for the latter). Before
+    an eligible host server receives the textless notification, kakehashi
+    queues any pending full-text `didChange` and `didSave` under the same
+    connection/document lock, so save hooks observe the editor's latest text.
 
   Each recipient is **gated per-server** on the relevant capability —
   `willSave` on `textDocumentSync.willSave`, `didSave` on `textDocumentSync.save`
@@ -92,8 +95,7 @@ Partially implemented:
   `didSave` gate on both layers additionally **excludes servers that demand
   `save.includeText = true`**: kakehashi advertises `includeText = false`
   upstream and so never receives the editor's saved bytes, so rather than send a
-  contract-violating textless didSave it declines (the server still has current
-  content from didChange). That gate reads **static** capabilities only — a
+  contract-violating textless didSave it declines. That gate reads **static** capabilities only — a
   *dynamic* didSave registration is not honored for forwarding, since the
   method-name-only dynamic registry cannot carry `includeText` and could
   otherwise smuggle an `includeText = true` server past the filter. Both are

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -93,7 +93,8 @@ Partially implemented:
     before `didSave` under the virtual document's transition lock. If the 200ms
     settle expires, the document advances, or the `didChange` enqueue fails, it
     drops the virtual `didSave` instead of running a save hook on stale or later
-    unsaved fragment text.
+    unsaved fragment text. At ingress, `didSave` is a per-document writer fence,
+    so a later wire-order `didChange` cannot overtake save-time version capture.
 
   Each recipient is **gated per-server** on the relevant capability —
   `willSave` on `textDocumentSync.willSave`, `didSave` on `textDocumentSync.save`

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -87,6 +87,9 @@ Partially implemented:
     an eligible host server receives the textless notification, kakehashi
     queues any pending full-text `didChange` and `didSave` under the same
     connection/document lock, so save hooks observe the editor's latest text.
+    Virtual forwarding first waits for the current parse snapshot and runs the
+    injection `didChange` pass; if that bounded settle cannot complete, it drops
+    the virtual `didSave` instead of running a save hook on stale fragment text.
 
   Each recipient is **gated per-server** on the relevant capability —
   `willSave` on `textDocumentSync.willSave`, `didSave` on `textDocumentSync.save`

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -84,8 +84,8 @@ Partially implemented:
     one, reason verbatim);
   - **`didSave`** goes to host servers that already have the real document open
     and to every open virtual document (URI rewritten for the latter). Before
-    an eligible host server receives the textless notification, kakehashi
-    queues any pending full-text `didChange` and `didSave` under the same
+    an eligible host server receives the notification, kakehashi queues any
+    pending full-text `didChange` and `didSave` under the same
     connection/document lock, so save hooks observe the editor's latest text.
     Virtual forwarding binds the parse snapshot and projected content to the
     exact incarnation/content version observed at save time, revalidates that
@@ -100,13 +100,11 @@ Partially implemented:
   `willSave` on `textDocumentSync.willSave`, `didSave` on `textDocumentSync.save`
   — which is also the safety valve: a virt server only hears about a fragment
   "save" if it opted into save hooks; one that didn't never sees it. The
-  `didSave` gate on both layers additionally **excludes servers that demand
-  `save.includeText = true`**: kakehashi advertises `includeText = false`
-  upstream and so never receives the editor's saved bytes, so rather than send a
-  contract-violating textless didSave it declines. That gate reads **static** capabilities only — a
-  *dynamic* didSave registration is not honored for forwarding, since the
-  method-name-only dynamic registry cannot carry `includeText` and could
-  otherwise smuggle an `includeText = true` server past the filter. Both are
+  `didSave` reads the server's **static** `save.includeText` preference. When it
+  is true, kakehashi attaches the tracked host text or the exact projected
+  virtual text bound to that save; otherwise it sends a textless notification.
+  A *dynamic-only* didSave registration is not honored for forwarding, since
+  the method-name-only dynamic registry cannot retain `includeText`. Both are
   fire-and-forget (no lazy spawn). Host recipients receive the real URI
   verbatim; virtual recipients receive their projected URI. `willSave` is advertised whenever a runnable
   bridge server (host or virt) is configured; `didSave` is always advertised to

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -95,6 +95,10 @@ Partially implemented:
     drops the virtual `didSave` instead of running a save hook on stale or later
     unsaved fragment text. At ingress, `didSave` is a per-document writer fence,
     so a later wire-order `didChange` cannot overtake save-time version capture.
+    Synthetic diagnostic collection registers an abortable background waiter
+    for that exact saved incarnation/version and snapshots only after its tree
+    is ready; parse or parser-install latency therefore neither blocks the
+    writer nor silently loses the save trigger.
 
   Each recipient is **gated per-server** on the relevant capability —
   `willSave` on `textDocumentSync.willSave`, `didSave` on `textDocumentSync.save`

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -657,6 +657,11 @@ impl DocumentStore {
         self.edit_locks.remove(uri);
     }
 
+    #[cfg(test)]
+    pub(crate) fn has_edit_lock(&self, uri: &Url) -> bool {
+        self.edit_locks.contains_key(uri)
+    }
+
     /// Remove the edit-lock entry, but only while the map
     /// still holds the exact `Arc` the caller acquired AND nobody else
     /// holds a clone — for miss paths that probe liveness some time after

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -21,7 +21,7 @@ mod settings;
 
 pub use bridge::LanguageServerPool;
 pub use ingress_order::IngressOrderGate;
-pub(crate) use ingress_order::current_writer_ticket;
+pub(crate) use ingress_order::{current_writer_ticket, reclaim_current_writer_sequence};
 pub use lsp_impl::Kakehashi;
 pub(crate) use request_id::current_upstream_id;
 pub use request_id::{CancelForwarder, RequestIdCapture};

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -872,8 +872,9 @@ impl ConnectionHandle {
             // didSave forwarding (virt save fan-out, #357) needs an
             // includeText-aware decision that the dynamic registry — which is
             // method-name-only and cannot carry `save.includeText` — would
-            // bypass. It uses [`Self::accepts_textless_did_save`] (static
-            // capabilities only) instead.
+            // bypass. It uses [`Self::did_save_include_text`] (static
+            // capabilities only) instead, retaining the server's text
+            // preference so the caller can shape the notification correctly.
             "textDocument/documentSymbol" => {
                 matches!(
                     caps.document_symbol_provider,
@@ -901,37 +902,27 @@ impl ConnectionHandle {
             .is_some_and(|provider| provider.commands.iter().any(|name| name == command))
     }
 
-    /// Whether this server accepts a **textless** `textDocument/didSave` from the
-    /// virt save fan-out (#357): it must advertise `save` in its STATIC
-    /// (initialize) `textDocumentSync` *without* demanding `includeText = true`.
+    /// Return whether this server requests text in `textDocument/didSave`, or
+    /// `None` when its STATIC (initialize) `textDocumentSync` does not support
+    /// save notifications (#357).
     ///
     /// Deliberately reads only static capabilities, NOT the dynamic registry:
-    /// kakehashi advertises `includeText = false` to the editor and so never
-    /// receives the saved bytes to forward, and the method-name-only dynamic
-    /// registry cannot carry `save.includeText` — so trusting a dynamic didSave
-    /// registration could send a textless didSave to a server that registered
-    /// `includeText: true`. `includeText = true`, `Supported(false)`, the bare
-    /// `Kind` form, and an absent `save` all yield false. A server that opts in
-    /// without `includeText` already has current content from the didChange
-    /// stream, so the textless notification is sufficient.
-    pub(crate) fn accepts_textless_did_save(&self) -> bool {
-        let Some(caps) = self.server_capabilities() else {
-            return false;
-        };
-        matches!(
-            caps.text_document_sync,
-            Some(TextDocumentSyncCapability::Options(
-                TextDocumentSyncOptions {
-                    save: Some(
-                        TextDocumentSyncSaveOptions::Supported(true)
-                            | TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
-                                include_text: None | Some(false),
-                            })
-                    ),
-                    ..
-                }
-            ))
-        )
+    /// The method-name-only dynamic registry cannot retain `includeText`, so a
+    /// dynamic-only registration is deliberately not accepted. `Supported(false)`,
+    /// the bare `Kind` form, and an absent `save` all yield `None`.
+    pub(crate) fn did_save_include_text(&self) -> Option<bool> {
+        let caps = self.server_capabilities()?;
+        match caps.text_document_sync {
+            Some(TextDocumentSyncCapability::Options(TextDocumentSyncOptions {
+                save: Some(TextDocumentSyncSaveOptions::Supported(true)),
+                ..
+            })) => Some(false),
+            Some(TextDocumentSyncCapability::Options(TextDocumentSyncOptions {
+                save: Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions { include_text })),
+                ..
+            })) => Some(include_text.unwrap_or(false)),
+            _ => None,
+        }
     }
 
     /// Begin graceful shutdown: transition to Closing (rejecting new requests) and
@@ -2629,21 +2620,33 @@ mod tests {
         }
     }
 
-    /// `accepts_textless_did_save` is true for a static `save` opt-in without
-    /// `includeText` — both the `Supported(true)` and `SaveOptions` forms (#357).
+    /// `did_save_include_text` returns the static server preference for every
+    /// supported `save` form (#357).
     #[tokio::test]
-    async fn accepts_textless_did_save_true_for_save_without_include_text() {
+    async fn did_save_include_text_preserves_the_static_server_preference() {
         use tower_lsp_server::ls_types::{
             SaveOptions, TextDocumentSyncCapability, TextDocumentSyncOptions,
             TextDocumentSyncSaveOptions,
         };
 
-        for save in [
-            TextDocumentSyncSaveOptions::Supported(true),
-            TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
-                include_text: Some(false),
-            }),
-            TextDocumentSyncSaveOptions::SaveOptions(SaveOptions { include_text: None }),
+        for (save, expected) in [
+            (TextDocumentSyncSaveOptions::Supported(true), false),
+            (
+                TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
+                    include_text: Some(false),
+                }),
+                false,
+            ),
+            (
+                TextDocumentSyncSaveOptions::SaveOptions(SaveOptions { include_text: None }),
+                false,
+            ),
+            (
+                TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
+                    include_text: Some(true),
+                }),
+                true,
+            ),
         ] {
             let handle = spawn_sink_handle().await;
             handle.set_server_capabilities(ServerCapabilities {
@@ -2655,36 +2658,27 @@ mod tests {
                 )),
                 ..Default::default()
             });
-            assert!(handle.accepts_textless_did_save());
+            assert_eq!(handle.did_save_include_text(), Some(expected));
         }
     }
 
-    /// `accepts_textless_did_save` is false with no capabilities, for
-    /// `Supported(false)`, the bare `Kind` form, and — crucially — a server
-    /// demanding `save.includeText = true` (kakehashi cannot supply the text)
-    /// (#357).
+    /// Unsupported and dynamic-only save capabilities remain ineligible (#357).
     #[tokio::test]
-    async fn accepts_textless_did_save_false_cases() {
+    async fn did_save_include_text_rejects_unsupported_or_dynamic_only_servers() {
         use tower_lsp_server::ls_types::{
-            Registration, SaveOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
+            Registration, TextDocumentSyncCapability, TextDocumentSyncKind,
             TextDocumentSyncOptions, TextDocumentSyncSaveOptions,
         };
 
         // No capabilities at all.
         let handle = spawn_sink_handle().await;
         handle.set_server_capabilities(ServerCapabilities::default());
-        assert!(!handle.accepts_textless_did_save());
+        assert_eq!(handle.did_save_include_text(), None);
 
         let sync_cases = [
             TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL),
             TextDocumentSyncCapability::Options(TextDocumentSyncOptions {
                 save: Some(TextDocumentSyncSaveOptions::Supported(false)),
-                ..Default::default()
-            }),
-            TextDocumentSyncCapability::Options(TextDocumentSyncOptions {
-                save: Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
-                    include_text: Some(true),
-                })),
                 ..Default::default()
             }),
         ];
@@ -2694,7 +2688,7 @@ mod tests {
                 text_document_sync: Some(sync),
                 ..Default::default()
             });
-            assert!(!handle.accepts_textless_did_save());
+            assert_eq!(handle.did_save_include_text(), None);
         }
 
         let handle = spawn_sink_handle().await;
@@ -2705,7 +2699,7 @@ mod tests {
             register_options: Some(serde_json::json!({ "includeText": false })),
         }]);
         assert!(
-            !handle.accepts_textless_did_save(),
+            handle.did_save_include_text().is_none(),
             "dynamic-only didSave must not bypass the static includeText-aware gate"
         );
     }

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -2666,8 +2666,8 @@ mod tests {
     #[tokio::test]
     async fn accepts_textless_did_save_false_cases() {
         use tower_lsp_server::ls_types::{
-            SaveOptions, TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
-            TextDocumentSyncSaveOptions,
+            Registration, SaveOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
+            TextDocumentSyncOptions, TextDocumentSyncSaveOptions,
         };
 
         // No capabilities at all.
@@ -2696,6 +2696,18 @@ mod tests {
             });
             assert!(!handle.accepts_textless_did_save());
         }
+
+        let handle = spawn_sink_handle().await;
+        handle.set_server_capabilities(ServerCapabilities::default());
+        handle.dynamic_capabilities().register(vec![Registration {
+            id: "save-1".to_string(),
+            method: "textDocument/didSave".to_string(),
+            register_options: Some(serde_json::json!({ "includeText": false })),
+        }]);
+        assert!(
+            !handle.accepts_textless_did_save(),
+            "dynamic-only didSave must not bypass the static includeText-aware gate"
+        );
     }
 
     /// The bare `Kind` form of `textDocumentSync` (a sync-kind number) carries

--- a/src/lsp/bridge/pool/test_helpers.rs
+++ b/src/lsp/bridge/pool/test_helpers.rs
@@ -139,6 +139,27 @@ pub(in crate::lsp::bridge) async fn create_handle_with_key(
     create_handle_with_state_and_pid_keyed(state, key).await.0
 }
 
+pub(in crate::lsp::bridge) async fn create_handle_accepting_textless_did_save(
+    key: ConnectionKey,
+) -> Arc<ConnectionHandle> {
+    use tower_lsp_server::ls_types::{
+        ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncOptions,
+        TextDocumentSyncSaveOptions,
+    };
+
+    let handle = create_handle_with_key(ConnectionState::Ready, key).await;
+    handle.set_server_capabilities(ServerCapabilities {
+        text_document_sync: Some(TextDocumentSyncCapability::Options(
+            TextDocumentSyncOptions {
+                save: Some(TextDocumentSyncSaveOptions::Supported(true)),
+                ..Default::default()
+            },
+        )),
+        ..Default::default()
+    });
+    handle
+}
+
 /// Like [`create_handle_with_key`], but also advertises `commands` as the
 /// connection's static `executeCommandProvider.commands`, and optionally records
 /// `spawned_from` as the config the connection was launched with.

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -24,7 +24,8 @@ fn build_baseline_capabilities(
         DocumentSymbolClientCapabilities, DynamicRegistrationClientCapabilities,
         GeneralClientCapabilities, GotoCapability, HoverClientCapabilities,
         InlayHintClientCapabilities, PositionEncodingKind, SignatureHelpClientCapabilities,
-        TextDocumentClientCapabilities, WorkspaceClientCapabilities,
+        TextDocumentClientCapabilities, TextDocumentSyncClientCapabilities,
+        WorkspaceClientCapabilities,
     };
 
     let goto_link = Some(GotoCapability {
@@ -33,6 +34,11 @@ fn build_baseline_capabilities(
     });
 
     let mut text_document = TextDocumentClientCapabilities {
+        synchronization: Some(TextDocumentSyncClientCapabilities {
+            dynamic_registration: Some(false),
+            did_save: Some(true),
+            ..Default::default()
+        }),
         hover: Some(HoverClientCapabilities {
             dynamic_registration: Some(false),
             ..Default::default()

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -473,6 +473,19 @@ mod tests {
     }
 
     #[test]
+    fn bridge_advertises_static_did_save_support() {
+        let capabilities = build_bridge_client_capabilities(None, true, false);
+        let synchronization = capabilities
+            .text_document
+            .as_ref()
+            .and_then(|text_document| text_document.synchronization.as_ref())
+            .expect("the bridge must advertise text-document synchronization");
+
+        assert_eq!(synchronization.dynamic_registration, Some(false));
+        assert_eq!(synchronization.did_save, Some(true));
+    }
+
+    #[test]
     fn merge_mirrors_workspace_edit_capability_without_annotations() {
         use tower_lsp_server::ls_types::{
             ChangeAnnotationWorkspaceEditClientCapabilities, FailureHandlingKind,

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
@@ -22,6 +22,10 @@ expression: merged
     }
   },
   "textDocument": {
+    "synchronization": {
+      "dynamicRegistration": false,
+      "didSave": true
+    },
     "completion": {
       "dynamicRegistration": false,
       "completionItem": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@experimental.snap
@@ -22,6 +22,10 @@ expression: merged
     }
   },
   "textDocument": {
+    "synchronization": {
+      "dynamicRegistration": false,
+      "didSave": true
+    },
     "completion": {
       "dynamicRegistration": false,
       "completionItem": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
@@ -14,6 +14,10 @@ expression: capabilities
     }
   },
   "textDocument": {
+    "synchronization": {
+      "dynamicRegistration": false,
+      "didSave": true
+    },
     "completion": {
       "dynamicRegistration": false,
       "completionItem": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@experimental.snap
@@ -14,6 +14,10 @@ expression: capabilities
     }
   },
   "textDocument": {
+    "synchronization": {
+      "dynamicRegistration": false,
+      "didSave": true
+    },
     "completion": {
       "dynamicRegistration": false,
       "completionItem": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
@@ -21,6 +21,10 @@ expression: request
         }
       },
       "textDocument": {
+        "synchronization": {
+          "dynamicRegistration": false,
+          "didSave": true
+        },
         "completion": {
           "dynamicRegistration": false,
           "completionItem": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@experimental.snap
@@ -21,6 +21,10 @@ expression: request
         }
       },
       "textDocument": {
+        "synchronization": {
+          "dynamicRegistration": false,
+          "didSave": true
+        },
         "completion": {
           "dynamicRegistration": false,
           "completionItem": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
@@ -32,6 +32,10 @@ expression: request
         }
       },
       "textDocument": {
+        "synchronization": {
+          "dynamicRegistration": false,
+          "didSave": true
+        },
         "completion": {
           "dynamicRegistration": false,
           "completionItem": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@experimental.snap
@@ -32,6 +32,10 @@ expression: request
         }
       },
       "textDocument": {
+        "synchronization": {
+          "dynamicRegistration": false,
+          "didSave": true
+        },
         "completion": {
           "dynamicRegistration": false,
           "completionItem": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
@@ -21,6 +21,10 @@ expression: request
         }
       },
       "textDocument": {
+        "synchronization": {
+          "dynamicRegistration": false,
+          "didSave": true
+        },
         "completion": {
           "dynamicRegistration": false,
           "completionItem": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@experimental.snap
@@ -21,6 +21,10 @@ expression: request
         }
       },
       "textDocument": {
+        "synchronization": {
+          "dynamicRegistration": false,
+          "didSave": true
+        },
         "completion": {
           "dynamicRegistration": false,
           "completionItem": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
@@ -21,6 +21,10 @@ expression: request
         }
       },
       "textDocument": {
+        "synchronization": {
+          "dynamicRegistration": false,
+          "didSave": true
+        },
         "completion": {
           "dynamicRegistration": false,
           "completionItem": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@experimental.snap
@@ -21,6 +21,10 @@ expression: request
         }
       },
       "textDocument": {
+        "synchronization": {
+          "dynamicRegistration": false,
+          "didSave": true
+        },
         "completion": {
           "dynamicRegistration": false,
           "completionItem": {

--- a/src/lsp/bridge/text_document/did_change.rs
+++ b/src/lsp/bridge/text_document/did_change.rs
@@ -149,7 +149,7 @@ impl LanguageServerPool {
     /// if the queue is full the notification is dropped with a warning log. The
     /// returned [`NotificationSendResult`] lets the caller record the content
     /// fingerprint only on a confirmed `Queued` enqueue (#422).
-    fn send_didchange_for_virtual_doc(
+    pub(super) fn send_didchange_for_virtual_doc(
         handle: &Arc<ConnectionHandle>,
         virtual_uri: &str,
         content: &str,

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -82,6 +82,37 @@ fn fingerprint(text: &str) -> u64 {
     hasher.finish()
 }
 
+async fn resync_open_host_document<S: MessageSender>(
+    sender: &mut S,
+    state: &mut HostDocSyncState,
+    uri: Uri,
+    text: &str,
+) -> io::Result<()> {
+    let fp = fingerprint(text);
+    if state.fingerprint == fp {
+        return Ok(());
+    }
+
+    let version = state.version + 1;
+    let notification = JsonRpcNotification::new(
+        "textDocument/didChange",
+        DidChangeTextDocumentParams {
+            text_document: VersionedTextDocumentIdentifier::new(uri, version),
+            content_changes: vec![TextDocumentContentChangeEvent {
+                range: None,
+                range_length: None,
+                text: text.to_string(),
+            }],
+        },
+    );
+    sender.send_notification(notification).await?;
+    *state = HostDocSyncState {
+        version,
+        fingerprint: fp,
+    };
+    Ok(())
+}
+
 /// Owned reader of a host document's current text, shared across the eager
 /// re-sync's per-server tasks. The eager on-edit re-sync builds one (capturing
 /// the document store + URI) and hands a clone to each task; the task passes it
@@ -155,25 +186,7 @@ pub(super) async fn sync_host_document<S: MessageSender>(
             });
         }
         Entry::Occupied(mut entry) => {
-            if entry.get().fingerprint != fp {
-                let version = entry.get().version + 1;
-                let notification = JsonRpcNotification::new(
-                    "textDocument/didChange",
-                    DidChangeTextDocumentParams {
-                        text_document: VersionedTextDocumentIdentifier::new(uri_lsp, version),
-                        content_changes: vec![TextDocumentContentChangeEvent {
-                            range: None,
-                            range_length: None,
-                            text: text.to_string(),
-                        }],
-                    },
-                );
-                sender.send_notification(notification).await?;
-                *entry.get_mut() = HostDocSyncState {
-                    version,
-                    fingerprint: fp,
-                };
-            }
+            resync_open_host_document(sender, entry.get_mut(), uri_lsp, text).await?;
         }
     }
     Ok(())
@@ -278,18 +291,37 @@ impl LanguageServerPool {
         .await;
     }
 
-    /// Forward a textless `textDocument/didSave` notification to every host
-    /// bridge server that already has this host document open and whose static
-    /// sync capability accepts saves without text.
-    pub(crate) async fn notify_host_did_save(&self, uri: &Url) {
+    /// Re-sync the current host text and then forward a textless
+    /// `textDocument/didSave` to every eligible, already-open host server.
+    /// Both notifications are queued while the connection and host-document
+    /// maps stay locked, preserving their downstream wire order.
+    pub(crate) async fn sync_and_notify_host_did_save(&self, uri: &Url, text: &str) {
         let params = serde_json::json!({ "textDocument": { "uri": uri.as_str() } });
-        self.notify_open_host_documents(
-            uri,
-            "textDocument/didSave",
-            ConnectionHandle::accepts_textless_did_save,
-            &params,
-        )
-        .await;
+        let Ok(uri_lsp) = host_url_to_lsp_uri(uri) else {
+            return;
+        };
+        let uri_string = uri.as_str().to_owned();
+
+        let connections = self.connections().await;
+        let mut docs = self.host_documents().await;
+        for (connection_key, handle) in connections.iter() {
+            if !can_notify_host_document(handle, &ConnectionHandle::accepts_textless_did_save) {
+                continue;
+            }
+            let Some(state) = docs.get_mut(&(uri_string.clone(), connection_key.clone())) else {
+                continue;
+            };
+
+            let mut sender = ConnectionHandleSender(handle);
+            if resync_open_host_document(&mut sender, state, uri_lsp.clone(), text)
+                .await
+                .is_err()
+            {
+                continue;
+            }
+            let notification = JsonRpcNotification::new("textDocument/didSave", &params);
+            let _ = sender.send_notification(notification).await;
+        }
     }
 
     /// Notify every live host connection that already has `uri` open and

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -291,12 +291,12 @@ impl LanguageServerPool {
         .await;
     }
 
-    /// Re-sync the current host text and then forward a textless
-    /// `textDocument/didSave` to every eligible, already-open host server.
+    /// Re-sync the current host text and then forward `textDocument/didSave` to
+    /// every eligible, already-open host server, attaching that saved text when
+    /// the server's static capability requests it.
     /// Both notifications are queued while the connection and host-document
     /// maps stay locked, preserving their downstream wire order.
     pub(crate) async fn sync_and_notify_host_did_save(&self, uri: &Url, text: &str) {
-        let params = serde_json::json!({ "textDocument": { "uri": uri.as_str() } });
         let Ok(uri_lsp) = host_url_to_lsp_uri(uri) else {
             return;
         };
@@ -305,9 +305,13 @@ impl LanguageServerPool {
         let connections = self.connections().await;
         let mut docs = self.host_documents().await;
         for (connection_key, handle) in connections.iter() {
-            if !can_notify_host_document(handle, &ConnectionHandle::accepts_textless_did_save) {
+            if !can_notify_host_document(handle, &|handle| handle.did_save_include_text().is_some())
+            {
                 continue;
             }
+            let Some(include_text) = handle.did_save_include_text() else {
+                continue;
+            };
             let Some(state) = docs.get_mut(&(uri_string.clone(), connection_key.clone())) else {
                 continue;
             };
@@ -319,6 +323,11 @@ impl LanguageServerPool {
             {
                 continue;
             }
+            let params = if include_text {
+                serde_json::json!({ "textDocument": { "uri": uri.as_str() }, "text": text })
+            } else {
+                serde_json::json!({ "textDocument": { "uri": uri.as_str() } })
+            };
             let notification = JsonRpcNotification::new("textDocument/didSave", &params);
             let _ = sender.send_notification(notification).await;
         }

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -271,6 +271,20 @@ impl LanguageServerPool {
         .await;
     }
 
+    /// Forward a textless `textDocument/didSave` notification to every host
+    /// bridge server that already has this host document open and whose static
+    /// sync capability accepts saves without text.
+    pub(crate) async fn notify_host_did_save(&self, uri: &Url) {
+        let params = serde_json::json!({ "textDocument": { "uri": uri.as_str() } });
+        self.notify_open_host_documents(
+            uri,
+            "textDocument/didSave",
+            ConnectionHandle::accepts_textless_did_save,
+            &params,
+        )
+        .await;
+    }
+
     /// Notify every live host connection that already has `uri` open and
     /// satisfies the method-specific capability predicate.
     async fn notify_open_host_documents<P: serde::Serialize + ?Sized>(

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -262,6 +262,24 @@ impl LanguageServerPool {
         uri: &Url,
         params: &tower_lsp_server::ls_types::WillSaveTextDocumentParams,
     ) {
+        self.notify_open_host_documents(
+            uri,
+            "textDocument/willSave",
+            |handle| handle.has_capability("textDocument/willSave"),
+            params,
+        )
+        .await;
+    }
+
+    /// Notify every live host connection that already has `uri` open and
+    /// satisfies the method-specific capability predicate.
+    async fn notify_open_host_documents<P: serde::Serialize + ?Sized>(
+        &self,
+        uri: &Url,
+        method: &'static str,
+        supports: impl Fn(&ConnectionHandle) -> bool,
+        params: &P,
+    ) {
         // `as_str()` is the already-serialized form; `.to_owned()` clones it in
         // one allocation, skipping the `Display`/`to_string` formatting path.
         let uri_string = uri.as_str().to_owned();
@@ -272,10 +290,10 @@ impl LanguageServerPool {
             if !docs.contains_key(&(uri_string.clone(), connection_key.clone())) {
                 continue;
             }
-            if !handle.has_capability("textDocument/willSave") {
+            if !supports(handle) {
                 continue;
             }
-            let notification = JsonRpcNotification::new("textDocument/willSave", params);
+            let notification = JsonRpcNotification::new(method, params);
             handle.send_notification(notification);
         }
     }

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -33,8 +33,8 @@ use url::Url;
 
 use super::super::actor::RouterCleanupGuard;
 use super::super::pool::{
-    ConnectionHandle, ConnectionHandleSender, ConnectionKey, HostDocSyncState, LanguageServerPool,
-    MessageSender, UpstreamId,
+    ConnectionHandle, ConnectionHandleSender, ConnectionKey, ConnectionState, HostDocSyncState,
+    LanguageServerPool, MessageSender, UpstreamId,
 };
 use super::super::protocol::{
     JsonRpcNotification, JsonRpcRequest, RequestId, jsonrpc_error_summary,
@@ -67,6 +67,13 @@ pub(crate) struct HostRawResponse {
     pub(crate) handle: Arc<ConnectionHandle>,
     pub(crate) incarnation: u64,
     pub(crate) connection_generation: u64,
+}
+
+fn can_notify_host_document(
+    handle: &ConnectionHandle,
+    supports: &impl Fn(&ConnectionHandle) -> bool,
+) -> bool {
+    handle.state() == ConnectionState::Ready && supports(handle)
 }
 
 fn fingerprint(text: &str) -> u64 {
@@ -301,10 +308,10 @@ impl LanguageServerPool {
         let connections = self.connections().await;
         let docs = self.host_documents().await;
         for (connection_key, handle) in connections.iter() {
-            if !docs.contains_key(&(uri_string.clone(), connection_key.clone())) {
+            if !can_notify_host_document(handle, &supports) {
                 continue;
             }
-            if !supports(handle) {
+            if !docs.contains_key(&(uri_string.clone(), connection_key.clone())) {
                 continue;
             }
             let notification = JsonRpcNotification::new(method, params);
@@ -799,6 +806,19 @@ pub(crate) fn normalize_host_goto_result(result: serde_json::Value) -> Option<Ve
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn host_save_notification_skips_failed_current_handle() {
+        let handle = crate::lsp::bridge::pool::test_helpers::create_handle_with_key(
+            ConnectionState::Failed,
+            ConnectionKey::for_server("save"),
+        )
+        .await;
+        assert!(
+            !can_notify_host_document(&handle, &|_| true),
+            "a mapped but failed handle is not a live notification target"
+        );
+    }
 
     #[test]
     fn raw_response_strips_envelope_and_passes_result_verbatim() {

--- a/src/lsp/bridge/text_document/save.rs
+++ b/src/lsp/bridge/text_document/save.rs
@@ -53,10 +53,10 @@ impl LanguageServerPool {
     }
 
     /// Bring every eligible open virtual document to `injections`' current
-    /// content and enqueue its textless didSave under the same per-document
-    /// transition. A failed didChange enqueue suppresses didSave for that
-    /// target, so a queue becoming writable between the two cannot expose a
-    /// stale save hook.
+    /// content and enqueue its didSave under the same per-document transition,
+    /// attaching the projected text when the server requests it. A failed
+    /// didChange enqueue suppresses didSave for that target, so a queue becoming
+    /// writable between the two cannot expose a stale save hook.
     pub(crate) async fn sync_and_forward_did_save_to_virtual_docs(
         &self,
         host_uri: &Url,
@@ -88,12 +88,12 @@ impl LanguageServerPool {
                 let connections = self.connections().await;
                 let Some(handle) = connections
                     .get(&connection_key)
-                    .filter(|handle| {
-                        handle.state() == ConnectionState::Ready
-                            && handle.accepts_textless_did_save()
-                    })
+                    .filter(|handle| handle.state() == ConnectionState::Ready)
                     .cloned()
                 else {
+                    continue;
+                };
+                let Some(include_text) = handle.did_save_include_text() else {
                     continue;
                 };
                 let transition = self.open_transition_lock(&virtual_uri, &connection_key);
@@ -136,10 +136,15 @@ impl LanguageServerPool {
                 };
 
                 let virtual_uri = virtual_uri.to_uri_string();
-                let notification = JsonRpcNotification::new(
-                    "textDocument/didSave",
-                    serde_json::json!({ "textDocument": { "uri": virtual_uri } }),
-                );
+                let params = if include_text {
+                    serde_json::json!({
+                        "textDocument": { "uri": virtual_uri },
+                        "text": injection.content,
+                    })
+                } else {
+                    serde_json::json!({ "textDocument": { "uri": virtual_uri } })
+                };
+                let notification = JsonRpcNotification::new("textDocument/didSave", params);
                 let _ = enqueue_did_save_if_content_synced(did_change, || {
                     handle.send_notification(notification)
                 });

--- a/src/lsp/bridge/text_document/save.rs
+++ b/src/lsp/bridge/text_document/save.rs
@@ -80,6 +80,11 @@ impl LanguageServerPool {
             let connection_keys = self.connections_opening_or_opened(&virtual_uri);
 
             for connection_key in connection_keys {
+                // Keep the current-generation map guard through transition,
+                // tracker validation, and both enqueues. Replacement purges
+                // tracker state while holding this same guard; releasing it
+                // early would make an unregistered target look unchanged and
+                // could send didSave to the invalidated process.
                 let connections = self.connections().await;
                 let Some(handle) = connections
                     .get(&connection_key)
@@ -93,7 +98,6 @@ impl LanguageServerPool {
                 };
                 let transition = self.open_transition_lock(&virtual_uri, &connection_key);
                 let transition_guard = transition.lock().await;
-                drop(connections);
                 if !self.is_document_opened_on_connection(&virtual_uri, &connection_key) {
                     drop(transition_guard);
                     self.remove_open_transition_lock_if_unshared(
@@ -140,6 +144,7 @@ impl LanguageServerPool {
                     handle.send_notification(notification)
                 });
                 drop(transition_guard);
+                drop(connections);
             }
         }
     }
@@ -211,8 +216,11 @@ impl LanguageServerPool {
 #[cfg(test)]
 mod tests {
     use std::cell::Cell;
+    use std::sync::Arc;
 
     use super::*;
+    use crate::lsp::bridge::coordinator::BridgeInjection;
+    use crate::lsp::bridge::pool::{ConnectionKey, test_helpers};
 
     #[test]
     fn queue_full_did_change_suppresses_textless_did_save() {
@@ -227,6 +235,63 @@ mod tests {
         assert!(
             !did_save_enqueued.get(),
             "didSave must not be attempted after its prerequisite didChange was dropped"
+        );
+    }
+
+    #[tokio::test]
+    async fn virtual_save_holds_connection_generation_through_transition() {
+        let pool = Arc::new(LanguageServerPool::new());
+        let key = ConnectionKey::for_server("save");
+        let handle = test_helpers::create_handle_accepting_textless_did_save(key.clone()).await;
+        pool.insert_connection(handle).await;
+
+        let host_uri = Url::parse("file:///test/save.md").unwrap();
+        let injection = BridgeInjection {
+            language: "lua".to_string(),
+            region_id: ulid::Ulid::generate().to_string(),
+            content: "print(1)".to_string(),
+        };
+        let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(&host_uri).unwrap();
+        let virtual_uri =
+            VirtualDocumentUri::new(&host_uri_lsp, &injection.language, &injection.region_id);
+        pool.register_opened_document(&host_uri, &virtual_uri, &key)
+            .await;
+        pool.record_sent_content_fingerprint(&virtual_uri, &key, &injection.content)
+            .await;
+
+        let transition = pool.open_transition_lock(&virtual_uri, &key);
+        let transition_guard = transition.lock().await;
+        let task_pool = Arc::clone(&pool);
+        let task_injection = injection.clone();
+        let task_uri = host_uri.clone();
+        let task = tokio::spawn(async move {
+            task_pool
+                .sync_and_forward_did_save_to_virtual_docs(&task_uri, 1, &[task_injection])
+                .await;
+        });
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
+        loop {
+            if tokio::time::timeout(std::time::Duration::from_millis(10), pool.connections())
+                .await
+                .is_err()
+            {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "save task never acquired the connection-generation guard"
+            );
+            tokio::task::yield_now().await;
+        }
+
+        drop(transition_guard);
+        task.await.expect("save task must finish");
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), pool.connections())
+                .await
+                .is_ok(),
+            "connection guard must release after the combined save transition"
         );
     }
 }

--- a/src/lsp/bridge/text_document/save.rs
+++ b/src/lsp/bridge/text_document/save.rs
@@ -16,8 +16,20 @@
 use tower_lsp_server::ls_types::TextDocumentSaveReason;
 use url::Url;
 
-use super::super::pool::{ConnectionHandle, ConnectionState, LanguageServerPool};
-use super::super::protocol::JsonRpcNotification;
+use super::super::pool::{
+    ConnectionHandle, ConnectionState, LanguageServerPool, NotificationSendResult,
+};
+use super::super::protocol::{JsonRpcNotification, VirtualDocumentUri};
+
+fn enqueue_did_save_if_content_synced(
+    did_change: Option<NotificationSendResult>,
+    enqueue_did_save: impl FnOnce() -> NotificationSendResult,
+) -> Option<NotificationSendResult> {
+    if did_change.is_some_and(|outcome| !matches!(outcome, NotificationSendResult::Queued)) {
+        return None;
+    }
+    Some(enqueue_did_save())
+}
 
 impl LanguageServerPool {
     /// Forward `textDocument/willSave` to every open virtual document of
@@ -40,26 +52,96 @@ impl LanguageServerPool {
         .await;
     }
 
-    /// Forward `textDocument/didSave` to every open virtual document of
-    /// `host_uri`, on each live server that accepts a textless didSave (#357).
-    ///
-    /// The notification carries no `text`. Servers that demand
-    /// `save.includeText = true` are filtered out by
-    /// [`ConnectionHandle::accepts_textless_did_save`] rather than served a
-    /// textless didSave: kakehashi advertises `includeText = false` upstream and
-    /// so never receives the editor's saved bytes to forward. Servers that accept
-    /// textless didSave already have current content from the didChange stream.
-    /// That gate reads STATIC capabilities only, so a dynamic didSave
-    /// registration (whose options the method-name-only dynamic registry can't
-    /// carry) cannot smuggle an `includeText = true` server past the filter.
-    pub(crate) async fn forward_did_save_to_virtual_docs(&self, host_uri: &Url) {
-        self.forward_save_notification_to_virtual_docs(
-            host_uri,
-            "textDocument/didSave",
-            ConnectionHandle::accepts_textless_did_save,
-            |virtual_uri| serde_json::json!({ "textDocument": { "uri": virtual_uri } }),
-        )
-        .await;
+    /// Bring every eligible open virtual document to `injections`' current
+    /// content and enqueue its textless didSave under the same per-document
+    /// transition. A failed didChange enqueue suppresses didSave for that
+    /// target, so a queue becoming writable between the two cannot expose a
+    /// stale save hook.
+    pub(crate) async fn sync_and_forward_did_save_to_virtual_docs(
+        &self,
+        host_uri: &Url,
+        incarnation: u64,
+        injections: &[crate::lsp::bridge::coordinator::BridgeInjection],
+    ) {
+        let Ok(host_uri_lsp) = crate::lsp::lsp_impl::url_to_uri(host_uri) else {
+            return;
+        };
+
+        for injection in injections {
+            self.record_latest_virtual_content(
+                host_uri,
+                incarnation,
+                &injection.language,
+                &injection.region_id,
+                &injection.content,
+            );
+            let virtual_uri =
+                VirtualDocumentUri::new(&host_uri_lsp, &injection.language, &injection.region_id);
+            let connection_keys = self.connections_opening_or_opened(&virtual_uri);
+
+            for connection_key in connection_keys {
+                let connections = self.connections().await;
+                let Some(handle) = connections
+                    .get(&connection_key)
+                    .filter(|handle| {
+                        handle.state() == ConnectionState::Ready
+                            && handle.accepts_textless_did_save()
+                    })
+                    .cloned()
+                else {
+                    continue;
+                };
+                let transition = self.open_transition_lock(&virtual_uri, &connection_key);
+                let transition_guard = transition.lock().await;
+                drop(connections);
+                if !self.is_document_opened_on_connection(&virtual_uri, &connection_key) {
+                    drop(transition_guard);
+                    self.remove_open_transition_lock_if_unshared(
+                        &virtual_uri,
+                        &connection_key,
+                        &transition,
+                    );
+                    continue;
+                }
+
+                let did_change = if let Some(version) = self
+                    .increment_version_if_content_changed(
+                        &virtual_uri,
+                        &connection_key,
+                        &injection.content,
+                    )
+                    .await
+                {
+                    let outcome = Self::send_didchange_for_virtual_doc(
+                        &handle,
+                        &virtual_uri.to_uri_string(),
+                        &injection.content,
+                        version,
+                    );
+                    if matches!(outcome, NotificationSendResult::Queued) {
+                        self.record_sent_content_fingerprint(
+                            &virtual_uri,
+                            &connection_key,
+                            &injection.content,
+                        )
+                        .await;
+                    }
+                    Some(outcome)
+                } else {
+                    None
+                };
+
+                let virtual_uri = virtual_uri.to_uri_string();
+                let notification = JsonRpcNotification::new(
+                    "textDocument/didSave",
+                    serde_json::json!({ "textDocument": { "uri": virtual_uri } }),
+                );
+                let _ = enqueue_did_save_if_content_synced(did_change, || {
+                    handle.send_notification(notification)
+                });
+                drop(transition_guard);
+            }
+        }
     }
 
     /// Shared fan-out: snapshot the host's open virtual docs and send `method`
@@ -123,5 +205,28 @@ impl LanguageServerPool {
             let notification = JsonRpcNotification::new(method, build_params(&virtual_uri));
             handle.send_notification(notification);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::*;
+
+    #[test]
+    fn queue_full_did_change_suppresses_textless_did_save() {
+        let did_save_enqueued = Cell::new(false);
+        let result =
+            enqueue_did_save_if_content_synced(Some(NotificationSendResult::QueueFull), || {
+                did_save_enqueued.set(true);
+                NotificationSendResult::Queued
+            });
+
+        assert!(result.is_none());
+        assert!(
+            !did_save_enqueued.get(),
+            "didSave must not be attempted after its prerequisite didChange was dropped"
+        );
     }
 }

--- a/src/lsp/debounced_diagnostics.rs
+++ b/src/lsp/debounced_diagnostics.rs
@@ -22,7 +22,7 @@ use super::lsp_impl::DiagnosticPublisher;
 use super::lsp_impl::text_document::publish_diagnostic::{
     DiagnosticSnapshot, PullLayerOutcome, collect_push_diagnostics,
 };
-use super::synthetic_diagnostics::SyntheticDiagnosticsManager;
+use super::synthetic_diagnostics::{SyntheticDiagnosticTrigger, SyntheticDiagnosticsManager};
 
 /// Default debounce duration for `didChange` events.
 ///
@@ -57,6 +57,8 @@ struct DebouncedDiagnosticData {
     /// Open lifetime captured when the timer was scheduled. A close/reopen at
     /// the same URI must not let this prior lifetime register new work.
     incarnation: u64,
+    content_version: u64,
+    settings_generation: u64,
     /// Reference to synthetic diagnostics manager for task registration
     synthetic_diagnostics: Arc<SyntheticDiagnosticsManager>,
     /// The single proactive publisher: feeds the pull result into the cache and
@@ -167,7 +169,21 @@ impl DebouncedDiagnosticsManager {
                 uri
             );
         }
-        let Some(incarnation) = documents.get(&uri).map(|doc| doc.incarnation()) else {
+        let Some((incarnation, content_version, settings_generation)) = snapshot_data
+            .as_ref()
+            .map(|snapshot| {
+                (
+                    snapshot.lineage.incarnation,
+                    snapshot.lineage.content_version,
+                    snapshot.lineage.settings_generation,
+                )
+            })
+            .or_else(|| {
+                documents
+                    .get(&uri)
+                    .map(|doc| (doc.incarnation(), doc.content_version(), 0))
+            })
+        else {
             return;
         };
 
@@ -180,6 +196,8 @@ impl DebouncedDiagnosticsManager {
             publisher,
             documents,
             incarnation,
+            content_version,
+            settings_generation,
             #[cfg(test)]
             execution_gate: self.execution_gate.lock().unwrap().clone(),
         };
@@ -272,6 +290,8 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
         publisher,
         documents,
         incarnation,
+        content_version,
+        settings_generation,
         #[cfg(test)]
         execution_gate,
     } = data;
@@ -288,9 +308,11 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
     // prior timer. The new await is also a cancellation checkpoint after sleep.
     let edit_lock = documents.edit_lock(&uri);
     let edit_guard = edit_lock.lock().await;
-    let current_incarnation = documents.get(&uri).map(|doc| doc.incarnation());
-    if current_incarnation != Some(incarnation) {
-        if current_incarnation.is_none() {
+    let current_lineage = documents
+        .get(&uri)
+        .map(|doc| (doc.incarnation(), doc.content_version()));
+    if current_lineage != Some((incarnation, content_version)) {
+        if current_lineage.is_none() {
             documents.remove_edit_lock_if_unshared(&uri, &edit_lock);
         }
         drop(edit_guard);
@@ -343,7 +365,7 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
     // This task is registered with SyntheticDiagnosticsManager for superseding
     let uri_clone = uri.clone();
     let publish_documents = Arc::clone(&documents);
-    let task = tokio::spawn(async move {
+    let future = async move {
         let diagnostics =
             collect_push_diagnostics(snapshot_data, &bridge_pool, &uri_clone, LOG_TARGET).await;
 
@@ -354,11 +376,11 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
         // lifetime and returns. didClose also aborts this registered task.
         let publish_edit_lock = publish_documents.edit_lock(&uri_clone);
         let publish_edit_guard = publish_edit_lock.lock().await;
-        let current_incarnation = publish_documents
+        let current_lineage = publish_documents
             .get(&uri_clone)
-            .map(|doc| doc.incarnation());
-        if current_incarnation != Some(incarnation) {
-            if current_incarnation.is_none() {
+            .map(|doc| (doc.incarnation(), doc.content_version()));
+        if current_lineage != Some((incarnation, content_version)) {
+            if current_lineage.is_none() {
                 publish_documents.remove_edit_lock_if_unshared(&uri_clone, &publish_edit_lock);
             }
             drop(publish_edit_guard);
@@ -387,12 +409,19 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
             }
         }
         drop(publish_edit_guard);
-    });
+    };
 
     // Register with SyntheticDiagnosticsManager for superseding
     // If a didSave or another debounced didChange triggers while this is running,
     // the new task will supersede this one
-    synthetic_diagnostics.register_task(uri, task.abort_handle());
+    synthetic_diagnostics.spawn_task_for_lineage(
+        uri,
+        incarnation,
+        content_version,
+        settings_generation,
+        SyntheticDiagnosticTrigger::Change,
+        future,
+    );
     drop(edit_guard);
 }
 

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -319,15 +319,28 @@ enum Role {
 fn classify(req: &Request) -> Option<Role> {
     let method = req.method();
     match method {
-        "textDocument/didOpen"
-        | "textDocument/didChange"
-        | "textDocument/didSave"
-        | "textDocument/didClose" => {
+        "textDocument/didSave" => {
+            // Cleanup for a missing save is signalled by the typed handler.
+            // Decode the complete params before issuing a ticket so malformed
+            // payloads rejected before handler entry cannot retain sequencing
+            // state indefinitely.
+            serde_json::from_value::<tower_lsp_server::ls_types::DidSaveTextDocumentParams>(
+                req.params()?.clone(),
+            )
+            .ok()?;
+            let uri = text_document_uri(req)?;
+            Some(Role::Writer {
+                uri,
+                close: false,
+                reclaim_if_missing: true,
+            })
+        }
+        "textDocument/didOpen" | "textDocument/didChange" | "textDocument/didClose" => {
             let uri = text_document_uri(req)?;
             Some(Role::Writer {
                 uri,
                 close: method == "textDocument/didClose",
-                reclaim_if_missing: method == "textDocument/didSave",
+                reclaim_if_missing: false,
             })
         }
         "textDocument/semanticTokens/full"
@@ -362,14 +375,15 @@ fn classify(req: &Request) -> Option<Role> {
 /// Extract `params.textDocument.uri`, normalized through `Url` so spelling
 /// variants of the same document (percent-encoding, default ports) sequence
 /// together — internal document state is keyed on parsed `Url`s, and the
-/// gate's keys must not be finer-grained than that. Falls back to the raw
-/// wire string when it doesn't parse (such requests fail in handlers anyway;
-/// gating them consistently by spelling is harmless).
+/// gate's keys must not be finer-grained than that. Invalid URIs are left
+/// ungated: typed LSP parameter decoding rejects them before a handler can
+/// request cleanup, so issuing a ticket would retain unreachable state.
 fn text_document_uri(req: &Request) -> Option<String> {
     // Indexing a missing key or non-object yields Value::Null, whose as_str()
     // returns None — same outcome as get() chains, less noise.
     let raw = req.params()?["textDocument"]["uri"].as_str()?;
-    Some(normalize_uri(raw))
+    let lsp_uri = raw.parse::<tower_lsp_server::ls_types::Uri>().ok()?;
+    url::Url::parse(lsp_uri.as_str()).map(String::from).ok()
 }
 
 /// Normalize a URI spelling through `Url` so variants of the same document
@@ -701,6 +715,39 @@ mod tests {
         late_save.await.unwrap();
 
         assert!(!gate.sequencer.docs.contains_key(URI));
+    }
+
+    #[tokio::test]
+    async fn malformed_save_reclaims_sequence_state_through_the_real_handler() {
+        let (service, _socket) = tower_lsp_server::LspService::new(crate::lsp::Kakehashi::new);
+        let mut gate = IngressOrderGate::new(service);
+        // WHATWG `url::Url` accepts and percent-encodes this space, while the
+        // typed LSP URI parser rejects it before `did_save_impl` is entered.
+        let malformed = "file:///test/a b";
+
+        gate.call(notification("textDocument/didSave", malformed))
+            .await
+            .unwrap();
+
+        assert!(gate.sequencer.docs.is_empty());
+        assert!(classify(&notification("textDocument/didSave", malformed)).is_none());
+    }
+
+    #[tokio::test]
+    async fn malformed_save_params_do_not_create_sequence_state() {
+        let (service, _socket) = tower_lsp_server::LspService::new(crate::lsp::Kakehashi::new);
+        let mut gate = IngressOrderGate::new(service);
+        let malformed = Request::build("textDocument/didSave")
+            .params(serde_json::json!({
+                "textDocument": { "uri": URI },
+                "text": 1,
+            }))
+            .finish();
+
+        assert!(classify(&malformed).is_none());
+        gate.call(malformed).await.unwrap();
+
+        assert!(gate.sequencer.docs.is_empty());
     }
 
     #[test]

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -46,6 +46,7 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll};
 
 use dashmap::DashMap;
@@ -71,6 +72,11 @@ tokio::task_local! {
     /// reader handler so it can wait for the parse watermark to reach this ticket.
     /// Read via [`current_reader_tail`].
     static READER_TAIL: u64;
+
+    /// Set by a reclaimable writer handler after it determines that the URI
+    /// has no live document. The outer gate then removes idle sequencing state
+    /// without resetting tickets for a live document.
+    static RECLAIM_WRITER_SEQUENCE: Arc<AtomicBool>;
 }
 
 /// The ingress writer ticket of the currently-running gated writer handler, or
@@ -89,6 +95,12 @@ pub(crate) fn current_writer_ticket() -> Option<u64> {
 #[cfg(test)]
 pub(crate) fn current_reader_tail() -> Option<u64> {
     READER_TAIL.try_with(|ticket| *ticket).ok()
+}
+
+/// Ask the ingress gate to remove this writer's per-URI sequencing entry once
+/// the handler completes, provided no later writer was already ticketed.
+pub(crate) fn reclaim_current_writer_sequence() {
+    let _ = RECLAIM_WRITER_SEQUENCE.try_with(|flag| flag.store(true, Ordering::Release));
 }
 
 /// Per-document sequencing state.
@@ -275,7 +287,11 @@ impl ReaderBarrier {
 /// How a request participates in per-document ordering.
 enum Role {
     /// Mutates document state; applies in strict wire order per URI.
-    Writer { uri: String, close: bool },
+    Writer {
+        uri: String,
+        close: bool,
+        reclaim_if_missing: bool,
+    },
     /// Reads the document tree; waits for writers that preceded it.
     Reader { uri: String },
 }
@@ -311,6 +327,7 @@ fn classify(req: &Request) -> Option<Role> {
             Some(Role::Writer {
                 uri,
                 close: method == "textDocument/didClose",
+                reclaim_if_missing: method == "textDocument/didSave",
             })
         }
         "textDocument/semanticTokens/full"
@@ -401,7 +418,11 @@ where
         let inner_fut = self.inner.call(req);
         match role {
             None => Box::pin(inner_fut),
-            Some(Role::Writer { uri, close }) => {
+            Some(Role::Writer {
+                uri,
+                close,
+                reclaim_if_missing,
+            }) => {
                 let sequencer = Arc::clone(&self.sequencer);
                 let mut gate = sequencer.issue_writer_ticket(&uri);
                 let ticket = gate.ticket();
@@ -409,10 +430,17 @@ where
                     gate.wait_turn().await;
                     // Scope the ticket around the handler so it can stamp its
                     // scheduled parse with this wire-order ticket.
-                    let result = WRITER_TICKET.scope(ticket, inner_fut).await;
+                    let reclaim = reclaim_if_missing.then(|| Arc::new(AtomicBool::new(false)));
+                    let result = if let Some(flag) = &reclaim {
+                        RECLAIM_WRITER_SEQUENCE
+                            .scope(Arc::clone(flag), WRITER_TICKET.scope(ticket, inner_fut))
+                            .await
+                    } else {
+                        WRITER_TICKET.scope(ticket, inner_fut).await
+                    };
                     // Mark done before any cleanup decision.
                     drop(gate);
-                    if close {
+                    if close || reclaim.is_some_and(|flag| flag.load(Ordering::Acquire)) {
                         sequencer.finish_close(&uri, ticket);
                     }
                     result
@@ -625,6 +653,54 @@ mod tests {
         Request::build(method)
             .params(serde_json::json!({ "textDocument": { "uri": uri } }))
             .finish()
+    }
+
+    struct MissingSaveInner;
+
+    impl Service<Request> for MissingSaveInner {
+        type Response = Option<Response>;
+        type Error = std::convert::Infallible;
+        type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, req: Request) -> Self::Future {
+            Box::pin(async move {
+                if req.method() == "textDocument/didSave" {
+                    reclaim_current_writer_sequence();
+                }
+                Ok(None)
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_save_reclaims_idle_sequence_state() {
+        let mut gate = IngressOrderGate::new(MissingSaveInner);
+
+        gate.call(notification("textDocument/didSave", URI))
+            .await
+            .unwrap();
+
+        assert!(!gate.sequencer.docs.contains_key(URI));
+    }
+
+    #[tokio::test]
+    async fn late_missing_save_reclaims_state_preserved_by_close() {
+        let mut gate = IngressOrderGate::new(MissingSaveInner);
+
+        let close = gate.call(notification("textDocument/didClose", URI));
+        let late_save = gate.call(notification("textDocument/didSave", URI));
+        close.await.unwrap();
+        assert!(
+            gate.sequencer.docs.contains_key(URI),
+            "close must retain state while the late save ticket is pending"
+        );
+        late_save.await.unwrap();
+
+        assert!(!gate.sequencer.docs.contains_key(URI));
     }
 
     #[test]

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -12,9 +12,11 @@
 //! *before* buffering the returned futures, so this middleware can assign
 //! per-URI sequence tickets at `call` time:
 //!
-//! - **Writers** (`didOpen` / `didChange` / `didClose`) take the next ticket
+//! - **Writers** (`didOpen` / `didChange` / `didSave` / `didClose`) take the next ticket
 //!   and run only after the previous writer for the same document finished,
-//!   so opens, edits, and closes apply in strict wire order. Gating `didOpen`
+//!   so opens, edits, saves, and closes apply in strict wire order. Treating
+//!   `didSave` as an ordering fence keeps a later unsaved edit from overtaking
+//!   the save-time host/virtual synchronization. Gating `didOpen`
 //!   (#374) closes the two residual first-poll-order races: a `didChange`
 //!   first-polled before `didOpen` no longer misses the document and discards
 //!   its edit (open→edit), and a reopen no longer inserts ahead of a gated
@@ -33,8 +35,8 @@
 //!   (#480) is therefore a liveness fix, not just a latency one; until then
 //!   the exposure is one-time, first open of an uninstalled parser.
 //! - **Readers** (the `semanticTokens` family, the `kakehashi/captures`
-//!   triple, the edit-producing formatting/rename requests, pull
-//!   diagnostics, and `didSave`'s diagnostic snapshot) snapshot the current
+//!   triple, the edit-producing formatting/rename requests, and pull
+//!   diagnostics) snapshot the current
 //!   tail ticket at `call` time and run only once that ticket is done, so a
 //!   request observes every edit that preceded it on the wire — without
 //!   serializing its computation against later edits or other documents.
@@ -285,8 +287,7 @@ enum Role {
 /// the `kakehashi/captures` triple, which mirrors it, the edit-producing
 /// requests (formatting, rename — their edits are applied by the client to
 /// its current text, so edits computed against a stale snapshot corrupt the
-/// document), pull diagnostics, and `didSave` (its synthetic-diagnostic task
-/// snapshots the document, which must reflect every edit before the save).
+/// document), and pull diagnostics.
 /// `textDocument/codeAction` is in the same class: its
 /// `context.diagnostics` and returned edits are computed against the
 /// document snapshot (#568). `codeLens/resolve` and `codeAction/resolve` are
@@ -302,7 +303,10 @@ enum Role {
 fn classify(req: &Request) -> Option<Role> {
     let method = req.method();
     match method {
-        "textDocument/didOpen" | "textDocument/didChange" | "textDocument/didClose" => {
+        "textDocument/didOpen"
+        | "textDocument/didChange"
+        | "textDocument/didSave"
+        | "textDocument/didClose" => {
             let uri = text_document_uri(req)?;
             Some(Role::Writer {
                 uri,
@@ -318,7 +322,6 @@ fn classify(req: &Request) -> Option<Role> {
         | "textDocument/prepareRename"
         | "textDocument/codeAction"
         | "textDocument/diagnostic"
-        | "textDocument/didSave"
         | "kakehashi/captures/full"
         | "kakehashi/captures/full/delta"
         | "kakehashi/captures/range" => {
@@ -641,6 +644,12 @@ mod tests {
             "didOpen must be a non-close writer"
         );
 
+        let save = classify(&notification("textDocument/didSave", URI));
+        assert!(
+            matches!(save, Some(Role::Writer { close: false, .. })),
+            "didSave must fence later didChange writers"
+        );
+
         for method in [
             "textDocument/semanticTokens/full",
             "textDocument/semanticTokens/full/delta",
@@ -651,7 +660,6 @@ mod tests {
             "textDocument/prepareRename",
             "textDocument/codeAction",
             "textDocument/diagnostic",
-            "textDocument/didSave",
             "kakehashi/captures/full",
             "kakehashi/captures/full/delta",
             "kakehashi/captures/range",

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -10,12 +10,41 @@ use crate::lsp::lsp_impl::bridge_context::{DocumentRequestContext, HostRequestCo
 use url::Url;
 
 use crate::lsp::lsp_impl::Kakehashi;
-use crate::lsp::lsp_impl::snapshot_read::FIRST_PARSE_BACKSTOP;
 use crate::lsp::lsp_impl::text_document::publish_diagnostic::{
     DiagnosticSnapshot, DiagnosticSnapshotLineage, PullLayerOutcome, collect_push_diagnostics,
 };
 use crate::lsp::settings_manager::SettingsManager;
-use crate::lsp::synthetic_diagnostics::SyntheticDiagnosticsManager;
+use crate::lsp::synthetic_diagnostics::{SyntheticDiagnosticTrigger, SyntheticDiagnosticsManager};
+
+fn document_matches_lineage(
+    document: &crate::document::Document,
+    expected_incarnation: u64,
+    expected_content_version: u64,
+) -> bool {
+    document.incarnation() == expected_incarnation
+        && document.content_version() == expected_content_version
+}
+
+fn snapshot_document_for_lineage(
+    documents: &DocumentStore,
+    uri: &Url,
+    expected_lineage: Option<(u64, u64)>,
+) -> Option<(
+    crate::document::model::DocumentSnapshot,
+    Option<String>,
+    u64,
+)> {
+    let document = documents.get(uri)?;
+    if expected_lineage.is_some_and(|(incarnation, content_version)| {
+        !document_matches_lineage(&document, incarnation, content_version)
+    }) {
+        return None;
+    }
+    let snapshot = document.snapshot()?;
+    let language_id = document.language_id().map(str::to_owned);
+    let content_version = document.content_version();
+    Some((snapshot, language_id, content_version))
+}
 
 /// Whether the proactive pull's **config-level** server selection for a method
 /// is non-empty — the visible walk resolved exactly as dispatch does (expand
@@ -79,25 +108,40 @@ pub(crate) struct DiagnosticScheduler {
     publisher: std::sync::Arc<super::DiagnosticPublisher>,
 }
 
-async fn collect_and_publish_synthetic_diagnostics(
-    snapshot_data: Option<DiagnosticSnapshot>,
-    bridge_pool: std::sync::Arc<crate::lsp::bridge::LanguageServerPool>,
-    publisher: std::sync::Arc<super::DiagnosticPublisher>,
-    uri: Url,
+async fn commit_synthetic_diagnostics_when_current(
+    documents: &DocumentStore,
+    publisher: &super::DiagnosticPublisher,
+    uri: &Url,
+    expected_incarnation: u64,
+    expected_content_version: u64,
+    outcome: PullLayerOutcome,
 ) {
-    let diagnostics = collect_push_diagnostics(snapshot_data, &bridge_pool, &uri, LOG_TARGET).await;
+    // Keep the saved-lineage check and cache/wire commit in the same edit-lock
+    // critical section. A didChange therefore either aborts this task before
+    // mutating the document, or runs strictly after the saved diagnostics have
+    // been published; it cannot let an older pull overwrite a newer edit.
+    let edit_lock = documents.edit_lock(uri);
+    let edit_guard = edit_lock.lock().await;
+    let is_current = documents.get(uri).is_some_and(|document| {
+        document_matches_lineage(&document, expected_incarnation, expected_content_version)
+    });
+    if !is_current {
+        drop(edit_guard);
+        documents.remove_edit_lock_if_unshared(uri, &edit_lock);
+        return;
+    }
 
-    match diagnostics {
+    match outcome {
         PullLayerOutcome::Skip => {}
-        PullLayerOutcome::Clear => publisher.clear_pull_layer(&uri).await,
+        PullLayerOutcome::Clear => publisher.clear_pull_layer(uri).await,
         PullLayerOutcome::Publish(diagnostics) => {
             log::debug!(
                 target: LOG_TARGET,
-                "Collected {} pull-layer diagnostics for {}",
+                "Collected {} current pull-layer diagnostics for {}",
                 diagnostics.len(),
                 uri
             );
-            publisher.publish_pull_layer(&uri, diagnostics).await;
+            publisher.publish_pull_layer(uri, diagnostics).await;
         }
     }
 }
@@ -118,14 +162,20 @@ async fn wait_for_expected_diagnostic_tree(
             let Some(document) = documents.get(uri) else {
                 return false;
             };
-            if document.incarnation() != expected_incarnation
-                || document.content_version() != expected_content_version
+            if !document_matches_lineage(&document, expected_incarnation, expected_content_version)
             {
                 return false;
             }
-            let tree_is_ready = document.tree().is_some();
             drop(document);
-            if tree_is_ready {
+            let snapshot_is_ready = documents.latest_snapshot(uri).is_some_and(|view| {
+                view.content_version == expected_content_version
+                    && view.slot.snapshot.is_some_and(|snapshot| {
+                        snapshot.incarnation == expected_incarnation
+                            && snapshot.parsed_version == expected_content_version
+                            && snapshot.tree.is_some()
+                    })
+            });
+            if snapshot_is_ready {
                 return true;
             }
             if receiver.changed().await.is_err() {
@@ -133,9 +183,7 @@ async fn wait_for_expected_diagnostic_tree(
             }
         }
     };
-    tokio::time::timeout(FIRST_PARSE_BACKSTOP, wait)
-        .await
-        .unwrap_or(false)
+    wait.await
 }
 
 impl DiagnosticScheduler {
@@ -187,22 +235,36 @@ impl DiagnosticScheduler {
     /// `textDocument/publishDiagnostics`.
     pub(crate) fn spawn_synthetic_diagnostic_task(&self, uri: Url) {
         let snapshot_data = self.prepare_diagnostic_snapshot(&uri);
+        let Some(lineage) = snapshot_data.as_ref().map(|snapshot| snapshot.lineage) else {
+            return;
+        };
         let bridge_pool = self.bridge.pool_arc();
         let publisher = std::sync::Arc::clone(&self.publisher);
+        let documents = std::sync::Arc::clone(&self.documents);
         let task_uri = uri.clone();
 
-        let task = tokio::spawn(async move {
-            collect_and_publish_synthetic_diagnostics(
-                snapshot_data,
-                bridge_pool,
-                publisher,
-                task_uri,
+        let future = async move {
+            let outcome =
+                collect_push_diagnostics(snapshot_data, &bridge_pool, &task_uri, LOG_TARGET).await;
+            commit_synthetic_diagnostics_when_current(
+                &documents,
+                &publisher,
+                &task_uri,
+                lineage.incarnation,
+                lineage.content_version,
+                outcome,
             )
             .await;
-        });
+        };
 
-        self.synthetic_diagnostics
-            .register_task(uri, task.abort_handle());
+        self.synthetic_diagnostics.spawn_task_for_lineage(
+            uri,
+            lineage.incarnation,
+            lineage.content_version,
+            lineage.settings_generation,
+            SyntheticDiagnosticTrigger::Open,
+            future,
+        );
     }
 
     /// Spawn the didSave diagnostic pull immediately, but defer snapshotting
@@ -221,7 +283,7 @@ impl DiagnosticScheduler {
         let publisher = std::sync::Arc::clone(&self.publisher);
         let task_uri = uri.clone();
 
-        let task = tokio::spawn(async move {
+        let future = async move {
             if !wait_for_expected_diagnostic_tree(
                 &documents,
                 &task_uri,
@@ -232,18 +294,33 @@ impl DiagnosticScheduler {
             {
                 return;
             }
-            let snapshot_data = snapshot_preparer.prepare_diagnostic_snapshot(&task_uri);
-            collect_and_publish_synthetic_diagnostics(
-                snapshot_data,
-                bridge_pool,
-                publisher,
-                task_uri,
+            let snapshot_data = snapshot_preparer.prepare_diagnostic_snapshot_when_current(
+                &task_uri,
+                expected_incarnation,
+                expected_content_version,
+            );
+            let outcome =
+                collect_push_diagnostics(snapshot_data, &bridge_pool, &task_uri, LOG_TARGET).await;
+            commit_synthetic_diagnostics_when_current(
+                &documents,
+                &publisher,
+                &task_uri,
+                expected_incarnation,
+                expected_content_version,
+                outcome,
             )
             .await;
-        });
+        };
 
-        self.synthetic_diagnostics
-            .register_task(uri, task.abort_handle());
+        let settings_generation = self.settings_manager.settings_generation();
+        self.synthetic_diagnostics.spawn_task_for_lineage(
+            uri,
+            expected_incarnation,
+            expected_content_version,
+            settings_generation,
+            SyntheticDiagnosticTrigger::Save,
+            future,
+        );
     }
 
     /// Prepare the per-layer diagnostic snapshot for a background task
@@ -263,18 +340,34 @@ impl DiagnosticScheduler {
 
 impl DiagnosticSnapshotPreparer {
     pub(crate) fn prepare_diagnostic_snapshot(&self, uri: &Url) -> Option<DiagnosticSnapshot> {
-        let (snapshot, language_name, content_version) = {
-            let doc = self.documents.get(uri)?;
-            let snapshot = doc.snapshot()?;
-            let language_name = self.language.detect_language(
-                uri.path(),
-                snapshot.text(),
-                None,
-                doc.language_id(),
-            )?;
-            let content_version = doc.content_version();
-            (snapshot, language_name, content_version)
-        };
+        self.prepare_diagnostic_snapshot_for_lineage(uri, None)
+    }
+
+    fn prepare_diagnostic_snapshot_when_current(
+        &self,
+        uri: &Url,
+        expected_incarnation: u64,
+        expected_content_version: u64,
+    ) -> Option<DiagnosticSnapshot> {
+        self.prepare_diagnostic_snapshot_for_lineage(
+            uri,
+            Some((expected_incarnation, expected_content_version)),
+        )
+    }
+
+    fn prepare_diagnostic_snapshot_for_lineage(
+        &self,
+        uri: &Url,
+        expected_lineage: Option<(u64, u64)>,
+    ) -> Option<DiagnosticSnapshot> {
+        let (snapshot, language_id, content_version) =
+            snapshot_document_for_lineage(&self.documents, uri, expected_lineage)?;
+        let language_name = self.language.detect_language(
+            uri.path(),
+            snapshot.text(),
+            None,
+            language_id.as_deref(),
+        )?;
 
         // Cross-layer gating, keyed by the same method name as the
         // aggregation configs below. A layer gated off still yields a
@@ -549,8 +642,9 @@ const LOG_TARGET: &str = "kakehashi::synthetic_diag";
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tower_lsp_server::LspService;
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn saved_diagnostic_wait_survives_the_virtual_settle_budget() {
         let documents = DocumentStore::new();
         let uri = Url::parse("file:///test/delayed-save.md").unwrap();
@@ -573,10 +667,10 @@ mod tests {
             content_version,
         ));
         assert!(
-            tokio::time::timeout(std::time::Duration::from_millis(250), &mut wait)
+            tokio::time::timeout(std::time::Duration::from_secs(16), &mut wait)
                 .await
                 .is_err(),
-            "diagnostic readiness must not be abandoned at the 200ms virtual-save budget"
+            "diagnostic readiness must survive both the 200ms virtual-save budget and the old 15s reader backstop"
         );
 
         let language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
@@ -613,6 +707,69 @@ mod tests {
             tokio::time::timeout(std::time::Duration::from_secs(1), &mut wait)
                 .await
                 .expect("tree publication must release the diagnostic waiter")
+        );
+    }
+
+    #[tokio::test]
+    async fn saved_diagnostic_snapshot_input_rejects_a_later_edit() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let uri = Url::parse("file:///test/saved-lineage.md").unwrap();
+        let text = "# saved\n";
+        let incarnation = server.documents.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let document = server.documents.get(&uri).unwrap();
+        let expected_text = document.text_arc();
+        let content_version = document.content_version();
+        drop(document);
+
+        let language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&language).unwrap();
+        let tree = parser.parse(text, None).unwrap();
+        assert!(server.documents.set_parse_result_if_inputs_unchanged(
+            &uri,
+            &expected_text,
+            incarnation,
+            content_version,
+            Some("markdown"),
+            Some(tree),
+        ));
+
+        assert!(document_matches_lineage(
+            &server.documents.get(&uri).unwrap(),
+            incarnation,
+            content_version,
+        ));
+        assert!(
+            snapshot_document_for_lineage(
+                &server.documents,
+                &uri,
+                Some((incarnation, content_version)),
+            )
+            .is_some(),
+            "the exact saved lineage should produce its parsed snapshot"
+        );
+        server
+            .documents
+            .apply_edit_clearing_tree(&uri, "# edited\n".to_string(), &[]);
+        assert!(!document_matches_lineage(
+            &server.documents.get(&uri).unwrap(),
+            incarnation,
+            content_version,
+        ));
+        assert!(
+            snapshot_document_for_lineage(
+                &server.documents,
+                &uri,
+                Some((incarnation, content_version)),
+            )
+            .is_none(),
+            "a save-triggered pull must not snapshot the later unsaved version"
         );
     }
 }

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -10,6 +10,7 @@ use crate::lsp::lsp_impl::bridge_context::{DocumentRequestContext, HostRequestCo
 use url::Url;
 
 use crate::lsp::lsp_impl::Kakehashi;
+use crate::lsp::lsp_impl::snapshot_read::FIRST_PARSE_BACKSTOP;
 use crate::lsp::lsp_impl::text_document::publish_diagnostic::{
     DiagnosticSnapshot, DiagnosticSnapshotLineage, PullLayerOutcome, collect_push_diagnostics,
 };
@@ -78,6 +79,65 @@ pub(crate) struct DiagnosticScheduler {
     publisher: std::sync::Arc<super::DiagnosticPublisher>,
 }
 
+async fn collect_and_publish_synthetic_diagnostics(
+    snapshot_data: Option<DiagnosticSnapshot>,
+    bridge_pool: std::sync::Arc<crate::lsp::bridge::LanguageServerPool>,
+    publisher: std::sync::Arc<super::DiagnosticPublisher>,
+    uri: Url,
+) {
+    let diagnostics = collect_push_diagnostics(snapshot_data, &bridge_pool, &uri, LOG_TARGET).await;
+
+    match diagnostics {
+        PullLayerOutcome::Skip => {}
+        PullLayerOutcome::Clear => publisher.clear_pull_layer(&uri).await,
+        PullLayerOutcome::Publish(diagnostics) => {
+            log::debug!(
+                target: LOG_TARGET,
+                "Collected {} pull-layer diagnostics for {}",
+                diagnostics.len(),
+                uri
+            );
+            publisher.publish_pull_layer(&uri, diagnostics).await;
+        }
+    }
+}
+
+async fn wait_for_expected_diagnostic_tree(
+    documents: &DocumentStore,
+    uri: &Url,
+    expected_incarnation: u64,
+    expected_content_version: u64,
+) -> bool {
+    let wait = async {
+        loop {
+            // Subscribe before checking to avoid losing a parse publication
+            // between the state read and `changed()`.
+            let Some(mut receiver) = documents.subscribe_snapshots(uri) else {
+                return false;
+            };
+            let Some(document) = documents.get(uri) else {
+                return false;
+            };
+            if document.incarnation() != expected_incarnation
+                || document.content_version() != expected_content_version
+            {
+                return false;
+            }
+            let tree_is_ready = document.tree().is_some();
+            drop(document);
+            if tree_is_ready {
+                return true;
+            }
+            if receiver.changed().await.is_err() {
+                return false;
+            }
+        }
+    };
+    tokio::time::timeout(FIRST_PARSE_BACKSTOP, wait)
+        .await
+        .unwrap_or(false)
+}
+
 impl DiagnosticScheduler {
     pub(crate) fn new(server: &Kakehashi) -> Self {
         Self {
@@ -129,28 +189,57 @@ impl DiagnosticScheduler {
         let snapshot_data = self.prepare_diagnostic_snapshot(&uri);
         let bridge_pool = self.bridge.pool_arc();
         let publisher = std::sync::Arc::clone(&self.publisher);
-        let uri_clone = uri.clone();
+        let task_uri = uri.clone();
 
         let task = tokio::spawn(async move {
-            let diagnostics =
-                collect_push_diagnostics(snapshot_data, &bridge_pool, &uri_clone, LOG_TARGET).await;
+            collect_and_publish_synthetic_diagnostics(
+                snapshot_data,
+                bridge_pool,
+                publisher,
+                task_uri,
+            )
+            .await;
+        });
 
-            // Feed the host-event pull outcome into the cache and republish the
-            // merged set (push-propagation-diagnostic-forwarding) instead of
-            // publishing directly — push slots for the same host survive.
-            match diagnostics {
-                PullLayerOutcome::Skip => {}
-                PullLayerOutcome::Clear => publisher.clear_pull_layer(&uri_clone).await,
-                PullLayerOutcome::Publish(diagnostics) => {
-                    log::debug!(
-                        target: LOG_TARGET,
-                        "Collected {} pull-layer diagnostics for {}",
-                        diagnostics.len(),
-                        uri_clone
-                    );
-                    publisher.publish_pull_layer(&uri_clone, diagnostics).await;
-                }
+        self.synthetic_diagnostics
+            .register_task(uri, task.abort_handle());
+    }
+
+    /// Spawn the didSave diagnostic pull immediately, but defer snapshotting
+    /// until the exact saved document version has a tree. The wait runs off
+    /// ingress and is registered with the synthetic-task manager, so a later
+    /// save, close, or shutdown supersedes it without blocking the writer.
+    pub(crate) fn spawn_synthetic_diagnostic_task_when_current(
+        &self,
+        uri: Url,
+        expected_incarnation: u64,
+        expected_content_version: u64,
+    ) {
+        let documents = std::sync::Arc::clone(&self.documents);
+        let snapshot_preparer = self.snapshot_preparer.clone();
+        let bridge_pool = self.bridge.pool_arc();
+        let publisher = std::sync::Arc::clone(&self.publisher);
+        let task_uri = uri.clone();
+
+        let task = tokio::spawn(async move {
+            if !wait_for_expected_diagnostic_tree(
+                &documents,
+                &task_uri,
+                expected_incarnation,
+                expected_content_version,
+            )
+            .await
+            {
+                return;
             }
+            let snapshot_data = snapshot_preparer.prepare_diagnostic_snapshot(&task_uri);
+            collect_and_publish_synthetic_diagnostics(
+                snapshot_data,
+                bridge_pool,
+                publisher,
+                task_uri,
+            )
+            .await;
         });
 
         self.synthetic_diagnostics
@@ -456,3 +545,74 @@ impl DiagnosticSnapshotPreparer {
 
 /// Logging target for synthetic push diagnostics.
 const LOG_TARGET: &str = "kakehashi::synthetic_diag";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn saved_diagnostic_wait_survives_the_virtual_settle_budget() {
+        let documents = DocumentStore::new();
+        let uri = Url::parse("file:///test/delayed-save.md").unwrap();
+        let text = "# delayed\n";
+        let incarnation = documents.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let document = documents.get(&uri).unwrap();
+        let expected_text = document.text_arc();
+        let content_version = document.content_version();
+        drop(document);
+
+        let mut wait = Box::pin(wait_for_expected_diagnostic_tree(
+            &documents,
+            &uri,
+            incarnation,
+            content_version,
+        ));
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(250), &mut wait)
+                .await
+                .is_err(),
+            "diagnostic readiness must not be abandoned at the 200ms virtual-save budget"
+        );
+
+        let language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&language).unwrap();
+        let tree = parser.parse(text, None).unwrap();
+        assert!(documents.set_parse_result_if_inputs_unchanged(
+            &uri,
+            &expected_text,
+            incarnation,
+            content_version,
+            Some("markdown"),
+            Some(tree.clone()),
+        ));
+        let snapshot = crate::document::snapshot::ParseSnapshot {
+            text: expected_text,
+            tree: Some(tree),
+            language: Some("markdown".to_string()),
+            parsed_version: content_version,
+            incarnation,
+            injection_regions: None,
+            bridge_regions: None,
+            resolved_regions: None,
+            layer_trees: std::sync::OnceLock::new(),
+        };
+        assert!(
+            documents
+                .get(&uri)
+                .unwrap()
+                .publish_snapshot(std::sync::Arc::new(snapshot))
+        );
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), &mut wait)
+                .await
+                .expect("tree publication must release the diagnostic waiter")
+        );
+    }
+}

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -31,6 +31,14 @@ impl Kakehashi {
         let edit_lock = self.documents.edit_lock(&uri);
         let _edit_guard = edit_lock.lock().await;
 
+        // Stop both the timer body and any already-registered collection from
+        // the previous edit before advancing the document version.
+        self.debounced_diagnostics.cancel(&uri);
+        // A save-triggered pull owns the exact saved incarnation/version. Abort
+        // it before changing the document so it cannot publish that old result
+        // after this edit. The later post-parse debounce installs the replacement.
+        self.synthetic_diagnostics.remove_document(&uri);
+
         self.notifier()
             .log_trace(format!("[DID_CHANGE] START uri={}", uri))
             .await;
@@ -144,5 +152,55 @@ impl Kakehashi {
         // like vim-lsp on Vim, which cannot respond to server requests while processing.
 
         self.notifier().log_info("file changed!").await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_lsp_server::LspService;
+    use tower_lsp_server::ls_types::{
+        TextDocumentContentChangeEvent, VersionedTextDocumentIdentifier,
+    };
+
+    #[tokio::test]
+    async fn did_change_aborts_an_in_flight_saved_diagnostic() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let uri = url::Url::parse("file:///test/edit-after-save.md").unwrap();
+        let incarnation = server.documents.insert(
+            uri.clone(),
+            "# saved\n".to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let content_version = server.documents.get(&uri).unwrap().content_version();
+        server
+            .diagnostic_scheduler()
+            .spawn_synthetic_diagnostic_task_when_current(
+                uri.clone(),
+                incarnation,
+                content_version,
+            );
+        assert!(server.synthetic_diagnostics.has_active_task(&uri));
+
+        server
+            .did_change_impl(DidChangeTextDocumentParams {
+                text_document: VersionedTextDocumentIdentifier {
+                    uri: crate::lsp::lsp_impl::url_to_uri(&uri).unwrap(),
+                    version: 2,
+                },
+                content_changes: vec![TextDocumentContentChangeEvent {
+                    range: None,
+                    range_length: None,
+                    text: "# edited\n".to_string(),
+                }],
+            })
+            .await;
+
+        assert!(
+            !server.synthetic_diagnostics.has_active_task(&uri),
+            "didChange must supersede the saved-version pull before editing"
+        );
     }
 }

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -1613,25 +1613,19 @@ print("hello")
     async fn cli_mode_did_open_does_not_schedule_synthetic_diagnostic_task() {
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
-        server
-            .language
-            .language_registry_for_parallel()
-            .register("markdown".to_string(), tree_sitter_md::LANGUAGE.into());
-        server.settings_manager.apply_settings(WorkspaceSettings {
-            auto_install: false,
-            ..Default::default()
-        });
+        configure_rust_self_host(server);
+        server.bridge.insert_ready_test_connection("rust_ls").await;
         server.mark_cli_mode();
 
-        let uri = Url::parse("file:///test/cli_no_synthetic.md").unwrap();
+        let uri = Url::parse("file:///test/cli_no_synthetic.rs").unwrap();
         let lsp_uri = crate::lsp::lsp_impl::url_to_uri(&uri).expect("URI should convert");
         server
             .did_open_impl(DidOpenTextDocumentParams {
                 text_document: TextDocumentItem {
                     uri: lsp_uri,
-                    language_id: "markdown".to_string(),
+                    language_id: "rust".to_string(),
                     version: 1,
-                    text: "# hi\n".to_string(),
+                    text: "fn main() {}\n".to_string(),
                 },
             })
             .await;

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -900,11 +900,11 @@ print("hello")
             .get_host_configs_for_language(&settings, "rust");
 
         // Snapshot text is CONSTANT across both fires; only the store text changes.
-        let snapshot = || DiagnosticSnapshot {
+        let snapshot = |incarnation, content_version| DiagnosticSnapshot {
             lineage:
                 crate::lsp::lsp_impl::text_document::publish_diagnostic::DiagnosticSnapshotLineage {
-                    incarnation: 0,
-                    content_version: 0,
+                    incarnation,
+                    content_version,
                     settings_generation: 0,
                 },
             virt_contexts: vec![],
@@ -955,9 +955,14 @@ print("hello")
             Some("rust".to_string()),
             None,
         );
+        let (incarnation, content_version) = server
+            .documents
+            .get(&uri)
+            .map(|doc| (doc.incarnation(), doc.content_version()))
+            .expect("live v1 document should exist");
         manager.schedule(
             uri.clone(),
-            Some(snapshot()),
+            Some(snapshot(incarnation, content_version)),
             server.bridge.pool_arc(),
             std::sync::Arc::clone(&server.bridge),
             std::sync::Arc::new(SyntheticDiagnosticsManager::new()),
@@ -976,9 +981,14 @@ print("hello")
             Some("rust".to_string()),
             None,
         );
+        let (incarnation, content_version) = server
+            .documents
+            .get(&uri)
+            .map(|doc| (doc.incarnation(), doc.content_version()))
+            .expect("live v2 document should exist");
         manager.schedule(
             uri.clone(),
-            Some(snapshot()),
+            Some(snapshot(incarnation, content_version)),
             server.bridge.pool_arc(),
             std::sync::Arc::clone(&server.bridge),
             std::sync::Arc::new(SyntheticDiagnosticsManager::new()),
@@ -1639,24 +1649,18 @@ print("hello")
     async fn lsp_mode_did_open_schedules_synthetic_diagnostic_task() {
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
-        server
-            .language
-            .language_registry_for_parallel()
-            .register("markdown".to_string(), tree_sitter_md::LANGUAGE.into());
-        server.settings_manager.apply_settings(WorkspaceSettings {
-            auto_install: false,
-            ..Default::default()
-        });
+        configure_rust_self_host(server);
+        server.bridge.insert_ready_test_connection("rust_ls").await;
 
-        let uri = Url::parse("file:///test/lsp_synthetic.md").unwrap();
+        let uri = Url::parse("file:///test/lsp_synthetic.rs").unwrap();
         let lsp_uri = crate::lsp::lsp_impl::url_to_uri(&uri).expect("URI should convert");
         server
             .did_open_impl(DidOpenTextDocumentParams {
                 text_document: TextDocumentItem {
                     uri: lsp_uri,
-                    language_id: "markdown".to_string(),
+                    language_id: "rust".to_string(),
                     version: 1,
-                    text: "# hi\n".to_string(),
+                    text: "fn main() {}\n".to_string(),
                 },
             })
             .await;

--- a/src/lsp/lsp_impl/text_document/did_save.rs
+++ b/src/lsp/lsp_impl/text_document/did_save.rs
@@ -37,6 +37,7 @@ impl Kakehashi {
         // Convert ls_types::Uri to url::Url for internal use
         let Ok(uri) = uri_to_url(&lsp_uri) else {
             log::warn!("Invalid URI in didSave: {}", lsp_uri.as_str());
+            crate::lsp::reclaim_current_writer_sequence();
             return;
         };
 

--- a/src/lsp/lsp_impl/text_document/did_save.rs
+++ b/src/lsp/lsp_impl/text_document/did_save.rs
@@ -79,31 +79,16 @@ impl Kakehashi {
         // otherwise an immediate save can overtake its projected didChange and
         // run the downstream save hook against stale fragment text. If the
         // bounded settle fails, omit didSave rather than violate that contract.
-        if let Some((_, saved_incarnation, saved_content_version)) = &saved_document {
-            let saved_snapshot_is_current =
-                saved_parse_is_current(self, &uri, *saved_incarnation, *saved_content_version)
-                    .await;
-
-            if saved_snapshot_is_current {
-                let edit_lock = self.documents.edit_lock(&uri);
-                let edit_guard = edit_lock.lock().await;
-                let still_saved_version = self.documents.get(&uri).is_some_and(|document| {
-                    document.incarnation() == *saved_incarnation
-                        && document.content_version() == *saved_content_version
-                });
-                if still_saved_version
-                    && let Some((_, injections)) =
-                        self.injection_coordinator().bridge_injections(&uri)
-                {
-                    pool.sync_and_forward_did_save_to_virtual_docs(
-                        &uri,
-                        *saved_incarnation,
-                        &injections,
-                    )
-                    .await;
-                }
-                drop(edit_guard);
-            }
+        if let Some((_, saved_incarnation, saved_content_version)) = &saved_document
+            && saved_parse_is_current(self, &uri, *saved_incarnation, *saved_content_version).await
+        {
+            self.forward_virtual_did_save_for_saved_version(
+                &pool,
+                &uri,
+                *saved_incarnation,
+                *saved_content_version,
+            )
+            .await;
         }
 
         // Register diagnostic collection immediately, but keep its parse wait
@@ -120,6 +105,32 @@ impl Kakehashi {
         }
 
         self.notifier().log_info("file saved!").await;
+    }
+
+    /// Forward the save to `uri`'s virtual documents, but only while the
+    /// document still carries the saved lineage. The edit lock is held across
+    /// the check and the downstream enqueue so a concurrent edit cannot slip
+    /// between them and turn the projected content stale.
+    async fn forward_virtual_did_save_for_saved_version(
+        &self,
+        pool: &std::sync::Arc<crate::lsp::LanguageServerPool>,
+        uri: &url::Url,
+        saved_incarnation: u64,
+        saved_content_version: u64,
+    ) {
+        let edit_lock = self.documents.edit_lock(uri);
+        let edit_guard = edit_lock.lock().await;
+        let still_saved_version = self.documents.get(uri).is_some_and(|document| {
+            document.incarnation() == saved_incarnation
+                && document.content_version() == saved_content_version
+        });
+        if still_saved_version
+            && let Some((_, injections)) = self.injection_coordinator().bridge_injections(uri)
+        {
+            pool.sync_and_forward_did_save_to_virtual_docs(uri, saved_incarnation, &injections)
+                .await;
+        }
+        drop(edit_guard);
     }
 }
 

--- a/src/lsp/lsp_impl/text_document/did_save.rs
+++ b/src/lsp/lsp_impl/text_document/did_save.rs
@@ -47,8 +47,8 @@ impl Kakehashi {
         );
 
         // Serialize the host save with document edits and snapshot the latest
-        // text. Host didSave is textless, so every recipient must first receive
-        // any pending full-text didChange on the same downstream queue.
+        // text. Every recipient must first receive any pending full-text
+        // didChange on the same downstream queue.
         let edit_lock = self.documents.edit_lock(&uri);
         let edit_guard = edit_lock.lock().await;
         let saved_document = self.documents.get(&uri).map(|document| {
@@ -60,17 +60,20 @@ impl Kakehashi {
         });
 
         // Forward didSave to both bridge layers, in host-before-virt order.
-        // Each path only touches an already-open document and excludes servers
-        // that require save text, which kakehashi does not advertise upstream
-        // (#357).
+        // Each path only touches an already-open document. The downstream
+        // notification includes this tracked saved text when requested (#357).
         let pool = self.bridge.pool_arc();
         if let Some((host_text, _, _)) = &saved_document {
             pool.sync_and_notify_host_did_save(&uri, host_text).await;
         }
         drop(edit_guard);
+        if saved_document.is_none() {
+            self.documents
+                .remove_edit_lock_if_unshared(&uri, &edit_lock);
+        }
 
         // A didChange reparses and refreshes virtual documents off-ingress.
-        // Settle that pipeline explicitly before the textless virtual didSave;
+        // Settle that pipeline explicitly before the virtual didSave;
         // otherwise an immediate save can overtake its projected didChange and
         // run the downstream save hook against stale fragment text. If the
         // bounded settle fails, omit didSave rather than violate that contract.
@@ -172,5 +175,22 @@ mod tests {
             started.elapsed() <= VIRTUAL_SAVE_SETTLE_BUDGET * 2,
             "both save-time waits must remain hard-bounded"
         );
+    }
+
+    #[tokio::test]
+    async fn missing_document_did_save_reclaims_its_edit_lock() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let uri = url::Url::parse("file:///test/missing-save.md").unwrap();
+        let params = DidSaveTextDocumentParams {
+            text_document: tower_lsp_server::ls_types::TextDocumentIdentifier {
+                uri: crate::lsp::lsp_impl::url_to_uri(&uri).unwrap(),
+            },
+            text: None,
+        };
+
+        server.did_save_impl(params).await;
+
+        assert!(!server.documents.has_edit_lock(&uri));
     }
 }

--- a/src/lsp/lsp_impl/text_document/did_save.rs
+++ b/src/lsp/lsp_impl/text_document/did_save.rs
@@ -105,7 +105,11 @@ impl Kakehashi {
         // off-ingress reparse, and `prepare_diagnostic_snapshot` returns `None`
         // without a tree — making the synthetic diagnostic a no-op for the virt
         // layer.
-        self.ensure_document_parsed(&uri).await;
+        let _ = tokio::time::timeout(
+            VIRTUAL_SAVE_SETTLE_BUDGET,
+            self.ensure_document_parsed(&uri),
+        )
+        .await;
 
         // Spawn background task for synthetic diagnostic collection
         self.diagnostic_scheduler()
@@ -142,5 +146,31 @@ mod tests {
             "an unparsed document cannot vouch for virtual save content"
         );
         assert_eq!(started.elapsed(), VIRTUAL_SAVE_SETTLE_BUDGET);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unparsed_did_save_handler_has_a_bounded_total_settle_time() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let uri = url::Url::parse("file:///test/unparsed-handler-save.md").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "# unparsed".to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let params = DidSaveTextDocumentParams {
+            text_document: tower_lsp_server::ls_types::TextDocumentIdentifier {
+                uri: crate::lsp::lsp_impl::url_to_uri(&uri).unwrap(),
+            },
+            text: None,
+        };
+
+        let started = tokio::time::Instant::now();
+        server.did_save_impl(params).await;
+        assert!(
+            started.elapsed() <= VIRTUAL_SAVE_SETTLE_BUDGET * 2,
+            "both save-time waits must remain hard-bounded"
+        );
     }
 }

--- a/src/lsp/lsp_impl/text_document/did_save.rs
+++ b/src/lsp/lsp_impl/text_document/did_save.rs
@@ -79,16 +79,17 @@ impl Kakehashi {
         // otherwise an immediate save can overtake its projected didChange and
         // run the downstream save hook against stale fragment text. If the
         // bounded settle fails, omit didSave rather than violate that contract.
-        if let Some((_, saved_incarnation, saved_content_version)) = saved_document {
+        if let Some((_, saved_incarnation, saved_content_version)) = &saved_document {
             let saved_snapshot_is_current =
-                saved_parse_is_current(self, &uri, saved_incarnation, saved_content_version).await;
+                saved_parse_is_current(self, &uri, *saved_incarnation, *saved_content_version)
+                    .await;
 
             if saved_snapshot_is_current {
                 let edit_lock = self.documents.edit_lock(&uri);
                 let edit_guard = edit_lock.lock().await;
                 let still_saved_version = self.documents.get(&uri).is_some_and(|document| {
-                    document.incarnation() == saved_incarnation
-                        && document.content_version() == saved_content_version
+                    document.incarnation() == *saved_incarnation
+                        && document.content_version() == *saved_content_version
                 });
                 if still_saved_version
                     && let Some((_, injections)) =
@@ -96,7 +97,7 @@ impl Kakehashi {
                 {
                     pool.sync_and_forward_did_save_to_virtual_docs(
                         &uri,
-                        saved_incarnation,
+                        *saved_incarnation,
                         &injections,
                     )
                     .await;
@@ -105,20 +106,18 @@ impl Kakehashi {
             }
         }
 
-        // Ensure a fresh tree before the synthetic task snapshots it: a save
-        // batched right after an edit (autosave / format-on-save) races the
-        // off-ingress reparse, and `prepare_diagnostic_snapshot` returns `None`
-        // without a tree — making the synthetic diagnostic a no-op for the virt
-        // layer.
-        let _ = tokio::time::timeout(
-            VIRTUAL_SAVE_SETTLE_BUDGET,
-            self.ensure_document_parsed(&uri),
-        )
-        .await;
-
-        // Spawn background task for synthetic diagnostic collection
-        self.diagnostic_scheduler()
-            .spawn_synthetic_diagnostic_task(uri);
+        // Register diagnostic collection immediately, but keep its parse wait
+        // off-ingress. This preserves the saved-version trigger even when
+        // parsing exceeds the virtual forwarding budget, while a later save,
+        // edit, close, or shutdown can still supersede the background task.
+        if let Some((_, saved_incarnation, saved_content_version)) = saved_document {
+            self.diagnostic_scheduler()
+                .spawn_synthetic_diagnostic_task_when_current(
+                    uri,
+                    saved_incarnation,
+                    saved_content_version,
+                );
+        }
 
         self.notifier().log_info("file saved!").await;
     }
@@ -174,8 +173,8 @@ mod tests {
         let started = tokio::time::Instant::now();
         server.did_save_impl(params).await;
         assert!(
-            started.elapsed() <= VIRTUAL_SAVE_SETTLE_BUDGET * 2,
-            "both save-time waits must remain hard-bounded"
+            started.elapsed() <= VIRTUAL_SAVE_SETTLE_BUDGET,
+            "diagnostic parse waiting must stay off the ingress writer"
         );
     }
 

--- a/src/lsp/lsp_impl/text_document/did_save.rs
+++ b/src/lsp/lsp_impl/text_document/did_save.rs
@@ -3,6 +3,7 @@
 use tower_lsp_server::ls_types::DidSaveTextDocumentParams;
 
 use super::super::{Kakehashi, uri_to_url};
+use crate::lsp::lsp_impl::snapshot_read::SnapshotWait;
 
 impl Kakehashi {
     /// Handle textDocument/didSave notification.
@@ -40,7 +41,23 @@ impl Kakehashi {
             pool.sync_and_notify_host_did_save(&uri, &host_text).await;
         }
         drop(edit_guard);
-        pool.forward_did_save_to_virtual_docs(&uri).await;
+
+        // A didChange reparses and refreshes virtual documents off-ingress.
+        // Settle that pipeline explicitly before the textless virtual didSave;
+        // otherwise an immediate save can overtake its projected didChange and
+        // run the downstream save hook against stale fragment text. If the
+        // bounded settle fails, omit didSave rather than violate that contract.
+        let virtual_documents_are_current = matches!(
+            self.wait_for_current_snapshot(&uri, std::time::Duration::from_millis(200))
+                .await,
+            SnapshotWait::Current(_)
+        );
+        if virtual_documents_are_current {
+            self.injection_coordinator()
+                .process_injections(&uri, true)
+                .await;
+            pool.forward_did_save_to_virtual_docs(&uri).await;
+        }
 
         // Ensure a fresh tree before the synthetic task snapshots it: a save
         // batched right after an edit (autosave / format-on-save) races the

--- a/src/lsp/lsp_impl/text_document/did_save.rs
+++ b/src/lsp/lsp_impl/text_document/did_save.rs
@@ -24,12 +24,22 @@ impl Kakehashi {
             uri
         );
 
-        // Forward didSave to both bridge layers, in the same host-before-virt
-        // order as willSave. Each path only touches an already-open document
-        // and excludes servers that require save text, which kakehashi does not
-        // advertise upstream (#357).
+        // Serialize the host save with document edits and snapshot the latest
+        // text. Host didSave is textless, so every recipient must first receive
+        // any pending full-text didChange on the same downstream queue.
+        let edit_lock = self.documents.edit_lock(&uri);
+        let edit_guard = edit_lock.lock().await;
+        let host_text = self.documents.get(&uri).map(|document| document.text_arc());
+
+        // Forward didSave to both bridge layers, in host-before-virt order.
+        // Each path only touches an already-open document and excludes servers
+        // that require save text, which kakehashi does not advertise upstream
+        // (#357).
         let pool = self.bridge.pool_arc();
-        pool.notify_host_did_save(&uri).await;
+        if let Some(host_text) = host_text {
+            pool.sync_and_notify_host_did_save(&uri, &host_text).await;
+        }
+        drop(edit_guard);
         pool.forward_did_save_to_virtual_docs(&uri).await;
 
         // Ensure a fresh tree before the synthetic task snapshots it: a save

--- a/src/lsp/lsp_impl/text_document/did_save.rs
+++ b/src/lsp/lsp_impl/text_document/did_save.rs
@@ -70,6 +70,7 @@ impl Kakehashi {
         if saved_document.is_none() {
             self.documents
                 .remove_edit_lock_if_unshared(&uri, &edit_lock);
+            crate::lsp::reclaim_current_writer_sequence();
         }
 
         // A didChange reparses and refreshes virtual documents off-ingress.

--- a/src/lsp/lsp_impl/text_document/did_save.rs
+++ b/src/lsp/lsp_impl/text_document/did_save.rs
@@ -24,14 +24,13 @@ impl Kakehashi {
             uri
         );
 
-        // Forward didSave to virt-bridge servers that have a virtual document
-        // open for this host and advertise `save` (#357). A save hook on a
-        // fenced language (e.g. a server caching dirty state) reacts here;
-        // willSaveWaitUntil stays host-only.
-        self.bridge
-            .pool_arc()
-            .forward_did_save_to_virtual_docs(&uri)
-            .await;
+        // Forward didSave to both bridge layers, in the same host-before-virt
+        // order as willSave. Each path only touches an already-open document
+        // and excludes servers that require save text, which kakehashi does not
+        // advertise upstream (#357).
+        let pool = self.bridge.pool_arc();
+        pool.notify_host_did_save(&uri).await;
+        pool.forward_did_save_to_virtual_docs(&uri).await;
 
         // Ensure a fresh tree before the synthetic task snapshots it: a save
         // batched right after an edit (autosave / format-on-save) races the

--- a/src/lsp/lsp_impl/text_document/did_save.rs
+++ b/src/lsp/lsp_impl/text_document/did_save.rs
@@ -5,6 +5,27 @@ use tower_lsp_server::ls_types::DidSaveTextDocumentParams;
 use super::super::{Kakehashi, uri_to_url};
 use crate::lsp::lsp_impl::snapshot_read::SnapshotWait;
 
+const VIRTUAL_SAVE_SETTLE_BUDGET: std::time::Duration = std::time::Duration::from_millis(200);
+
+async fn saved_parse_is_current(
+    server: &Kakehashi,
+    uri: &url::Url,
+    incarnation: u64,
+    content_version: u64,
+) -> bool {
+    let settle = tokio::time::timeout(
+        VIRTUAL_SAVE_SETTLE_BUDGET,
+        server.wait_for_current_snapshot(uri, VIRTUAL_SAVE_SETTLE_BUDGET),
+    )
+    .await;
+    matches!(
+        settle,
+        Ok(SnapshotWait::Current(snapshot))
+            if snapshot.incarnation == incarnation
+                && snapshot.parsed_version == content_version
+    )
+}
+
 impl Kakehashi {
     /// Handle textDocument/didSave notification.
     ///
@@ -30,15 +51,21 @@ impl Kakehashi {
         // any pending full-text didChange on the same downstream queue.
         let edit_lock = self.documents.edit_lock(&uri);
         let edit_guard = edit_lock.lock().await;
-        let host_text = self.documents.get(&uri).map(|document| document.text_arc());
+        let saved_document = self.documents.get(&uri).map(|document| {
+            (
+                document.text_arc(),
+                document.incarnation(),
+                document.content_version(),
+            )
+        });
 
         // Forward didSave to both bridge layers, in host-before-virt order.
         // Each path only touches an already-open document and excludes servers
         // that require save text, which kakehashi does not advertise upstream
         // (#357).
         let pool = self.bridge.pool_arc();
-        if let Some(host_text) = host_text {
-            pool.sync_and_notify_host_did_save(&uri, &host_text).await;
+        if let Some((host_text, _, _)) = &saved_document {
+            pool.sync_and_notify_host_did_save(&uri, host_text).await;
         }
         drop(edit_guard);
 
@@ -47,16 +74,30 @@ impl Kakehashi {
         // otherwise an immediate save can overtake its projected didChange and
         // run the downstream save hook against stale fragment text. If the
         // bounded settle fails, omit didSave rather than violate that contract.
-        let virtual_documents_are_current = matches!(
-            self.wait_for_current_snapshot(&uri, std::time::Duration::from_millis(200))
-                .await,
-            SnapshotWait::Current(_)
-        );
-        if virtual_documents_are_current {
-            self.injection_coordinator()
-                .process_injections(&uri, true)
-                .await;
-            pool.forward_did_save_to_virtual_docs(&uri).await;
+        if let Some((_, saved_incarnation, saved_content_version)) = saved_document {
+            let saved_snapshot_is_current =
+                saved_parse_is_current(self, &uri, saved_incarnation, saved_content_version).await;
+
+            if saved_snapshot_is_current {
+                let edit_lock = self.documents.edit_lock(&uri);
+                let edit_guard = edit_lock.lock().await;
+                let still_saved_version = self.documents.get(&uri).is_some_and(|document| {
+                    document.incarnation() == saved_incarnation
+                        && document.content_version() == saved_content_version
+                });
+                if still_saved_version
+                    && let Some((_, injections)) =
+                        self.injection_coordinator().bridge_injections(&uri)
+                {
+                    pool.sync_and_forward_did_save_to_virtual_docs(
+                        &uri,
+                        saved_incarnation,
+                        &injections,
+                    )
+                    .await;
+                }
+                drop(edit_guard);
+            }
         }
 
         // Ensure a fresh tree before the synthetic task snapshots it: a save
@@ -71,5 +112,35 @@ impl Kakehashi {
             .spawn_synthetic_diagnostic_task(uri);
 
         self.notifier().log_info("file saved!").await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_lsp_server::LspService;
+
+    #[tokio::test(start_paused = true)]
+    async fn virtual_save_settle_obeys_the_real_time_budget_when_unparsed() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let uri = url::Url::parse("file:///test/unparsed-save.md").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "# unparsed".to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let document = server.documents.get(&uri).unwrap();
+        let incarnation = document.incarnation();
+        let content_version = document.content_version();
+        drop(document);
+
+        let started = tokio::time::Instant::now();
+        assert!(
+            !saved_parse_is_current(server, &uri, incarnation, content_version).await,
+            "an unparsed document cannot vouch for virtual save content"
+        );
+        assert_eq!(started.elapsed(), VIRTUAL_SAVE_SETTLE_BUDGET);
     }
 }

--- a/src/lsp/lsp_impl/text_document/did_save.rs
+++ b/src/lsp/lsp_impl/text_document/did_save.rs
@@ -190,6 +190,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn closed_document_virtual_save_reclaims_its_edit_lock() {
+        // A close that lands after the settle vouched for the saved parse
+        // leaves this path minting an edit-lock entry for a URI that no
+        // longer has a document, and no other path reclaims it: the
+        // background diagnostic waiter bails out before its own reclaim, and
+        // `remove_preserving_edit_lock` retains the entry on purpose.
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let uri = url::Url::parse("file:///test/closed-virtual-save.md").unwrap();
+        let pool = server.bridge.pool_arc();
+
+        server
+            .forward_virtual_did_save_for_saved_version(&pool, &uri, 1, 1)
+            .await;
+
+        assert!(
+            !server.documents.has_edit_lock(&uri),
+            "a save for a closed document must not retain its edit-lock entry"
+        );
+    }
+
+    #[tokio::test]
     async fn missing_document_did_save_reclaims_its_edit_lock() {
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();

--- a/src/lsp/lsp_impl/text_document/did_save.rs
+++ b/src/lsp/lsp_impl/text_document/did_save.rs
@@ -120,17 +120,22 @@ impl Kakehashi {
     ) {
         let edit_lock = self.documents.edit_lock(uri);
         let edit_guard = edit_lock.lock().await;
-        let still_saved_version = self.documents.get(uri).is_some_and(|document| {
-            document.incarnation() == saved_incarnation
-                && document.content_version() == saved_content_version
-        });
-        if still_saved_version
+        let current_lineage = self
+            .documents
+            .get(uri)
+            .map(|document| (document.incarnation(), document.content_version()));
+        if current_lineage == Some((saved_incarnation, saved_content_version))
             && let Some((_, injections)) = self.injection_coordinator().bridge_injections(uri)
         {
             pool.sync_and_forward_did_save_to_virtual_docs(uri, saved_incarnation, &injections)
                 .await;
         }
         drop(edit_guard);
+        // `edit_lock` get-or-inserts, so a close during the settle leaves this
+        // path holding an entry the closed document will never reclaim.
+        if current_lineage.is_none() {
+            self.documents.remove_edit_lock_if_unshared(uri, &edit_lock);
+        }
     }
 }
 

--- a/src/lsp/synthetic_diagnostics.rs
+++ b/src/lsp/synthetic_diagnostics.rs
@@ -6,7 +6,10 @@
 //! collection publishes, and uses `DashMap` for concurrent access via sharded
 //! locks (no single global lock).
 
-use dashmap::DashMap;
+use std::future::Future;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use dashmap::{DashMap, mapref::entry::Entry};
 use tokio::task::AbortHandle;
 use url::Url;
 
@@ -17,9 +20,45 @@ use url::Url;
 /// collection publishes results.
 #[derive(Default)]
 pub(crate) struct SyntheticDiagnosticsManager {
-    /// Map from document URI to the AbortHandle of the active diagnostic task.
-    /// When a new task starts, the previous task (if any) is aborted.
-    active_tasks: DashMap<Url, AbortHandle>,
+    /// Map from document URI to its latest ordering key and optional active
+    /// handle. A completed task leaves a key tombstone until didClose.
+    active_tasks: DashMap<Url, ActiveTask>,
+    registration_lock: std::sync::Mutex<()>,
+    shutdown: AtomicBool,
+}
+
+struct ActiveTask {
+    key: SyntheticDiagnosticTaskKey,
+    abort_handle: Option<AbortHandle>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum SyntheticDiagnosticTrigger {
+    Open,
+    Change,
+    Save,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct SyntheticDiagnosticTaskKey {
+    incarnation: u64,
+    content_version: u64,
+    settings_generation: u64,
+    trigger: SyntheticDiagnosticTrigger,
+}
+
+impl ActiveTask {
+    fn is_finished(&self) -> bool {
+        self.abort_handle
+            .as_ref()
+            .is_some_and(AbortHandle::is_finished)
+    }
+
+    fn abort(&self) {
+        if let Some(handle) = &self.abort_handle {
+            handle.abort();
+        }
+    }
 }
 
 impl SyntheticDiagnosticsManager {
@@ -27,6 +66,8 @@ impl SyntheticDiagnosticsManager {
     pub(crate) fn new() -> Self {
         Self {
             active_tasks: DashMap::new(),
+            registration_lock: std::sync::Mutex::new(()),
+            shutdown: AtomicBool::new(false),
         }
     }
 
@@ -34,27 +75,105 @@ impl SyntheticDiagnosticsManager {
     /// any existing task and returning its `AbortHandle`.
     ///
     /// Also opportunistically cleans up finished tasks to prevent memory buildup.
-    pub(crate) fn register_task(&self, uri: Url, abort_handle: AbortHandle) -> Option<AbortHandle> {
+    #[cfg(test)]
+    pub(crate) fn register_task(&self, uri: Url, abort_handle: AbortHandle) -> bool {
+        self.register_task_for_lineage(uri, 0, 0, 0, SyntheticDiagnosticTrigger::Open, abort_handle)
+    }
+
+    /// Register work for one document version and trigger. Lexicographic
+    /// lineage ordering prevents late old-lifetime/version work from replacing
+    /// newer work; at the same version and settings generation, save outranks
+    /// change, which outranks open.
+    pub(crate) fn register_task_for_lineage(
+        &self,
+        uri: Url,
+        incarnation: u64,
+        content_version: u64,
+        settings_generation: u64,
+        trigger: SyntheticDiagnosticTrigger,
+        abort_handle: AbortHandle,
+    ) -> bool {
+        let _registration = self.registration_lock.lock().unwrap();
+        if self.shutdown.load(Ordering::Acquire) {
+            abort_handle.abort();
+            return false;
+        }
         // Opportunistic cleanup: remove entries for tasks that have completed.
         // This prevents memory buildup from documents that were saved but not re-saved.
         // We limit to a small number to avoid blocking the registration.
         self.cleanup_finished_tasks(5);
 
-        let previous = self.active_tasks.insert(uri, abort_handle);
-
-        if let Some(ref prev_handle) = previous {
-            // Abort the previous task - it's now superseded
-            prev_handle.abort();
-            log::debug!(
-                target: "kakehashi::synthetic_diag",
-                "Superseded previous diagnostic task"
-            );
+        let key = SyntheticDiagnosticTaskKey {
+            incarnation,
+            content_version,
+            settings_generation,
+            trigger,
+        };
+        match self.active_tasks.entry(uri) {
+            Entry::Vacant(entry) => {
+                entry.insert(ActiveTask {
+                    key,
+                    abort_handle: Some(abort_handle),
+                });
+                true
+            }
+            Entry::Occupied(mut entry) => {
+                if entry.get().key > key {
+                    // Newer document/trigger work already owns the URI. Discard
+                    // the late older task instead of aborting its successor.
+                    abort_handle.abort();
+                    return false;
+                }
+                let previous = entry.insert(ActiveTask {
+                    key,
+                    abort_handle: Some(abort_handle),
+                });
+                previous.abort();
+                log::debug!(
+                    target: "kakehashi::synthetic_diag",
+                    "Superseded previous diagnostic task"
+                );
+                true
+            }
         }
-
-        previous
     }
 
-    /// Remove entries for tasks that have finished.
+    /// Spawn work behind a start gate, then release it only if registration
+    /// wins. Rejected and post-shutdown tasks never execute their future.
+    pub(crate) fn spawn_task_for_lineage<F>(
+        &self,
+        uri: Url,
+        incarnation: u64,
+        content_version: u64,
+        settings_generation: u64,
+        trigger: SyntheticDiagnosticTrigger,
+        future: F,
+    ) -> bool
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let (start_tx, start_rx) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(async move {
+            if start_rx.await.is_ok() {
+                future.await;
+            }
+        });
+        let accepted = self.register_task_for_lineage(
+            uri,
+            incarnation,
+            content_version,
+            settings_generation,
+            trigger,
+            task.abort_handle(),
+        );
+        if accepted {
+            let _ = start_tx.send(());
+        }
+        accepted
+    }
+
+    /// Drop handles for tasks that have finished while preserving each URI's
+    /// latest ordering key as a high-watermark until didClose.
     ///
     /// Called opportunistically during registration to prevent memory buildup.
     /// Limited to avoid O(n) scan on every registration.
@@ -65,14 +184,14 @@ impl SyntheticDiagnosticsManager {
         if cleaned > 0 {
             log::trace!(
                 target: "kakehashi::synthetic_diag",
-                "Cleaned up {} finished diagnostic task entries",
+                "Released {} finished diagnostic task handles",
                 cleaned
             );
         }
     }
 
     fn finished_task_uris(&self, limit: usize) -> Vec<Url> {
-        // Collect keys to remove to avoid holding multiple references during iteration.
+        // Collect keys to clean without holding multiple references during iteration.
         let mut uris = Vec::with_capacity(limit);
         for entry in self.active_tasks.iter() {
             if entry.value().is_finished() {
@@ -86,20 +205,18 @@ impl SyntheticDiagnosticsManager {
     }
 
     fn remove_if_still_finished(&self, uris: Vec<Url>) -> usize {
-        let mut removed = 0;
+        let mut cleaned = 0;
         for uri in uris {
-            // Recheck the current value so a newly registered task for the same
-            // URI cannot be deleted after the scan observed an older finished
-            // handle.
-            if self
-                .active_tasks
-                .remove_if(&uri, |_, handle| handle.is_finished())
-                .is_some()
+            // Recheck under the entry guard so a newly registered task cannot
+            // lose its handle after the scan observed an older finished one.
+            if let Some(mut task) = self.active_tasks.get_mut(&uri)
+                && task.is_finished()
             {
-                removed += 1;
+                task.abort_handle = None;
+                cleaned += 1;
             }
         }
-        removed
+        cleaned
     }
 
     /// Check if there's an active task for a document.
@@ -107,13 +224,17 @@ impl SyntheticDiagnosticsManager {
     /// Useful for debugging and tests.
     #[cfg(test)]
     pub(crate) fn has_active_task(&self, uri: &Url) -> bool {
-        self.active_tasks.contains_key(uri)
+        self.active_tasks
+            .get(uri)
+            .is_some_and(|task| task.abort_handle.is_some())
     }
 
     /// Abort all active tasks and clear the map.
     ///
     /// Called during server shutdown to clean up.
     pub(crate) fn abort_all(&self) {
+        let _registration = self.registration_lock.lock().unwrap();
+        self.shutdown.store(true, Ordering::Release);
         for entry in self.active_tasks.iter() {
             entry.value().abort();
         }
@@ -125,8 +246,8 @@ impl SyntheticDiagnosticsManager {
     /// Called when a document is closed. The task is aborted since publishing
     /// diagnostics for a closed document would be wasteful.
     pub(crate) fn remove_document(&self, uri: &Url) {
-        if let Some((_, handle)) = self.active_tasks.remove(uri) {
-            handle.abort();
+        if let Some((_, task)) = self.active_tasks.remove(uri) {
+            task.abort();
             log::debug!(
                 target: "kakehashi::synthetic_diag",
                 "Aborted diagnostic task for closed document"
@@ -138,6 +259,18 @@ impl SyntheticDiagnosticsManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn active_task(abort_handle: AbortHandle) -> ActiveTask {
+        ActiveTask {
+            key: SyntheticDiagnosticTaskKey {
+                incarnation: 0,
+                content_version: 0,
+                settings_generation: 0,
+                trigger: SyntheticDiagnosticTrigger::Open,
+            },
+            abort_handle: Some(abort_handle),
+        }
+    }
 
     #[tokio::test]
     async fn test_register_supersedes_previous() {
@@ -152,8 +285,7 @@ mod tests {
         let handle1 = task1.abort_handle();
 
         // Register task 1
-        let superseded = manager.register_task(uri.clone(), handle1.clone());
-        assert!(superseded.is_none());
+        assert!(manager.register_task(uri.clone(), handle1.clone()));
         assert!(manager.has_active_task(&uri));
 
         // Spawn and register task 2
@@ -163,8 +295,7 @@ mod tests {
         });
         let handle2 = task2.abort_handle();
 
-        let superseded = manager.register_task(uri.clone(), handle2);
-        assert!(superseded.is_some());
+        assert!(manager.register_task(uri.clone(), handle2));
 
         // Task 1 should be aborted - yield to let the abort propagate
         tokio::task::yield_now().await;
@@ -174,6 +305,235 @@ mod tests {
         let result = task2.await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 43);
+    }
+
+    #[tokio::test]
+    async fn late_old_incarnation_cannot_abort_reopened_document_task() {
+        let manager = SyntheticDiagnosticsManager::new();
+        let uri = Url::parse("file:///reopened.md").unwrap();
+        let reopened_task = tokio::spawn(std::future::pending::<()>());
+        let reopened_handle = reopened_task.abort_handle();
+        manager.register_task_for_lineage(
+            uri.clone(),
+            2,
+            0,
+            0,
+            SyntheticDiagnosticTrigger::Open,
+            reopened_handle.clone(),
+        );
+
+        let late_old_task = tokio::spawn(std::future::pending::<()>());
+        let late_old_handle = late_old_task.abort_handle();
+        manager.register_task_for_lineage(
+            uri,
+            1,
+            0,
+            0,
+            SyntheticDiagnosticTrigger::Save,
+            late_old_handle.clone(),
+        );
+
+        tokio::task::yield_now().await;
+        assert!(
+            late_old_handle.is_finished(),
+            "late work for the closed lifetime must discard itself"
+        );
+        assert!(
+            !reopened_handle.is_finished(),
+            "late old-lifetime work must not supersede the reopened document"
+        );
+        reopened_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn late_older_version_cannot_abort_saved_task_in_the_same_incarnation() {
+        let manager = SyntheticDiagnosticsManager::new();
+        let uri = Url::parse("file:///saved.md").unwrap();
+        let saved_task = tokio::spawn(std::future::pending::<()>());
+        let saved_handle = saved_task.abort_handle();
+        manager.register_task_for_lineage(
+            uri.clone(),
+            1,
+            2,
+            0,
+            SyntheticDiagnosticTrigger::Save,
+            saved_handle.clone(),
+        );
+
+        let late_open_task = tokio::spawn(std::future::pending::<()>());
+        let late_open_handle = late_open_task.abort_handle();
+        manager.register_task_for_lineage(
+            uri,
+            1,
+            1,
+            0,
+            SyntheticDiagnosticTrigger::Open,
+            late_open_handle.clone(),
+        );
+
+        tokio::task::yield_now().await;
+        assert!(late_open_handle.is_finished());
+        assert!(!saved_handle.is_finished());
+        saved_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn late_same_version_change_cannot_abort_saved_task() {
+        let manager = SyntheticDiagnosticsManager::new();
+        let uri = Url::parse("file:///saved-same-version.md").unwrap();
+        let saved_task = tokio::spawn(std::future::pending::<()>());
+        let saved_handle = saved_task.abort_handle();
+        manager.register_task_for_lineage(
+            uri.clone(),
+            1,
+            2,
+            0,
+            SyntheticDiagnosticTrigger::Save,
+            saved_handle.clone(),
+        );
+
+        let late_change_task = tokio::spawn(std::future::pending::<()>());
+        let late_change_handle = late_change_task.abort_handle();
+        manager.register_task_for_lineage(
+            uri,
+            1,
+            2,
+            0,
+            SyntheticDiagnosticTrigger::Change,
+            late_change_handle.clone(),
+        );
+
+        tokio::task::yield_now().await;
+        assert!(
+            late_change_handle.is_finished(),
+            "same-version debounce work must yield to the save trigger"
+        );
+        assert!(
+            !saved_handle.is_finished(),
+            "same-version debounce work must not abort the save trigger"
+        );
+        saved_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn completed_save_key_still_rejects_same_version_change() {
+        let manager = SyntheticDiagnosticsManager::new();
+        let uri = Url::parse("file:///completed-save.md").unwrap();
+        let (finished_tx, finished_rx) = tokio::sync::oneshot::channel();
+        assert!(manager.spawn_task_for_lineage(
+            uri.clone(),
+            1,
+            2,
+            0,
+            SyntheticDiagnosticTrigger::Save,
+            async move {
+                let _ = finished_tx.send(());
+            },
+        ));
+        finished_rx.await.unwrap();
+        tokio::task::yield_now().await;
+        manager.cleanup_finished_tasks(5);
+
+        let ran = std::sync::Arc::new(AtomicBool::new(false));
+        let task_ran = std::sync::Arc::clone(&ran);
+        assert!(!manager.spawn_task_for_lineage(
+            uri,
+            1,
+            2,
+            0,
+            SyntheticDiagnosticTrigger::Change,
+            async move {
+                task_ran.store(true, Ordering::Release);
+            },
+        ));
+        tokio::task::yield_now().await;
+        assert!(!ran.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn newer_settings_generation_supersedes_completed_save() {
+        let manager = SyntheticDiagnosticsManager::new();
+        let uri = Url::parse("file:///reconfigured-after-save.md").unwrap();
+        let (saved_tx, saved_rx) = tokio::sync::oneshot::channel();
+        assert!(manager.spawn_task_for_lineage(
+            uri.clone(),
+            1,
+            2,
+            1,
+            SyntheticDiagnosticTrigger::Save,
+            async move {
+                let _ = saved_tx.send(());
+            },
+        ));
+        saved_rx.await.unwrap();
+        tokio::task::yield_now().await;
+        manager.cleanup_finished_tasks(5);
+
+        let (change_tx, change_rx) = tokio::sync::oneshot::channel();
+        assert!(manager.spawn_task_for_lineage(
+            uri,
+            1,
+            2,
+            2,
+            SyntheticDiagnosticTrigger::Change,
+            async move {
+                let _ = change_tx.send(());
+            },
+        ));
+        change_rx.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn rejected_lower_priority_task_never_starts() {
+        let manager = SyntheticDiagnosticsManager::new();
+        let uri = Url::parse("file:///start-gated.md").unwrap();
+        let saved_task = tokio::spawn(std::future::pending::<()>());
+        let saved_handle = saved_task.abort_handle();
+        manager.register_task_for_lineage(
+            uri.clone(),
+            1,
+            1,
+            0,
+            SyntheticDiagnosticTrigger::Save,
+            saved_handle.clone(),
+        );
+
+        let ran = std::sync::Arc::new(AtomicBool::new(false));
+        let task_ran = std::sync::Arc::clone(&ran);
+        assert!(!manager.spawn_task_for_lineage(
+            uri,
+            1,
+            1,
+            0,
+            SyntheticDiagnosticTrigger::Open,
+            async move {
+                task_ran.store(true, Ordering::Release);
+            },
+        ));
+        tokio::task::yield_now().await;
+        assert!(!ran.load(Ordering::Acquire));
+        saved_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn shutdown_rejects_tasks_before_they_start() {
+        let manager = SyntheticDiagnosticsManager::new();
+        manager.abort_all();
+        let ran = std::sync::Arc::new(AtomicBool::new(false));
+        let task_ran = std::sync::Arc::clone(&ran);
+        assert!(!manager.spawn_task_for_lineage(
+            Url::parse("file:///after-shutdown.md").unwrap(),
+            1,
+            1,
+            0,
+            SyntheticDiagnosticTrigger::Save,
+            async move {
+                task_ran.store(true, Ordering::Release);
+            },
+        ));
+        tokio::task::yield_now().await;
+        assert!(!ran.load(Ordering::Acquire));
+        assert!(manager.active_tasks.is_empty());
     }
 
     #[tokio::test]
@@ -224,7 +584,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cleanup_finished_tasks_removes_finished_entries() {
+    async fn cleanup_finished_tasks_releases_handles_but_keeps_keys() {
         let manager = SyntheticDiagnosticsManager::new();
         let uri = Url::parse("file:///finished.md").unwrap();
 
@@ -233,10 +593,13 @@ mod tests {
         task.await.unwrap();
         assert!(handle.is_finished());
 
-        manager.active_tasks.insert(uri.clone(), handle);
+        manager
+            .active_tasks
+            .insert(uri.clone(), active_task(handle));
         manager.cleanup_finished_tasks(5);
 
         assert!(!manager.has_active_task(&uri));
+        assert!(manager.active_tasks.contains_key(&uri));
     }
 
     #[tokio::test]
@@ -249,7 +612,9 @@ mod tests {
         });
         let handle = task.abort_handle();
 
-        manager.active_tasks.insert(uri.clone(), handle.clone());
+        manager
+            .active_tasks
+            .insert(uri.clone(), active_task(handle.clone()));
         manager.cleanup_finished_tasks(5);
 
         assert!(manager.has_active_task(&uri));
@@ -269,7 +634,7 @@ mod tests {
 
         manager
             .active_tasks
-            .insert(uri.clone(), finished_handle.clone());
+            .insert(uri.clone(), active_task(finished_handle.clone()));
         let stale_cleanup_candidates = manager.finished_task_uris(5);
         assert_eq!(stale_cleanup_candidates, vec![uri.clone()]);
 
@@ -279,7 +644,7 @@ mod tests {
         let replacement_handle = replacement_task.abort_handle();
         manager
             .active_tasks
-            .insert(uri.clone(), replacement_handle.clone());
+            .insert(uri.clone(), active_task(replacement_handle.clone()));
 
         let removed = manager.remove_if_still_finished(stale_cleanup_candidates);
 
@@ -301,7 +666,7 @@ mod tests {
         assert!(finished_handle.is_finished());
         manager
             .active_tasks
-            .insert(finished_uri.clone(), finished_handle);
+            .insert(finished_uri.clone(), active_task(finished_handle));
 
         let new_task = tokio::spawn(async {
             tokio::time::sleep(std::time::Duration::from_secs(10)).await;

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -159,6 +159,7 @@ fn main() {
     let mut last_will_save_uri: Option<String> = None;
     let mut did_save_count: usize = 0;
     let mut last_did_save_uri: Option<String> = None;
+    let mut last_did_save_had_text = false;
     let mut diagnostic_generation: u64 = 0;
     // `diagnostics-refresh-prefetch-unchanged`: once ANY unchanged report was
     // answered, the baseline demonstrably exists — a later baseline-less full
@@ -494,6 +495,7 @@ fn main() {
                 // (#357). didSave carries no text (includeText:false), so just
                 // accepting it is the property under test.
                 did_save_count += 1;
+                last_did_save_had_text = message.pointer("/params/text").is_some();
                 last_did_save_uri = message
                     .pointer("/params/textDocument/uri")
                     .and_then(Value::as_str)
@@ -554,6 +556,7 @@ fn main() {
                         "willUri": last_will_save_uri,
                         "did": did_save_count,
                         "didUri": last_did_save_uri,
+                        "didHadText": last_did_save_had_text,
                     });
                     json!({ "contents": state.to_string() })
                 } else if mode.starts_with("workspace-folders") {

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -112,6 +112,8 @@
 //! - `will-save-incapable` — like `will-save` (records + reports save state via
 //!   hover) but advertises NEITHER `willSave` nor `save`, so the bridge's
 //!   per-server capability gate must skip it and its counts stay zero (#357).
+//! - `will-save-include-text` — records save state but requires didSave text;
+//!   textless forwarding must skip it.
 //! - `notify` — right after answering `initialize`, emits a
 //!   `window/showMessage` followed by a `window/logMessage` notification.
 //!   Used by `tests/e2e/e2e_window_notifications.rs` to prove the bridge forwards
@@ -295,6 +297,14 @@ fn main() {
                     "will-save-incapable" => json!({
                         "hoverProvider": true,
                         "textDocumentSync": 1
+                    }),
+                    "will-save-include-text" => json!({
+                        "hoverProvider": true,
+                        "textDocumentSync": {
+                            "openClose": true,
+                            "change": 1,
+                            "save": { "includeText": true }
+                        }
                     }),
                     "workspace-folders" => json!({
                         "hoverProvider": true,

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -160,6 +160,7 @@ fn main() {
     let mut did_save_count: usize = 0;
     let mut last_did_save_uri: Option<String> = None;
     let mut last_did_save_had_text = false;
+    let mut last_did_save_document_text: Option<String> = None;
     let mut diagnostic_generation: u64 = 0;
     // `diagnostics-refresh-prefetch-unchanged`: once ANY unchanged report was
     // answered, the baseline demonstrably exists — a later baseline-less full
@@ -500,6 +501,10 @@ fn main() {
                     .pointer("/params/textDocument/uri")
                     .and_then(Value::as_str)
                     .map(str::to_string);
+                last_did_save_document_text = last_did_save_uri
+                    .as_deref()
+                    .and_then(|uri| documents.get(uri))
+                    .cloned();
             }
             "$/cancelRequest" => {
                 record_mock_event(&mode, "cancel", &message);
@@ -557,6 +562,7 @@ fn main() {
                         "did": did_save_count,
                         "didUri": last_did_save_uri,
                         "didHadText": last_did_save_had_text,
+                        "didDocumentText": last_did_save_document_text,
                     });
                     json!({ "contents": state.to_string() })
                 } else if mode.starts_with("workspace-folders") {

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -112,8 +112,8 @@
 //! - `will-save-incapable` — like `will-save` (records + reports save state via
 //!   hover) but advertises NEITHER `willSave` nor `save`, so the bridge's
 //!   per-server capability gate must skip it and its counts stay zero (#357).
-//! - `will-save-include-text` — records save state but requires didSave text;
-//!   textless forwarding must skip it.
+//! - `will-save-include-text` — records save state and requires didSave text;
+//!   hover exposes the received payload so forwarding can be checked exactly.
 //! - `notify` — right after answering `initialize`, emits a
 //!   `window/showMessage` followed by a `window/logMessage` notification.
 //!   Used by `tests/e2e/e2e_window_notifications.rs` to prove the bridge forwards
@@ -160,6 +160,7 @@ fn main() {
     let mut did_save_count: usize = 0;
     let mut last_did_save_uri: Option<String> = None;
     let mut last_did_save_had_text = false;
+    let mut last_did_save_text: Option<String> = None;
     let mut last_did_save_document_text: Option<String> = None;
     let mut diagnostic_generation: u64 = 0;
     // `diagnostics-refresh-prefetch-unchanged`: once ANY unchanged report was
@@ -492,11 +493,14 @@ fn main() {
                     .map(str::to_string);
             }
             "textDocument/didSave" => {
-                // Notification (no id): record receipt + URI for the hover probe
-                // (#357). didSave carries no text (includeText:false), so just
-                // accepting it is the property under test.
+                // Notification (no id): record receipt, URI, and the optional
+                // payload text for the hover probe (#357).
                 did_save_count += 1;
-                last_did_save_had_text = message.pointer("/params/text").is_some();
+                last_did_save_text = message
+                    .pointer("/params/text")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                last_did_save_had_text = last_did_save_text.is_some();
                 last_did_save_uri = message
                     .pointer("/params/textDocument/uri")
                     .and_then(Value::as_str)
@@ -566,6 +570,7 @@ fn main() {
                         "did": did_save_count,
                         "didUri": last_did_save_uri,
                         "didHadText": last_did_save_had_text,
+                        "didText": last_did_save_text,
                         "didDocumentText": last_did_save_document_text,
                         "documentText": document_text,
                     });

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -97,10 +97,11 @@
 //! - `will-save` — advertises `hoverProvider` + a `textDocumentSync` Options
 //!   block with `willSave`, `willSaveWaitUntil`, and `save` true. Records every
 //!   `textDocument/willSave` (count + last reason + last URI) and
-//!   `textDocument/didSave` (count + last URI), and answers
+//!   `textDocument/didSave` (count + last URI + optional payload text), and answers
 //!   `textDocument/willSaveWaitUntil` with a save-time edit echoing the
 //!   requested URI (only for documents synced via `didOpen`). `hover` returns
-//!   the recorded state as a JSON string (`{will,reason,willUri,did,didUri}`),
+//!   the recorded state as JSON, including the save payload and synchronized
+//!   document text,
 //!   so a test can prove the notifications reached this server carrying the URI
 //!   it knows — the host URI for a host server, the *virtual* URI for a virt
 //!   server. Used by `tests/e2e/e2e_host_bridge.rs` to prove host- AND virt-bridge

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -555,6 +555,10 @@ fn main() {
                     // Report the recorded willSave/didSave state as a JSON string
                     // so the test can prove the notifications reached this server
                     // and carried the document URI it knows (#357).
+                    let document_text = message
+                        .pointer("/params/textDocument/uri")
+                        .and_then(Value::as_str)
+                        .and_then(|uri| documents.get(uri));
                     let state = json!({
                         "will": will_save_count,
                         "reason": last_will_save_reason,
@@ -563,6 +567,7 @@ fn main() {
                         "didUri": last_did_save_uri,
                         "didHadText": last_did_save_had_text,
                         "didDocumentText": last_did_save_document_text,
+                        "documentText": document_text,
                     });
                     json!({ "contents": state.to_string() })
                 } else if mode.starts_with("workspace-folders") {

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -243,6 +243,7 @@ fn main() {
                     // (below). Used to prove `pullFallback = false` still
                     // publishes a pull-driven server's spontaneous push (#425).
                     "diagnostics"
+                    | "diagnostics-save"
                     | "diagnostics-fail"
                     | "diagnostics-malformed"
                     | "diagnostics-refresh-prefetch"
@@ -1005,6 +1006,9 @@ fn main() {
                 respond(&mut writer, id, json!({ "executed": command }));
             }
             "textDocument/diagnostic" => {
+                if mode == "diagnostics-save" {
+                    diagnostic_generation += 1;
+                }
                 if matches!(
                     mode.as_str(),
                     "diagnostics-refresh-prefetch"
@@ -1248,7 +1252,9 @@ fn main() {
                 // but only for documents this server actually received via
                 // didOpen, so the test also proves the host document was
                 // synced before the pull.
-                let diagnostic_message = if mode == "diagnostics-refresh-burst" {
+                let diagnostic_message = if mode == "diagnostics-save" {
+                    format!("mock-diagnostic-save:{diagnostic_generation}")
+                } else if mode == "diagnostics-refresh-burst" {
                     format!("mock-diagnostic-generation:{diagnostic_generation}")
                 } else if matches!(
                     mode.as_str(),

--- a/tests/e2e/e2e_host_bridge.rs
+++ b/tests/e2e/e2e_host_bridge.rs
@@ -963,6 +963,50 @@ fn e2e_host_did_save_notification_reaches_host() {
     shutdown(&mut client);
 }
 
+#[test]
+fn e2e_host_did_save_observes_the_latest_host_text() {
+    const SAVED_TEXT: &str = "# Saved immediately\n";
+    let (mut client, _config_dir, _init) =
+        init_will_save_client("[languages.markdown.bridge._self]\nenabled = true\n");
+
+    for _ in 0..300 {
+        if host_save_hover(&mut client).is_some() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": SAVE_URI, "version": 2 },
+            "contentChanges": [{ "text": SAVED_TEXT }],
+        }),
+    );
+    client.send_notification(
+        "textDocument/didSave",
+        json!({ "textDocument": { "uri": SAVE_URI } }),
+    );
+
+    let mut seen = None;
+    for _ in 0..300 {
+        if let Some(state) = host_save_hover(&mut client)
+            && state["did"] != 0
+        {
+            seen = Some(state);
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let state = seen.expect("the immediate didSave must reach the host server");
+    assert_eq!(
+        state["didDocumentText"], SAVED_TEXT,
+        "host didChange must precede didSave on the downstream wire"
+    );
+
+    shutdown(&mut client);
+}
+
 fn assert_host_did_save_is_skipped(mode: &str) {
     let (mut client, _config_dir, _init) = init_will_save_client_with_mode(
         "[languages.markdown.bridge._self]\nenabled = true\n",

--- a/tests/e2e/e2e_host_bridge.rs
+++ b/tests/e2e/e2e_host_bridge.rs
@@ -1281,6 +1281,67 @@ fn e2e_virt_did_save_observes_the_latest_virtual_text() {
 }
 
 #[test]
+fn e2e_virt_did_save_never_observes_a_later_unsaved_edit() {
+    const SAVED_MARKDOWN: &str = "# Title\n\n```lua\nprint(2)\n```\n";
+    const UNSAVED_MARKDOWN: &str = "# Title\n\n```lua\nprint(3)\n```\n";
+    let (mut client, _config_dir) = init_virt_save_client();
+
+    let mut warmed = false;
+    for _ in 0..300 {
+        if virt_save_hover(&mut client).is_some() {
+            warmed = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(warmed, "virtual document must be open before the edits");
+
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": VIRT_SAVE_URI, "version": 2 },
+            "contentChanges": [{ "text": SAVED_MARKDOWN }],
+        }),
+    );
+    client.send_notification(
+        "textDocument/didSave",
+        json!({ "textDocument": { "uri": VIRT_SAVE_URI } }),
+    );
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": VIRT_SAVE_URI, "version": 3 },
+            "contentChanges": [{ "text": UNSAVED_MARKDOWN }],
+        }),
+    );
+
+    let mut settled = None;
+    for _ in 0..300 {
+        if let Some(state) = virt_save_hover(&mut client)
+            && state["documentText"]
+                .as_str()
+                .is_some_and(|text| text.contains("print(3)"))
+        {
+            settled = Some(state);
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let state = settled.expect("the later unsaved didChange must reach the virtual server");
+    if state["did"] != 0 {
+        let saved_text = state["didDocumentText"]
+            .as_str()
+            .expect("a delivered didSave must record its document text");
+        assert!(
+            saved_text.contains("print(2)"),
+            "didSave may observe saved text or be omitted, never later unsaved text: {saved_text:?}"
+        );
+    }
+
+    shutdown(&mut client);
+}
+
+#[test]
 fn e2e_virt_save_skips_server_without_save_capability() {
     // The per-server capability gate is the phantom-save mitigation: a virt
     // server that advertises neither `willSave` nor `save` must NOT be told

--- a/tests/e2e/e2e_host_bridge.rs
+++ b/tests/e2e/e2e_host_bridge.rs
@@ -1032,7 +1032,7 @@ fn assert_host_did_save_is_skipped(mode: &str) {
         let state = host_save_hover(&mut client).expect("hover must answer");
         assert_eq!(
             state["did"], 0,
-            "textless didSave must not reach includeText=true server: {state}"
+            "didSave must not reach an incapable server: {state}"
         );
     }
 
@@ -1040,8 +1040,39 @@ fn assert_host_did_save_is_skipped(mode: &str) {
 }
 
 #[test]
-fn e2e_host_did_save_skips_server_requiring_text() {
-    assert_host_did_save_is_skipped("will-save-include-text");
+fn e2e_host_did_save_includes_saved_text_when_requested() {
+    let (mut client, _config_dir, _init) = init_will_save_client_with_mode(
+        "[languages.markdown.bridge._self]\nenabled = true\n",
+        "will-save-include-text",
+    );
+
+    for _ in 0..300 {
+        if host_save_hover(&mut client).is_some() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    client.send_notification(
+        "textDocument/didSave",
+        json!({ "textDocument": { "uri": SAVE_URI } }),
+    );
+
+    let mut seen = None;
+    for _ in 0..300 {
+        if let Some(state) = host_save_hover(&mut client)
+            && state["did"] != 0
+        {
+            seen = Some(state);
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let state = seen.expect("includeText=true server must receive didSave");
+    assert_eq!(state["didHadText"], true);
+    assert_eq!(state["didDocumentText"], MARKDOWN);
+
+    shutdown(&mut client);
 }
 
 #[test]
@@ -1276,6 +1307,43 @@ fn e2e_virt_did_save_observes_the_latest_virtual_text() {
         !saved_text.contains("print(1)"),
         "stale virtual text remained"
     );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_virt_did_save_includes_projected_text_when_requested() {
+    let (mut client, _config_dir) = init_virt_save_client_with_mode("will-save-include-text");
+
+    for _ in 0..300 {
+        if virt_save_hover(&mut client).is_some() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    client.send_notification(
+        "textDocument/didSave",
+        json!({ "textDocument": { "uri": VIRT_SAVE_URI } }),
+    );
+
+    let mut seen = None;
+    for _ in 0..300 {
+        if let Some(state) = virt_save_hover(&mut client)
+            && state["did"] != 0
+        {
+            seen = Some(state);
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let state = seen.expect("includeText=true virtual server must receive didSave");
+    assert_eq!(state["didHadText"], true);
+    let text = state["didDocumentText"]
+        .as_str()
+        .expect("didSave must include projected virtual text");
+    assert!(text.contains("print(1)"));
+    assert!(!text.contains("# Title"));
 
     shutdown(&mut client);
 }

--- a/tests/e2e/e2e_host_bridge.rs
+++ b/tests/e2e/e2e_host_bridge.rs
@@ -955,15 +955,18 @@ fn e2e_host_did_save_notification_reaches_host() {
     let state = seen.expect("the forwarded didSave must reach the host server");
     assert_eq!(state["did"], 1);
     assert_eq!(state["didUri"], SAVE_URI, "host URI must remain verbatim");
+    assert_eq!(
+        state["didHadText"], false,
+        "host didSave must omit the text field"
+    );
 
     shutdown(&mut client);
 }
 
-#[test]
-fn e2e_host_did_save_skips_server_requiring_text() {
+fn assert_host_did_save_is_skipped(mode: &str) {
     let (mut client, _config_dir, _init) = init_will_save_client_with_mode(
         "[languages.markdown.bridge._self]\nenabled = true\n",
-        "will-save-include-text",
+        mode,
     );
 
     let mut warmed = false;
@@ -990,6 +993,16 @@ fn e2e_host_did_save_skips_server_requiring_text() {
     }
 
     shutdown(&mut client);
+}
+
+#[test]
+fn e2e_host_did_save_skips_server_requiring_text() {
+    assert_host_did_save_is_skipped("will-save-include-text");
+}
+
+#[test]
+fn e2e_host_did_save_skips_server_without_save_capability() {
+    assert_host_did_save_is_skipped("will-save-incapable");
 }
 
 #[test]

--- a/tests/e2e/e2e_host_bridge.rs
+++ b/tests/e2e/e2e_host_bridge.rs
@@ -1228,6 +1228,56 @@ fn e2e_virt_will_save_and_did_save_reach_virtual_doc() {
 }
 
 #[test]
+fn e2e_virt_did_save_observes_the_latest_virtual_text() {
+    const SAVED_MARKDOWN: &str = "# Title\n\n```lua\nprint(2)\n```\n";
+    let (mut client, _config_dir) = init_virt_save_client();
+
+    let mut warmed = false;
+    for _ in 0..300 {
+        if virt_save_hover(&mut client).is_some() {
+            warmed = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(warmed, "virtual document must be open before the edit");
+
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": VIRT_SAVE_URI, "version": 2 },
+            "contentChanges": [{ "text": SAVED_MARKDOWN }],
+        }),
+    );
+    client.send_notification(
+        "textDocument/didSave",
+        json!({ "textDocument": { "uri": VIRT_SAVE_URI } }),
+    );
+
+    let mut seen = None;
+    for _ in 0..300 {
+        if let Some(state) = virt_save_hover(&mut client)
+            && state["did"] != 0
+        {
+            seen = Some(state);
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let state = seen.expect("the immediate didSave must reach the virtual server");
+    let saved_text = state["didDocumentText"]
+        .as_str()
+        .expect("the server must retain its virtual document text at didSave");
+    assert!(
+        saved_text.contains("print(2)"),
+        "virtual didChange must precede didSave; got {saved_text:?}"
+    );
+    assert!(!saved_text.contains("print(1)"), "stale virtual text remained");
+
+    shutdown(&mut client);
+}
+
+#[test]
 fn e2e_virt_save_skips_server_without_save_capability() {
     // The per-server capability gate is the phantom-save mitigation: a virt
     // server that advertises neither `willSave` nor `save` must NOT be told

--- a/tests/e2e/e2e_host_bridge.rs
+++ b/tests/e2e/e2e_host_bridge.rs
@@ -922,6 +922,77 @@ fn e2e_host_will_save_notification_reaches_host() {
 }
 
 #[test]
+fn e2e_host_did_save_notification_reaches_host() {
+    let (mut client, _config_dir, _init) =
+        init_will_save_client("[languages.markdown.bridge._self]\nenabled = true\n");
+
+    let mut warmed = false;
+    for _ in 0..300 {
+        if let Some(state) = host_save_hover(&mut client) {
+            assert_eq!(state["did"], 0, "no didSave before notification: {state}");
+            warmed = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(warmed, "host document must be open before didSave");
+
+    client.send_notification(
+        "textDocument/didSave",
+        json!({ "textDocument": { "uri": SAVE_URI } }),
+    );
+
+    let mut seen = None;
+    for _ in 0..300 {
+        if let Some(state) = host_save_hover(&mut client)
+            && state["did"] != 0
+        {
+            seen = Some(state);
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let state = seen.expect("the forwarded didSave must reach the host server");
+    assert_eq!(state["did"], 1);
+    assert_eq!(state["didUri"], SAVE_URI, "host URI must remain verbatim");
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_host_did_save_skips_server_requiring_text() {
+    let (mut client, _config_dir, _init) = init_will_save_client_with_mode(
+        "[languages.markdown.bridge._self]\nenabled = true\n",
+        "will-save-include-text",
+    );
+
+    let mut warmed = false;
+    for _ in 0..300 {
+        if host_save_hover(&mut client).is_some() {
+            warmed = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(warmed, "host document must be open before didSave");
+
+    client.send_notification(
+        "textDocument/didSave",
+        json!({ "textDocument": { "uri": SAVE_URI } }),
+    );
+    for _ in 0..10 {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        let state = host_save_hover(&mut client).expect("hover must answer");
+        assert_eq!(
+            state["did"], 0,
+            "textless didSave must not reach includeText=true server: {state}"
+        );
+    }
+
+    shutdown(&mut client);
+}
+
+#[test]
 fn e2e_host_will_save_wait_until_times_out_without_hanging_save() {
     // The host server stalls 8s on willSaveWaitUntil; kakehashi's 5s save budget
     // must abandon the request and return null near 5s — NOT wait the 30s

--- a/tests/e2e/e2e_host_bridge.rs
+++ b/tests/e2e/e2e_host_bridge.rs
@@ -1272,7 +1272,10 @@ fn e2e_virt_did_save_observes_the_latest_virtual_text() {
         saved_text.contains("print(2)"),
         "virtual didChange must precede didSave; got {saved_text:?}"
     );
-    assert!(!saved_text.contains("print(1)"), "stale virtual text remained");
+    assert!(
+        !saved_text.contains("print(1)"),
+        "stale virtual text remained"
+    );
 
     shutdown(&mut client);
 }

--- a/tests/e2e/e2e_host_bridge.rs
+++ b/tests/e2e/e2e_host_bridge.rs
@@ -1041,6 +1041,7 @@ fn assert_host_did_save_is_skipped(mode: &str) {
 
 #[test]
 fn e2e_host_did_save_includes_saved_text_when_requested() {
+    const INCLUDED_SAVED_TEXT: &str = "# Included saved text\n";
     let (mut client, _config_dir, _init) = init_will_save_client_with_mode(
         "[languages.markdown.bridge._self]\nenabled = true\n",
         "will-save-include-text",
@@ -1053,6 +1054,13 @@ fn e2e_host_did_save_includes_saved_text_when_requested() {
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
 
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": SAVE_URI, "version": 2 },
+            "contentChanges": [{ "text": INCLUDED_SAVED_TEXT }],
+        }),
+    );
     client.send_notification(
         "textDocument/didSave",
         json!({ "textDocument": { "uri": SAVE_URI } }),
@@ -1070,7 +1078,8 @@ fn e2e_host_did_save_includes_saved_text_when_requested() {
     }
     let state = seen.expect("includeText=true server must receive didSave");
     assert_eq!(state["didHadText"], true);
-    assert_eq!(state["didDocumentText"], MARKDOWN);
+    assert_eq!(state["didText"], INCLUDED_SAVED_TEXT);
+    assert_eq!(state["didDocumentText"], INCLUDED_SAVED_TEXT);
 
     shutdown(&mut client);
 }
@@ -1313,6 +1322,7 @@ fn e2e_virt_did_save_observes_the_latest_virtual_text() {
 
 #[test]
 fn e2e_virt_did_save_includes_projected_text_when_requested() {
+    const INCLUDED_SAVED_MARKDOWN: &str = "# Title\n\n```lua\nprint(2)\n```\n";
     let (mut client, _config_dir) = init_virt_save_client_with_mode("will-save-include-text");
 
     for _ in 0..300 {
@@ -1322,6 +1332,13 @@ fn e2e_virt_did_save_includes_projected_text_when_requested() {
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
 
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": VIRT_SAVE_URI, "version": 2 },
+            "contentChanges": [{ "text": INCLUDED_SAVED_MARKDOWN }],
+        }),
+    );
     client.send_notification(
         "textDocument/didSave",
         json!({ "textDocument": { "uri": VIRT_SAVE_URI } }),
@@ -1339,10 +1356,11 @@ fn e2e_virt_did_save_includes_projected_text_when_requested() {
     }
     let state = seen.expect("includeText=true virtual server must receive didSave");
     assert_eq!(state["didHadText"], true);
-    let text = state["didDocumentText"]
+    let text = state["didText"]
         .as_str()
         .expect("didSave must include projected virtual text");
-    assert!(text.contains("print(1)"));
+    assert_eq!(state["didText"], state["didDocumentText"]);
+    assert!(text.contains("print(2)"));
     assert!(!text.contains("# Title"));
 
     shutdown(&mut client);

--- a/tests/e2e/e2e_synthetic_push_diagnostic.rs
+++ b/tests/e2e/e2e_synthetic_push_diagnostic.rs
@@ -1,16 +1,17 @@
 //! End-to-end test for synthetic push diagnostics (pull-first-diagnostic-forwarding Phase 2).
 //!
 //! This test verifies the `textDocument/publishDiagnostics` push path on
-//! `didSave`/`didOpen`. Note the two flavours below: tests gated by a real
-//! downstream (lua-ls) treat the push as OPTIONAL — they only assert structure
-//! IF one arrives within `OPTIONAL_PUSH_WAIT` (valid Lua may produce none), and
-//! otherwise just require the server not to crash. The layers-gate test, whose
-//! empty publish is deterministic (no downstream), DOES require the push.
+//! `didSave`/`didOpen`. The didOpen test treats a real-downstream push as
+//! optional because valid Lua can leave the merged set unchanged. The didSave
+//! test uses a pull-capable mock whose result has a request generation and
+//! requires the didSave generation. The layers-gate test also requires its
+//! deterministic empty push.
 //!
 //! Run with: `cargo test --features e2e --test e2e e2e_synthetic_push_diagnostic::`
 //!
 //! **Requirements**: lua-language-server must be installed and in PATH.
 
+use crate::helpers::lsp_client::LspClient;
 use crate::helpers::lsp_polling::wait_for_server_ready;
 use crate::helpers::lua_bridge::{create_lua_configured_client, shutdown_client};
 use serde_json::json;
@@ -26,6 +27,41 @@ use std::time::Duration;
 /// server is ready. Tests that *require* a deterministic push keep their own
 /// longer, explicit timeout.
 const OPTIONAL_PUSH_WAIT: Duration = Duration::from_secs(3);
+const REQUIRED_PUSH_WAIT: Duration = Duration::from_secs(10);
+
+fn mock_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_mock-lsp-formatter")
+}
+
+fn create_save_diagnostic_client() -> (LspClient, tempfile::TempDir) {
+    let config_dir = tempfile::TempDir::new().expect("temp dir");
+    let config_path = config_dir.path().join("save_diagnostic.toml");
+    std::fs::write(&config_path, "").expect("write config");
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("utf8 path"))
+        .build();
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "diagnosticsDebounceMs": 10_000,
+                "languageServers": {
+                    "mock-diagnostic": {
+                        "cmd": [mock_bin(), "diagnostics-save"],
+                        "languages": ["lua"]
+                    }
+                }
+            }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+    (client, config_dir)
+}
 
 /// E2E test: publishDiagnostics is sent on didOpen
 ///
@@ -111,7 +147,7 @@ print(x)
 /// diagnostics from downstream servers and publish them.
 #[test]
 fn e2e_synthetic_push_on_did_save() {
-    let (mut client, _config_dir) = create_lua_configured_client();
+    let (mut client, _config_dir) = create_save_diagnostic_client();
 
     // First open the document
     let markdown_content = r#"# Test Document
@@ -135,13 +171,40 @@ local x = 1
         }),
     );
 
-    // Wait for lua-ls to be ready
-    wait_for_server_ready(&mut client, markdown_uri, 5, 100);
+    // Require the didOpen pull's generation so the later assertion can identify
+    // the didSave pull specifically. Avoid a readiness probe here because that
+    // probe is itself a diagnostic request and would consume a mock generation.
+    client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            REQUIRED_PUSH_WAIT,
+            |params| {
+                params["diagnostics"].as_array().is_some_and(|diagnostics| {
+                    diagnostics
+                        .iter()
+                        .any(|diagnostic| diagnostic["message"] == json!("mock-diagnostic-save:1"))
+                })
+            },
+        )
+        .expect("didOpen must establish diagnostic generation 1");
 
-    // Drain any existing notifications from didOpen
-    let _ = client.wait_for_notification("textDocument/publishDiagnostics", Duration::from_secs(3));
+    // didChange's own pull is delayed for 10s, so generation 2 identifies the
+    // immediate didSave path. The unit waiter test separately holds the exact
+    // saved parse snapshot unready for 16 virtual seconds.
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": {
+                "uri": markdown_uri,
+                "version": 2
+            },
+            "contentChanges": [{
+                "text": "# Test Document\n\n```lua\nlocal =\n```\n"
+            }]
+        }),
+    );
 
-    // Now send didSave - this should trigger another synthetic push
+    // Now send didSave - this should trigger another synthetic push.
     client.send_notification(
         "textDocument/didSave",
         json!({
@@ -152,10 +215,19 @@ local x = 1
     );
 
     // Wait for publishDiagnostics notification from didSave
-    let notification =
-        client.wait_for_notification("textDocument/publishDiagnostics", OPTIONAL_PUSH_WAIT);
+    let notification = client.wait_for_notification_where(
+        &["textDocument/publishDiagnostics"],
+        Duration::from_secs(5),
+        |params| {
+            params["diagnostics"].as_array().is_some_and(|diagnostics| {
+                diagnostics
+                    .iter()
+                    .any(|diagnostic| diagnostic["message"] == json!("mock-diagnostic-save:2"))
+            })
+        },
+    );
 
-    if let Some(params) = notification {
+    if let Some((_, params)) = notification {
         println!(
             "Received publishDiagnostics on save: {}",
             serde_json::to_string_pretty(&params).unwrap()
@@ -169,19 +241,20 @@ local x = 1
         );
 
         let diagnostics = params.get("diagnostics").and_then(|d| d.as_array());
+        let diagnostics = diagnostics.expect("publishDiagnostics should have diagnostics array");
         assert!(
-            diagnostics.is_some(),
-            "publishDiagnostics should have diagnostics array"
+            !diagnostics.is_empty(),
+            "the save pull must produce its identifiable diagnostic generation"
         );
 
         println!(
             "✓ E2E: Synthetic push on didSave - received {} diagnostics",
-            diagnostics.unwrap().len()
+            diagnostics.len()
         );
     } else {
-        println!(
-            "⚠ E2E: No publishDiagnostics received on save within timeout. \
-             This may happen if lua-ls is slow."
+        let stderr = client.drain_stderr();
+        panic!(
+            "didSave must produce publishDiagnostics within the E2E timeout; server stderr:\n{stderr}"
         );
     }
 

--- a/tests/integration/test_cli.rs
+++ b/tests/integration/test_cli.rs
@@ -3121,8 +3121,60 @@ fn test_language_uninstall_cancel() {
     );
 }
 
+/// Create a pipe whose both ends are `FD_CLOEXEC`.
+///
+/// The flag is what keeps these tests deterministic: plain `pipe()` creates
+/// inheritable fds, and tests run in parallel threads — a child spawned
+/// concurrently by ANOTHER test can inherit our read end and keep the pipe
+/// alive, in which case the child under test writes into a live pipe and exits
+/// 0 instead of dying by SIGPIPE. That is the historical flake in these tests.
+///
+/// Where the platform has `pipe2` the flag is applied **atomically at
+/// creation**, leaving no window at all — this is what CI runs on, and the
+/// residual window is exactly where the flake kept recurring. Platforms
+/// without `pipe2` (macOS) set the flags in a second syscall and keep a few
+/// instructions of exposure.
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "illumos",
+    target_os = "solaris",
+))]
+fn cloexec_pipe() -> (std::os::fd::OwnedFd, std::os::fd::OwnedFd) {
+    nix::unistd::pipe2(nix::fcntl::OFlag::O_CLOEXEC).expect("create CLOEXEC pipe")
+}
+
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "illumos",
+        target_os = "solaris",
+    ))
+))]
+fn cloexec_pipe() -> (std::os::fd::OwnedFd, std::os::fd::OwnedFd) {
+    use nix::fcntl::{FcntlArg, FdFlag, fcntl};
+
+    let (read_fd, write_fd) = nix::unistd::pipe().expect("create pipe");
+    fcntl(&read_fd, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC)).expect("set CLOEXEC on read end");
+    fcntl(&write_fd, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC)).expect("set CLOEXEC on write end");
+    (read_fd, write_fd)
+}
+
 /// Run the kakehashi binary with `args`, giving it a stdout pipe whose read end
 /// is closed *before* the child is spawned, and return the finished output.
+///
+/// `Stdio::from(write_fd)` still reaches the child despite `FD_CLOEXEC`,
+/// because std dup2s stdio fds for the child and the duplicate loses the flag.
 ///
 /// With no reader, the child inherits only the write end, so its first stdout
 /// write fails with EPIPE — and, once the default SIGPIPE disposition is
@@ -3131,22 +3183,9 @@ fn test_language_uninstall_cancel() {
 /// spawn/write race.
 #[cfg(unix)]
 fn run_with_broken_stdout_pipe(args: &[&str]) -> std::process::Output {
-    use std::os::fd::OwnedFd;
     use std::process::Stdio;
 
-    let (read_fd, write_fd): (OwnedFd, OwnedFd) = nix::unistd::pipe().expect("create pipe");
-    // Mark both ends CLOEXEC immediately: `pipe()` creates inheritable fds,
-    // and tests run in parallel threads — a concurrently spawned child of
-    // ANOTHER test could inherit our read end and keep it open, in which
-    // case the child under test writes into a live pipe and exits 0 instead
-    // of dying by SIGPIPE (the historical flake in these tests). CLOEXEC
-    // stops the leak; `Stdio::from(write_fd)` still works because std dup2s
-    // stdio fds for the child, which clears CLOEXEC on the duplicate.
-    // (macOS has no `pipe2`, so the flags are set in a second syscall; the
-    // remaining pipe()-to-fcntl window is a few instructions wide.)
-    use nix::fcntl::{FcntlArg, FdFlag, fcntl};
-    fcntl(&read_fd, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC)).expect("set CLOEXEC on read end");
-    fcntl(&write_fd, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC)).expect("set CLOEXEC on write end");
+    let (read_fd, write_fd) = cloexec_pipe();
     // Close the read end before spawning: the child gets only the write end, so
     // there is no reader and the first write hits EPIPE.
     drop(read_fd);


### PR DESCRIPTION
## Summary

- forward `textDocument/didSave` to already-open host and virtual bridge documents
- synchronize saved host/projected text before each notification and honor downstream `save.includeText`
- fence save-time routing against later edits, connection replacement, queue failure, and missing/malformed document state
- advertise downstream didSave support and document the host/virt contract
- rework synthetic-diagnostic task ownership so a save survives parse latency
  without blocking ingress (see **Incidental change**)

## User-visible impact

Downstream save hooks now run for both host and injected-language servers against the text that was actually saved. Servers without save support are skipped, while `includeText = true` servers receive the exact host or projected virtual content.

## Verification

- `make check`
- `cargo test --lib did_save`
- `cargo test --lib ingress_order`
- `cargo test --features e2e --test e2e did_save -- --test-threads=1`
- focused host/virt includeText, queue-pressure, generation, timeout, and stale-text regressions
- `git diff --check`

A local `make test_all` run passed all 3,597 unit tests; under unrelated sustained CPU stress, three timing-sensitive E2Es failed. Both cancellation tests passed when rerun individually; the semantic-token test continued to hit its 30s timeout under that load. GitHub CI is the clean-environment full-suite gate.

## Incidental change (beyond didSave forwarding)

About half the diff reworks **synthetic diagnostic task ownership**
(`synthetic_diagnostics.rs`, `coordinator/diagnostic.rs`, `ingress_order.rs`,
`debounced_diagnostics.rs`, `text_document/did_change.rs`). It is not a
separable prerequisite: forwarding a save correctly forces it, in this order.

1. A save must survive parse latency, but `didSave` is now an **ingress writer
   fence** — it has to be, or a later `didChange` overtakes the save-time
   version capture — so the old `ensure_document_parsed(&uri).await` on the
   handler would block every later writer for that document behind a parse.
2. So the parse wait moves **off-ingress**, into a background waiter bound to
   the exact saved `(incarnation, content version)`
   (`wait_for_expected_diagnostic_tree`), abortable and re-checked before it
   snapshots.
3. A background waiter needs a **total order over triggers**, otherwise the
   post-parse debounce registration that lands moments later cancels the save's
   own pull. Ownership is therefore keyed on
   `(incarnation, content version, settings generation, trigger)` with
   `didSave > didChange > didOpen` at an equal version and settings generation:
   a lower key aborts itself, a higher key supersedes the incumbent, and a
   newer settings generation can still legitimately win. A `oneshot` start gate
   means a task that loses registration never runs its body at all, and
   shutdown permanently closes registration before aborting.
4. An ownership window that outlives the edit needs a **commit-time
   revalidation**: `commit_synthetic_diagnostics_when_current` republishes only
   under the edit lock and only for the still-current lineage, and
   `did_change_impl` aborts the saved pull *before* mutating the document. Both
   are required — the first closes the wait-to-snapshot window, the second the
   in-flight-downstream-request window.

`ingress_order.rs` additionally decodes `DidSaveTextDocumentParams` fully before
issuing a ticket, and adds `reclaim_current_writer_sequence()` so a save on a
missing document releases its per-URI sequencing entry instead of retaining it.
`textDocument/diagnostic` joins the reader class for the same ordering reason.

**Behavioral consequence beyond save:** a diagnostic pull can no longer publish
against a version the document has left, and a `didChange` now cancels the
previous edit's debounce and any registered collection before advancing the
version. Push diagnostics that used to land late (post-edit, for the pre-edit
text) are dropped instead of published.

## Incidental change (`willSave`)

Extracting the host `willSave` fan-out into the shared `notify_open_host_documents`
gave it `didSave`'s liveness check. The per-server predicate is now
`state() == ConnectionState::Ready && supports(handle)`; before it was the
capability alone, with no state check:

```rust
// before
if !docs.contains_key(&(uri_string.clone(), connection_key.clone())) { continue; }
if !handle.has_capability("textDocument/willSave") { continue; }

// after
if !can_notify_host_document(handle, &supports) { continue; }   // adds state() == Ready
if !docs.contains_key(&(uri_string.clone(), connection_key.clone())) { continue; }
```

So a connection still mapped as holding the host document, but already moved to
`Failed` (or not yet `Ready`), no longer receives `willSave`. A host document is
normally only registered on a connection that reached `Ready`, so this is close
to a no-op in practice; where it does differ it drops a notification the
connection could not have served. Covered by
`host_save_notification_skips_failed_current_handle`.

Stacked on #1023.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- `didSave` notifications now reach eligible host and virtual language servers.
- Servers receive the latest saved text when requested, including accurately projected virtual-document text.
- Save notifications are ordered after corresponding document changes to prevent stale or unsaved content.

## Bug Fixes
- Prevented stale diagnostic results from being published after document edits.
- Improved handling of invalid or missing documents and interrupted save processing.
- Added bounded waiting to keep save handling responsive while virtual documents settle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

