### PR TITLE
feat(lsp): support documentLink/resolve across layers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ Current bridge-backed requests include:
 - Hover
 - Find References
 - Rename / Prepare Rename
-- Document Highlight / Document Symbol / Document Link
+- Document Highlight / Document Symbol / Document Link (incl. `documentLink/resolve` routed back to the producing host or injection server; stale injection links fail soft)
 - Moniker / Inlay Hint
 - Code Lens (incl. `codeLens/resolve` routed back to the origin server for both injection- and host-layer lenses; host-layer payloads and coordinates pass through verbatim, while injection resolution fails soft when the region was moved or invalidated since the lens was produced, and always in runtime-range-adjusted (`#offset!` / `#trim!`) regions such as frontmatter)
 - Code Action (incl. `codeAction/resolve` routed back to the origin server, host-layer actions via `bridge._self`, and a merged menu across every injection region a multi-fence range overlaps; advertised only to clients with `codeActionLiteralSupport`)

--- a/docs/architecture-decisions/bridge-routing-protocol.md
+++ b/docs/architecture-decisions/bridge-routing-protocol.md
@@ -779,7 +779,7 @@ structures with different lifetimes carry the outcome:
   through to kakehashi's ordinary resolution. The binding governs
   **every** site that derives a connection from the host URI — the
   resolve envelopes (`completionItem/resolve`, `codeAction/resolve`,
-  `codeLens/resolve` — every envelope that re-derives a connection from
+  `codeLens/resolve`, `documentLink/resolve` — every envelope that re-derives a connection from
   a host URI) included, whose re-resolution would otherwise reach the
   config-root process instead of the one that produced the item
   (ls-bridge-server-pool-coordination is amended accordingly). The

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -65,7 +65,9 @@ Partially implemented:
   generation, reserved-key collision, and cancellation rules. It preserves the
   already-translated range while allowing the producer to materialize `target`,
   `tooltip`, and updated opaque `data`; a moved or invalidated virtual region
-  returns the original unresolved link.
+  returns the original unresolved link. Both layers bind opaque link data to
+  the exact producing process: resolve never respawns or selects a replacement
+  connection after a restart, configuration reroute, or pool-key change.
   Formatting additionally supports the cross-layer
   `concatenated` pipeline: virt region edits apply first, the host
   formatter formats the intermediate text, and the chain collapses into one

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -61,6 +61,11 @@ Partially implemented:
   Ordinary downstream failures remain fail-soft,
   while an upstream client cancellation returns `RequestCancelled` and
   cancels the in-flight downstream resolve.
+  `documentLink/resolve` uses the same origin, incarnation, connection-key,
+  generation, reserved-key collision, and cancellation rules. It preserves the
+  already-translated range while allowing the producer to materialize `target`,
+  `tooltip`, and updated opaque `data`; a moved or invalidated virtual region
+  returns the original unresolved link.
   Formatting additionally supports the cross-layer
   `concatenated` pipeline: virt region edits apply first, the host
   formatter formats the intermediate text, and the chain collapses into one

--- a/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
+++ b/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
@@ -55,8 +55,8 @@ envelopes (`KakehashiEnvelope` / `CodeActionEnvelope` / `CodeLensEnvelope` /
 and used to re-resolve the same `(server, root)` connection that produced the
 item. (A legacy **completion** envelope without that field falls back to
 the client-root connection — the pre-#382 rule, and still the shipped
-behavior today, via the field's serde default; the code-action and
-code-lens envelopes *require* the field, so a stamp-less one fails to
+behavior today, via the field's serde default; the code-action, code-lens, and
+document-link envelopes *require* the field, so a stamp-less one fails to
 deserialize and the item is returned unresolved. The fail-soft rule
 below is target state that lands with bridge-routing-protocol's
 implementation.) Amended with

--- a/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
+++ b/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
@@ -47,9 +47,11 @@ The `ConnectionKey` is stored on each connection handle, so the request,
 `didChange`, host, and cancel paths route per-connection state via
 `handle.key()` without re-resolving the root.
 
-`completionItem/resolve`, `codeAction/resolve`, and `codeLens/resolve` carry
+`completionItem/resolve`, `codeAction/resolve`, `codeLens/resolve`, and
+`documentLink/resolve` carry
 no `textDocument`, so the originating host URI is stashed in their routing
-envelopes (`KakehashiEnvelope` / `CodeActionEnvelope` / `CodeLensEnvelope`)
+envelopes (`KakehashiEnvelope` / `CodeActionEnvelope` / `CodeLensEnvelope` /
+`DocumentLinkEnvelope`)
 and used to re-resolve the same `(server, root)` connection that produced the
 item. (A legacy **completion** envelope without that field falls back to
 the client-root connection — the pre-#382 rule, and still the shipped

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -184,7 +184,10 @@ Returns a hierarchical or flat outline depending on what your editor supports.
 
 [`textDocument/documentLink`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_documentLink)
 
-Collects clickable links from all embedded blocks.
+Collects clickable links from all embedded blocks. Lazy links are resolved by
+the same host or embedded-language server that produced them; links from an
+edited or invalidated embedded region are returned unresolved instead of being
+translated with stale coordinates.
 
 ### Rename / Prepare rename
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1787,8 +1787,9 @@ async fn serve_lsp() {
     // the wedge threshold becomes INGRESS_CONCURRENCY + tower-lsp's 100-slot
     // channel queue of outstanding messages, and a wedge self-heals within
     // the parked readers' settle backstop. `$/cancelRequest` is immune either
-    // way — `RequestIdCapture::call` dispatches its forwarding as a detached
-    // fire-and-forget spawn and needs no admission slot to do so. Sized for
+    // way — `RequestIdCapture::call` captures and queues cancellation
+    // synchronously before tower-lsp handles the notification, so it needs no
+    // admission slot. Sized for
     // the worst observed per-keystroke
     // burst (≈10 concurrent reader parks per document) across several
     // documents, with headroom.

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -82,8 +82,9 @@ pub(crate) use protocol::workspace_edit_preserves_line_prefixes;
 pub(crate) use protocol::workspace_edit_within_region;
 pub(crate) use text_document::host::{HostDocument, HostTextReader, normalize_host_goto_result};
 pub(crate) use text_document::{
-    CodeActionEnvelope, CodeLensEnvelope, UpstreamCodeActionCaps, bridge_code_actions,
-    envelope_host_code_lenses, extract_code_action_envelope, extract_code_lens_envelope,
+    CodeActionEnvelope, CodeLensEnvelope, DocumentLinkEnvelope, UpstreamCodeActionCaps,
+    bridge_code_actions, envelope_host_code_lenses, envelope_host_document_links,
+    extract_code_action_envelope, extract_code_lens_envelope, extract_document_link_envelope,
     parse_code_actions_leniently,
 };
 pub(crate) use text_document::{KakehashiEnvelope, bridge_host_completion_items, extract_envelope};

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1701,7 +1701,7 @@ impl BridgeCoordinator {
                 }
                 configs = async {
                     let lifecycle = pool.host_lifecycle_lock(&host_uri_owned);
-                    let _guard = lifecycle.lock().await;
+                    let _guard = lifecycle.write().await;
                     Self::resolve_document_routing(
                         &pool,
                         &host_uri_owned,

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -292,7 +292,14 @@ struct OpenClaimGuard {
 }
 
 type OpenTransitionLocks = DashMap<(ConnectionKey, String), Arc<tokio::sync::Mutex<()>>>;
-type HostLifecycleLocks = DashMap<Url, Arc<tokio::sync::Mutex<()>>>;
+/// Per-host-document lifecycle lock, as a reader/writer lock: in-flight
+/// requests take it **shared**, lifecycle transitions (open / close / eager
+/// open / routing resolution) take it **exclusive**. Shared is what makes the
+/// host and virt layers of one document run concurrently — with a plain mutex
+/// each layer waited out the other's full downstream round trip, so
+/// `race_layers_concatenated`'s `try_join!` was serialized by a lock and a
+/// client cancel could not reach a layer that had not started yet.
+type HostLifecycleLocks = DashMap<Url, Arc<tokio::sync::RwLock<()>>>;
 pub(crate) struct HostVirtualContents {
     // The open lifetime that owns this container. Reopen replaces the whole
     // container, so a stale publisher holding the old DashMap guard can only
@@ -2077,11 +2084,14 @@ impl LanguageServerPool {
             .insert(region_id.to_string(), Arc::<str>::from(content));
     }
 
-    pub(crate) fn host_lifecycle_lock(&self, host_uri: &Url) -> Arc<tokio::sync::Mutex<()>> {
+    /// The document's lifecycle lock, created on first use. Transitions lock it
+    /// exclusively (`write`); requests take [`Self::request_host_lifecycle`],
+    /// which locks it shared.
+    pub(crate) fn host_lifecycle_lock(&self, host_uri: &Url) -> Arc<tokio::sync::RwLock<()>> {
         Arc::clone(
             self.host_lifecycle_locks
                 .entry(host_uri.clone())
-                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                .or_insert_with(|| Arc::new(tokio::sync::RwLock::new(())))
                 .value(),
         )
     }
@@ -2095,7 +2105,7 @@ impl LanguageServerPool {
     pub(crate) fn existing_host_lifecycle_lock(
         &self,
         host_uri: &Url,
-    ) -> Option<Arc<tokio::sync::Mutex<()>>> {
+    ) -> Option<Arc<tokio::sync::RwLock<()>>> {
         self.host_lifecycle_locks
             .get(host_uri)
             .map(|entry| Arc::clone(entry.value()))
@@ -2104,7 +2114,7 @@ impl LanguageServerPool {
     pub(crate) fn remove_host_lifecycle_lock_if_unshared(
         &self,
         host_uri: &Url,
-        lifecycle: &Arc<tokio::sync::Mutex<()>>,
+        lifecycle: &Arc<tokio::sync::RwLock<()>>,
     ) {
         self.host_lifecycle_locks.remove_if(host_uri, |_, current| {
             Arc::ptr_eq(current, lifecycle)
@@ -2115,7 +2125,7 @@ impl LanguageServerPool {
 
     pub(crate) async fn open_host_incarnation(&self, host_uri: &Url, incarnation: u64) {
         let lifecycle = self.host_lifecycle_lock(host_uri);
-        let _guard = lifecycle.lock().await;
+        let _guard = lifecycle.write().await;
         self.latest_virtual_contents.insert(
             host_uri.clone(),
             HostVirtualContents {
@@ -2127,7 +2137,7 @@ impl LanguageServerPool {
 
     pub(crate) async fn close_host_incarnation(&self, host_uri: &Url, incarnation: u64) {
         let lifecycle = self.host_lifecycle_lock(host_uri);
-        let guard = lifecycle.lock().await;
+        let guard = lifecycle.write().await;
         // A delayed close from an older lifetime must not clear a fast reopen's
         // cache container.
         self.latest_virtual_contents

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -3818,21 +3818,55 @@ impl LanguageServerPool {
         let mut targets = Vec::new();
         if let Some(connection_counts) = registry.get(&upstream_id) {
             for connection_key in connection_counts.keys() {
-                let Some(producers) = handles
+                // Every drop below is best-effort per LSP, but it must still be
+                // countable: this is the only path production takes, so an
+                // invisible drop here is a cancel that vanishes with no trace.
+                let producers: Vec<Arc<ConnectionHandle>> = handles
                     .get(&upstream_id)
                     .and_then(|by_key| by_key.get(connection_key))
-                else {
+                    .map(|producers| producers.iter().filter_map(Weak::upgrade).collect())
+                    .unwrap_or_default();
+                if producers.is_empty() {
+                    // The producing process is gone (replaced connection, or a
+                    // handle dropped between registration and cancel).
+                    self.cancel_metrics.record_no_connection();
+                    log::debug!(
+                        target: "kakehashi::bridge::cancel",
+                        "Cancel dropped: no live producer for '{}' (upstream_id: {}, expected if the connection was replaced)",
+                        connection_key,
+                        upstream_id
+                    );
                     continue;
-                };
-                for handle in producers
-                    .iter()
-                    .filter_map(Weak::upgrade)
+                }
+                let ready: Vec<Arc<ConnectionHandle>> = producers
+                    .into_iter()
                     .filter(|handle| handle.state() == ConnectionState::Ready)
-                {
+                    .collect();
+                if ready.is_empty() {
+                    // Still handshaking or already failed - cancels cannot be
+                    // written to a connection that is not Ready.
+                    self.cancel_metrics.record_not_ready();
+                    log::debug!(
+                        target: "kakehashi::bridge::cancel",
+                        "Cancel dropped: no ready producer for '{}' (upstream_id: {})",
+                        connection_key,
+                        upstream_id
+                    );
+                    continue;
+                }
+                for handle in ready {
                     let (known, downstream_ids) =
                         handle.router().prepare_cancel_by_upstream(&upstream_id);
                     if !known {
+                        // Request already completed, or the id never reached
+                        // this router.
                         self.cancel_metrics.record_unknown_id();
+                        log::debug!(
+                            target: "kakehashi::bridge::cancel",
+                            "Cancel dropped: upstream ID {} not found for '{}' (request may have completed)",
+                            upstream_id,
+                            connection_key
+                        );
                         continue;
                     }
                     targets.push((connection_key.clone(), handle, downstream_ids));
@@ -3840,6 +3874,11 @@ impl LanguageServerPool {
             }
         } else {
             self.cancel_metrics.record_not_in_registry();
+            log::debug!(
+                target: "kakehashi::bridge::cancel",
+                "Cancel dropped: upstream ID {} not in registry (expected during init or after completion)",
+                upstream_id
+            );
         }
         drop(handles);
         drop(registry);

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -7410,7 +7410,7 @@ mod tests {
         // Forward cancel request
         let result = pool.forward_cancel_by_upstream_id_with_notify(upstream_id.clone(), || {});
 
-        // Shouldsucceed (the notification was sent)
+        // Should succeed (the notification was sent)
         assert!(
             result.is_ok(),
             "forward_cancel should succeed: {:?}",
@@ -7506,7 +7506,7 @@ mod tests {
 
         let result = pool.forward_cancel_by_upstream_id_with_notify(upstream_id, || {});
 
-        // Per bet-effort semantics, this should succeed (silent drop)
+        // Per best-effort semantics, this should succeed (silent drop)
         assert!(
             result.is_ok(),
             "forward_cancel should silently drop for nonexistent connection"
@@ -7533,7 +7533,7 @@ mod tests {
 
         let result = pool.forward_cancel_by_upstream_id_with_notify(upstream_id, || {});
 
-        // Per bet-effort semantics, this should succeed (silent drop)
+        // Per best-effort semantics, this should succeed (silent drop)
         assert!(
             result.is_ok(),
             "forward_cancel should silently drop for unknown upstream ID"
@@ -7695,7 +7695,7 @@ mod tests {
         // Forward cancel by upstream ID only (no language parameter)
         let result = pool.forward_cancel_by_upstream_id_with_notify(upstream_id.clone(), || {});
 
-        // Shouldsucceed because the registry has the mapping
+        // Should succeed because the registry has the mapping
         assert!(
             result.is_ok(),
             "forward_cancel_by_upstream_id should succeed: {:?}",
@@ -7711,7 +7711,7 @@ mod tests {
         // Don't register anything in the registry
         let result = pool.forward_cancel_by_upstream_id_with_notify(UpstreamId::Number(999), || {});
 
-        // Per bet-effort semantics, this should succeed (silent drop)
+        // Per best-effort semantics, this should succeed (silent drop)
         assert!(
             result.is_ok(),
             "forward_cancel_by_upstream_id should silently drop for unknown ID"
@@ -7879,7 +7879,7 @@ mod tests {
         // Forward cancel
         let _ = pool.forward_cancel_by_upstream_id_with_notify(upstream_id.clone(), || {});
 
-        // Check etrics
+        // Check metrics
         let (successful, no_conn, not_ready, unknown_id, not_in_reg) =
             pool.cancel_metrics().snapshot();
         assert_eq!(successful, 1, "Should record 1 successful cancel");

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -431,8 +431,8 @@ pub struct LanguageServerPool {
     /// fail gracefully and IDs get reused.
     upstream_request_registry: std::sync::Mutex<HashMap<UpstreamId, HashMap<ConnectionKey, usize>>>,
     /// Exact producer handles for synchronous cancel capture at middleware
-    /// ingress. Kept separate so key-only registry tests retain their compact
-    /// count model; production registrations always populate both maps.
+    /// ingress, keyed alongside `upstream_request_registry` and written by the
+    /// same registration call so the two maps cannot drift.
     upstream_cancel_handles: std::sync::Mutex<UpstreamCancelHandles>,
     /// Metrics for cancel forwarding observability.
     cancel_metrics: CancelForwardingMetrics,
@@ -3668,11 +3668,13 @@ impl LanguageServerPool {
         }
     }
 
-    /// Test-only compatibility wrapper that fans out `$/cancelRequest` to
-    /// every server registered for `upstream_id`, invoking `notify` after every
+    /// Test-only convenience wrapper that fans out `$/cancelRequest` to every
+    /// server registered for `upstream_id`, invoking `notify` after every
     /// `(connection, downstream ids)` target has been captured and before any
-    /// cancel is sent. Production `RequestIdCapture` uses the generation-aware
-    /// [`Self::forward_cancel_by_upstream_id_if_current`] path instead.
+    /// cancel is sent. It delegates to the production
+    /// [`Self::forward_cancel_by_upstream_id_if_current_sync`] path with a
+    /// generation check that always passes, so these tests exercise the same
+    /// code the middleware runs.
     ///
     /// LSP cancel is best-effort, so we silently return `Ok(())` (rather than
     /// erroring) when: the ID is unknown, the connection is still initializing,
@@ -3688,116 +3690,38 @@ impl LanguageServerPool {
     /// only already-writing/sent IDs that still need a FIFO cancel notification;
     /// the later cleanup is then harmless.
     #[cfg(test)]
-    pub(crate) async fn forward_cancel_by_upstream_id_with_notify(
+    pub(crate) fn forward_cancel_by_upstream_id_with_notify(
         &self,
         upstream_id: UpstreamId,
         notify: impl FnOnce(),
     ) -> io::Result<()> {
-        self.forward_cancel_by_upstream_id_if_current(upstream_id, || true, notify)
-            .await
+        self.forward_cancel_by_upstream_id_if_current_sync(upstream_id, || true, notify)
     }
 
-    /// Generation-aware cancellation used by the upstream middleware. The
-    /// validity check runs while the upstream registry is locked, so request-ID
-    /// reuse cannot replace the old request's downstream mappings between the
-    /// check and target capture.
-    #[cfg(test)]
-    pub(crate) async fn forward_cancel_by_upstream_id_if_current(
-        &self,
-        upstream_id: UpstreamId,
-        is_current: impl FnOnce() -> bool,
-        notify: impl FnOnce(),
-    ) -> io::Result<()> {
-        // Acquire the async connections lock first, then keep the synchronous
-        // upstream registry locked from generation validation through router
-        // target capture. Registration/unregistration uses that registry lock,
-        // so an ID cannot change request lifetime in the middle of this block.
-        let connections = self.connections().await;
-        let mut targets: Vec<(ConnectionKey, Arc<ConnectionHandle>, Vec<RequestId>)> = Vec::new();
-        let registered = {
-            let registry = self
-                .upstream_request_registry
-                .lock()
-                .recover_poison("LanguageServerPool::forward_cancel_by_upstream_id_if_current");
-            if !is_current() {
-                return Ok(());
-            }
-            if let Some(connection_counts) = registry.get(&upstream_id) {
-                for connection_key in connection_counts.keys() {
-                    let Some(handle) = self.ready_handle_for_cancel_in(
-                        &connections,
-                        connection_key,
-                        &format!("upstream_id: {upstream_id}"),
-                    ) else {
-                        continue;
-                    };
-                    let (known, downstream_ids) =
-                        handle.router().prepare_cancel_by_upstream(&upstream_id);
-                    if !known {
-                        // Request already completed or ID never registered.
-                        // Silently drop per best-effort semantics.
-                        self.cancel_metrics.record_unknown_id();
-                        log::debug!(
-                            target: "kakehashi::bridge::cancel",
-                            "Cancel dropped: upstream ID {} not found for '{}' (request may have completed)",
-                            upstream_id,
-                            connection_key
-                        );
-                        continue;
-                    }
-                    if !downstream_ids.is_empty() {
-                        targets.push((connection_key.clone(), handle, downstream_ids));
-                    }
-                }
-                true
-            } else {
-                false
-            }
-        };
-        drop(connections);
-
-        if !registered {
-            // Request not registered yet (still initializing) or already completed.
-            // This is expected - silently drop the downstream cancel, but still
-            // notify the active local handler.
-            self.cancel_metrics.record_not_in_registry();
-            log::debug!(
-                target: "kakehashi::bridge::cancel",
-                "Cancel dropped: upstream ID {} not in registry (expected during init or after completion)",
-                upstream_id
-            );
-            notify();
-            return Ok(());
-        }
-
-        // Wake the upstream handler only now that targets are captured.
-        notify();
-
-        // 4. Send the cancels (best-effort, log I/O errors).
-        for (connection_key, handle, downstream_ids) in targets {
-            for downstream_id in downstream_ids {
-                if let Err(e) =
-                    self.send_cancel_notification(&handle, &connection_key, downstream_id)
-                {
-                    // Log I/O errors (queue full, channel closed) for observability.
-                    // These indicate connection issues worth investigating.
-                    log::warn!(
-                        target: "kakehashi::bridge::cancel",
-                        "Error forwarding cancel for upstream_id {}: {}",
-                        upstream_id,
-                        e
-                    );
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Synchronous production path used from `RequestIdCapture::call` before
-    /// tower-lsp can process the raw-ID cancellation. Production request
-    /// registration retains a weak reference to each exact producer handle, so
-    /// target capture does not need the async connections mutex.
+    /// Generation-aware cancellation used by the upstream middleware, called
+    /// synchronously from `RequestIdCapture::call` before tower-lsp can process
+    /// the raw-ID cancellation. Request registration retains a weak reference to
+    /// each exact producer handle, so target capture does not need the async
+    /// connections mutex.
+    ///
+    /// The validity check runs while the upstream registry is locked, so
+    /// request-ID reuse cannot replace the old request's downstream mappings
+    /// between the check and target capture.
+    ///
+    /// LSP cancel is best-effort, so we silently return `Ok(())` (rather than
+    /// erroring) when: the ID is unknown, the connection is still initializing,
+    /// the downstream ID was already cleaned up, or an individual server send
+    /// fails. This avoids racing cancel against handshake completion. Every such
+    /// drop still records a `CancelForwardingMetrics` counter and a debug log.
+    ///
+    /// Prepare-before-notify ordering is load-bearing: `notify` wakes the
+    /// upstream handler (via `CancelForwarder::notify_cancel`), whose
+    /// cancellation path immediately destroys the very state this lookup reads —
+    /// `unregister_all_for_upstream_id` empties the registry, and dropping the
+    /// in-flight request futures removes their router cancel mappings. Preparing
+    /// first atomically marks queued work for writer-side skipping and captures
+    /// only already-writing/sent IDs that still need a FIFO cancel notification;
+    /// the later cleanup is then harmless.
     pub(crate) fn forward_cancel_by_upstream_id_if_current_sync(
         &self,
         upstream_id: UpstreamId,
@@ -3959,25 +3883,9 @@ impl LanguageServerPool {
     /// Callers MUST call `unregister_upstream_request` per request on completion
     /// (success, error, or timeout) — typically after `wait_for_response()` or
     /// in `ensure_document_opened()` error cleanup — to avoid leaking entries.
-    #[cfg(test)]
-    pub(crate) fn register_upstream_request(
-        &self,
-        upstream_id: UpstreamId,
-        connection_key: &ConnectionKey,
-    ) {
-        let mut registry = self
-            .upstream_request_registry
-            .lock()
-            .recover_poison("LanguageServerPool::register_upstream_request");
-        *registry
-            .entry(upstream_id)
-            .or_default()
-            .entry(connection_key.clone())
-            .or_insert(0) += 1;
-    }
-
-    /// Production registration retaining the exact connection handle so
-    /// cancellation targets can be captured synchronously before tower-lsp's
+    ///
+    /// The exact producing handle is retained (weakly) alongside the count so
+    /// cancellation targets can be captured synchronously, before tower-lsp's
     /// raw-ID cancel handler runs.
     pub(crate) fn register_upstream_request_for_handle(
         &self,
@@ -7497,14 +7405,12 @@ mod tests {
             .lock()
             .await
             .insert(ConnectionKey::for_server("lua"), Arc::clone(&handle));
-        pool.register_upstream_request(upstream_id.clone(), &ConnectionKey::for_server("lua"));
+        pool.register_upstream_request_for_handle(upstream_id.clone(), &handle);
 
         // Forward cancel request
-        let result = pool
-            .forward_cancel_by_upstream_id_with_notify(upstream_id.clone(), || {})
-            .await;
+        let result = pool.forward_cancel_by_upstream_id_with_notify(upstream_id.clone(), || {});
 
-        // Should succeed (the notification was sent)
+        // Shouldsucceed (the notification was sent)
         assert!(
             result.is_ok(),
             "forward_cancel should succeed: {:?}",
@@ -7591,16 +7497,16 @@ mod tests {
     async fn forward_cancel_silently_drops_when_no_connection() {
         let pool = LanguageServerPool::new();
         let upstream_id = UpstreamId::Number(42);
-        pool.register_upstream_request(
-            upstream_id.clone(),
-            &ConnectionKey::for_server("nonexistent"),
-        );
+        {
+            let gone =
+                create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("gone"))
+                    .await;
+            pool.register_upstream_request_for_handle(upstream_id.clone(), &gone);
+        }
 
-        let result = pool
-            .forward_cancel_by_upstream_id_with_notify(upstream_id, || {})
-            .await;
+        let result = pool.forward_cancel_by_upstream_id_with_notify(upstream_id, || {});
 
-        // Per best-effort semantics, this should succeed (silent drop)
+        // Per bet-effort semantics, this should succeed (silent drop)
         assert!(
             result.is_ok(),
             "forward_cancel should silently drop for nonexistent connection"
@@ -7623,13 +7529,11 @@ mod tests {
             .await
             .insert(ConnectionKey::for_server("lua"), Arc::clone(&handle));
         let upstream_id = UpstreamId::Number(999);
-        pool.register_upstream_request(upstream_id.clone(), &ConnectionKey::for_server("lua"));
+        pool.register_upstream_request_for_handle(upstream_id.clone(), &handle);
 
-        let result = pool
-            .forward_cancel_by_upstream_id_with_notify(upstream_id, || {})
-            .await;
+        let result = pool.forward_cancel_by_upstream_id_with_notify(upstream_id, || {});
 
-        // Per best-effort semantics, this should succeed (silent drop)
+        // Per bet-effort semantics, this should succeed (silent drop)
         assert!(
             result.is_ok(),
             "forward_cancel should silently drop for unknown upstream ID"
@@ -7640,12 +7544,14 @@ mod tests {
     // Upstream Request Registry Tests
     // ============================================================
 
-    /// Test that register_upstream_request stores the mapping.
-    #[test]
-    fn register_upstream_request_stores_mapping() {
+    /// Test that registering an upstream request stores the mapping.
+    #[tokio::test]
+    async fn register_upstream_request_stores_mapping() {
         let pool = LanguageServerPool::new();
+        let handle =
+            create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("lua")).await;
 
-        pool.register_upstream_request(UpstreamId::Number(42), &ConnectionKey::for_server("lua"));
+        pool.register_upstream_request_for_handle(UpstreamId::Number(42), &handle);
 
         let registry = pool.upstream_request_registry.lock().unwrap();
         let servers = registry
@@ -7656,11 +7562,13 @@ mod tests {
     }
 
     /// Test that unregister_upstream_request removes the mapping.
-    #[test]
-    fn unregister_upstream_request_removes_mapping() {
+    #[tokio::test]
+    async fn unregister_upstream_request_removes_mapping() {
         let pool = LanguageServerPool::new();
+        let handle =
+            create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("lua")).await;
 
-        pool.register_upstream_request(UpstreamId::Number(42), &ConnectionKey::for_server("lua"));
+        pool.register_upstream_request_for_handle(UpstreamId::Number(42), &handle);
         pool.unregister_upstream_request(
             &UpstreamId::Number(42),
             &ConnectionKey::for_server("lua"),
@@ -7694,17 +7602,16 @@ mod tests {
             .lock()
             .await
             .insert(ConnectionKey::for_server("lua"), Arc::clone(&handle));
-        pool.register_upstream_request(upstream_id.clone(), &ConnectionKey::for_server("lua"));
+        pool.register_upstream_request_for_handle(upstream_id.clone(), &handle);
 
         // Simulate the handler waking on the cancel notification and running
         // its cleanup before the forwarding pass sends anything.
         let cleanup_pool = Arc::clone(&pool);
         let cleanup_id = upstream_id.clone();
-        let result = pool
-            .forward_cancel_by_upstream_id_with_notify(upstream_id.clone(), move || {
+        let result =
+            pool.forward_cancel_by_upstream_id_with_notify(upstream_id.clone(), move || {
                 cleanup_pool.unregister_all_for_upstream_id(Some(&cleanup_id));
-            })
-            .await;
+            });
 
         assert!(
             result.is_ok(),
@@ -7730,12 +7637,14 @@ mod tests {
     /// region must not unregister the server while a sibling request is still
     /// in flight, or `forward_cancel_by_upstream_id` would skip that server
     /// and the sibling's cancel would never reach it.
-    #[test]
-    fn unregister_upstream_request_keeps_server_while_sibling_requests_in_flight() {
+    #[tokio::test]
+    async fn unregister_upstream_request_keeps_server_while_sibling_requests_in_flight() {
         let pool = LanguageServerPool::new();
+        let handle =
+            create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("lua")).await;
 
-        pool.register_upstream_request(UpstreamId::Number(42), &ConnectionKey::for_server("lua"));
-        pool.register_upstream_request(UpstreamId::Number(42), &ConnectionKey::for_server("lua"));
+        pool.register_upstream_request_for_handle(UpstreamId::Number(42), &handle);
+        pool.register_upstream_request_for_handle(UpstreamId::Number(42), &handle);
 
         pool.unregister_upstream_request(
             &UpstreamId::Number(42),
@@ -7781,14 +7690,12 @@ mod tests {
             .insert(ConnectionKey::for_server("lua"), Arc::clone(&handle));
 
         // Register the upstream request in the registry
-        pool.register_upstream_request(upstream_id.clone(), &ConnectionKey::for_server("lua"));
+        pool.register_upstream_request_for_handle(upstream_id.clone(), &handle);
 
         // Forward cancel by upstream ID only (no language parameter)
-        let result = pool
-            .forward_cancel_by_upstream_id_with_notify(upstream_id.clone(), || {})
-            .await;
+        let result = pool.forward_cancel_by_upstream_id_with_notify(upstream_id.clone(), || {});
 
-        // Should succeed because the registry has the mapping
+        // Shouldsucceed because the registry has the mapping
         assert!(
             result.is_ok(),
             "forward_cancel_by_upstream_id should succeed: {:?}",
@@ -7802,11 +7709,9 @@ mod tests {
         let pool = LanguageServerPool::new();
 
         // Don't register anything in the registry
-        let result = pool
-            .forward_cancel_by_upstream_id_with_notify(UpstreamId::Number(999), || {})
-            .await;
+        let result = pool.forward_cancel_by_upstream_id_with_notify(UpstreamId::Number(999), || {});
 
-        // Per best-effort semantics, this should succeed (silent drop)
+        // Per bet-effort semantics, this should succeed (silent drop)
         assert!(
             result.is_ok(),
             "forward_cancel_by_upstream_id should silently drop for unknown ID"
@@ -7837,12 +7742,11 @@ mod tests {
             .lock()
             .await
             .insert(ConnectionKey::for_server("lua"), Arc::clone(&handle));
-        pool.register_upstream_request(upstream_id.clone(), &ConnectionKey::for_server("lua"));
+        pool.register_upstream_request_for_handle(upstream_id.clone(), &handle);
 
         // Forward cancel request (simulating client cancelling the request)
-        let cancel_result = pool
-            .forward_cancel_by_upstream_id_with_notify(upstream_id.clone(), || {})
-            .await;
+        let cancel_result =
+            pool.forward_cancel_by_upstream_id_with_notify(upstream_id.clone(), || {});
         assert!(cancel_result.is_ok(), "cancel should succeed");
 
         // Now simulate the downstream server responding (with a normal result)
@@ -7913,12 +7817,11 @@ mod tests {
             .lock()
             .await
             .insert(ConnectionKey::for_server("lua"), Arc::clone(&handle));
-        pool.register_upstream_request(upstream_id.clone(), &ConnectionKey::for_server("lua"));
+        pool.register_upstream_request_for_handle(upstream_id.clone(), &handle);
 
         // Forward cancel request
-        let cancel_result = pool
-            .forward_cancel_by_upstream_id_with_notify(upstream_id.clone(), || {})
-            .await;
+        let cancel_result =
+            pool.forward_cancel_by_upstream_id_with_notify(upstream_id.clone(), || {});
         assert!(cancel_result.is_ok(), "cancel should succeed");
 
         // Simulate the downstream server responding with RequestCancelled error
@@ -7971,14 +7874,12 @@ mod tests {
             .lock()
             .await
             .insert(ConnectionKey::for_server("lua"), Arc::clone(&handle));
-        pool.register_upstream_request(upstream_id.clone(), &ConnectionKey::for_server("lua"));
+        pool.register_upstream_request_for_handle(upstream_id.clone(), &handle);
 
         // Forward cancel
-        let _ = pool
-            .forward_cancel_by_upstream_id_with_notify(upstream_id.clone(), || {})
-            .await;
+        let _ = pool.forward_cancel_by_upstream_id_with_notify(upstream_id.clone(), || {});
 
-        // Check metrics
+        // Check etrics
         let (successful, no_conn, not_ready, unknown_id, not_in_reg) =
             pool.cancel_metrics().snapshot();
         assert_eq!(successful, 1, "Should record 1 successful cancel");
@@ -7986,73 +7887,6 @@ mod tests {
         assert_eq!(not_ready, 0);
         assert_eq!(unknown_id, 0);
         assert_eq!(not_in_reg, 0);
-    }
-
-    /// Test that metrics are recorded for cancel failures.
-    #[tokio::test]
-    async fn cancel_metrics_records_failures() {
-        use std::sync::Arc;
-
-        let pool = LanguageServerPool::new();
-
-        // Test: no connection
-        pool.register_upstream_request(
-            UpstreamId::Number(1),
-            &ConnectionKey::for_server("nonexistent"),
-        );
-        let _ = pool
-            .forward_cancel_by_upstream_id_with_notify(UpstreamId::Number(1), || {})
-            .await;
-
-        // Test: not in registry
-        let _ = pool
-            .forward_cancel_by_upstream_id_with_notify(UpstreamId::Number(999), || {})
-            .await;
-
-        // Test: connection not ready
-        let handle_init = create_handle_with_key(
-            ConnectionState::Initializing,
-            ConnectionKey::for_server("init_lang"),
-        )
-        .await;
-        pool.connections.lock().await.insert(
-            ConnectionKey::for_server("init_lang"),
-            Arc::clone(&handle_init),
-        );
-        pool.register_upstream_request(
-            UpstreamId::Number(2),
-            &ConnectionKey::for_server("init_lang"),
-        );
-        let _ = pool
-            .forward_cancel_by_upstream_id_with_notify(UpstreamId::Number(2), || {})
-            .await;
-
-        // Test: unknown upstream ID
-        let handle_ready = create_handle_with_key(
-            ConnectionState::Ready,
-            ConnectionKey::for_server("ready_lang"),
-        )
-        .await;
-        pool.connections.lock().await.insert(
-            ConnectionKey::for_server("ready_lang"),
-            Arc::clone(&handle_ready),
-        );
-        pool.register_upstream_request(
-            UpstreamId::Number(3),
-            &ConnectionKey::for_server("ready_lang"),
-        );
-        let _ = pool
-            .forward_cancel_by_upstream_id_with_notify(UpstreamId::Number(3), || {})
-            .await;
-
-        // Check metrics
-        let (successful, no_conn, not_ready, unknown_id, not_in_reg) =
-            pool.cancel_metrics().snapshot();
-        assert_eq!(successful, 0, "No successful cancels");
-        assert_eq!(no_conn, 1, "1 no_connection failure");
-        assert_eq!(not_ready, 1, "1 not_ready failure");
-        assert_eq!(unknown_id, 1, "1 unknown_id failure");
-        assert_eq!(not_in_reg, 1, "1 not_in_registry failure");
     }
 
     /// The synchronous middleware path is the only one production takes, so
@@ -8566,14 +8400,26 @@ mod tests {
     // Multi-Server Cancel Forwarding Tests
     // ============================================================
 
+    /// Two Ready producers on distinct pool keys, for the fan-out registry
+    /// tests that register one upstream id against both.
+    async fn two_ready_handles() -> (Arc<ConnectionHandle>, Arc<ConnectionHandle>) {
+        (
+            create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("lua-ls"))
+                .await,
+            create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("pyright"))
+                .await,
+        )
+    }
+
     /// Test that registering multiple servers for the same upstream ID creates a set.
-    #[test]
-    fn register_upstream_request_multiple_servers_creates_set() {
+    #[tokio::test]
+    async fn register_upstream_request_multiple_servers_creates_set() {
         let pool = LanguageServerPool::new();
         let upstream_id = UpstreamId::Number(42);
+        let (lua, pyright) = two_ready_handles().await;
 
-        pool.register_upstream_request(upstream_id.clone(), &ConnectionKey::for_server("lua-ls"));
-        pool.register_upstream_request(upstream_id.clone(), &ConnectionKey::for_server("pyright"));
+        pool.register_upstream_request_for_handle(upstream_id.clone(), &lua);
+        pool.register_upstream_request_for_handle(upstream_id.clone(), &pyright);
 
         let registry = pool.upstream_request_registry.lock().unwrap();
         let servers = registry.get(&upstream_id).expect("should have entry");
@@ -8584,13 +8430,14 @@ mod tests {
     }
 
     /// Test that unregistering removes only the specified server from the set.
-    #[test]
-    fn unregister_upstream_request_removes_single_server() {
+    #[tokio::test]
+    async fn unregister_upstream_request_removes_single_server() {
         let pool = LanguageServerPool::new();
         let upstream_id = UpstreamId::Number(42);
+        let (lua, pyright) = two_ready_handles().await;
 
-        pool.register_upstream_request(upstream_id.clone(), &ConnectionKey::for_server("lua-ls"));
-        pool.register_upstream_request(upstream_id.clone(), &ConnectionKey::for_server("pyright"));
+        pool.register_upstream_request_for_handle(upstream_id.clone(), &lua);
+        pool.register_upstream_request_for_handle(upstream_id.clone(), &pyright);
         pool.unregister_upstream_request(&upstream_id, &ConnectionKey::for_server("lua-ls"));
 
         let registry = pool.upstream_request_registry.lock().unwrap();
@@ -8602,12 +8449,15 @@ mod tests {
     }
 
     /// Test that unregistering the last server cleans up the entire entry.
-    #[test]
-    fn unregister_upstream_request_cleans_up_empty_set() {
+    #[tokio::test]
+    async fn unregister_upstream_request_cleans_up_empty_set() {
         let pool = LanguageServerPool::new();
         let upstream_id = UpstreamId::Number(42);
+        let lua =
+            create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("lua-ls"))
+                .await;
 
-        pool.register_upstream_request(upstream_id.clone(), &ConnectionKey::for_server("lua-ls"));
+        pool.register_upstream_request_for_handle(upstream_id.clone(), &lua);
         pool.unregister_upstream_request(&upstream_id, &ConnectionKey::for_server("lua-ls"));
 
         let registry = pool.upstream_request_registry.lock().unwrap();
@@ -8652,13 +8502,11 @@ mod tests {
         }
 
         // Register both servers for the same upstream ID
-        pool.register_upstream_request(upstream_id.clone(), &ConnectionKey::for_server("lua-ls"));
-        pool.register_upstream_request(upstream_id.clone(), &ConnectionKey::for_server("pyright"));
+        pool.register_upstream_request_for_handle(upstream_id.clone(), &handle_lua);
+        pool.register_upstream_request_for_handle(upstream_id.clone(), &handle_py);
 
         // Forward cancel - should succeed for both servers
-        let result = pool
-            .forward_cancel_by_upstream_id_with_notify(upstream_id.clone(), || {})
-            .await;
+        let result = pool.forward_cancel_by_upstream_id_with_notify(upstream_id.clone(), || {});
         assert!(result.is_ok());
 
         // Verify metrics show 2 successful cancels
@@ -8670,13 +8518,14 @@ mod tests {
     }
 
     /// Test that unregister_all_for_upstream_id removes the entire entry at once.
-    #[test]
-    fn unregister_all_for_upstream_id_removes_entire_entry() {
+    #[tokio::test]
+    async fn unregister_all_for_upstream_id_removes_entire_entry() {
         let pool = LanguageServerPool::new();
         let upstream_id = UpstreamId::Number(42);
+        let (lua, pyright) = two_ready_handles().await;
 
-        pool.register_upstream_request(upstream_id.clone(), &ConnectionKey::for_server("lua-ls"));
-        pool.register_upstream_request(upstream_id.clone(), &ConnectionKey::for_server("pyright"));
+        pool.register_upstream_request_for_handle(upstream_id.clone(), &lua);
+        pool.register_upstream_request_for_handle(upstream_id.clone(), &pyright);
         pool.unregister_all_for_upstream_id(Some(&upstream_id));
 
         let registry = pool.upstream_request_registry.lock().unwrap();

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -8016,6 +8016,75 @@ mod tests {
         assert_eq!(not_in_reg, 1, "1 not_in_registry failure");
     }
 
+    /// The synchronous middleware path is the only one production takes, so
+    /// every way it drops a cancel must stay as observable as the async
+    /// path's: a producer whose process is gone, a producer that is not yet
+    /// ready, an id the producer never routed, and an id absent from the
+    /// registry each have their own counter.
+    #[tokio::test]
+    async fn sync_cancel_records_metrics_for_every_dropped_producer() {
+        let pool = LanguageServerPool::new();
+
+        // No live producer: the registration outlives the handle it named.
+        {
+            let gone = create_handle_with_key(
+                ConnectionState::Ready,
+                ConnectionKey::for_server("gone_lang"),
+            )
+            .await;
+            pool.register_upstream_request_for_handle(UpstreamId::Number(1), &gone);
+        }
+        let _ = pool.forward_cancel_by_upstream_id_if_current_sync(
+            UpstreamId::Number(1),
+            || true,
+            || {},
+        );
+
+        // Not in registry.
+        let _ = pool.forward_cancel_by_upstream_id_if_current_sync(
+            UpstreamId::Number(999),
+            || true,
+            || {},
+        );
+
+        // Producer still initializing.
+        let handle_init = create_handle_with_key(
+            ConnectionState::Initializing,
+            ConnectionKey::for_server("init_lang"),
+        )
+        .await;
+        pool.register_upstream_request_for_handle(UpstreamId::Number(2), &handle_init);
+        let _ = pool.forward_cancel_by_upstream_id_if_current_sync(
+            UpstreamId::Number(2),
+            || true,
+            || {},
+        );
+
+        // Ready producer that never routed this upstream id.
+        let handle_ready = create_handle_with_key(
+            ConnectionState::Ready,
+            ConnectionKey::for_server("ready_lang"),
+        )
+        .await;
+        pool.register_upstream_request_for_handle(UpstreamId::Number(3), &handle_ready);
+        let _ = pool.forward_cancel_by_upstream_id_if_current_sync(
+            UpstreamId::Number(3),
+            || true,
+            || {},
+        );
+
+        let (successful, no_conn, not_ready, unknown_id, not_in_reg) =
+            pool.cancel_metrics().snapshot();
+        assert_eq!(successful, 0, "no cancel reached a downstream");
+        assert_eq!(no_conn, 1, "the dropped producer must be counted");
+        assert_eq!(not_ready, 1, "the initializing producer must be counted");
+        assert_eq!(unknown_id, 1, "the unrouted upstream id must be counted");
+        assert_eq!(
+            not_in_reg, 1,
+            "the unregistered upstream id must be counted"
+        );
+    }
+
     // ========================================
     // Process-sharing didClose tests
     // ========================================

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -135,7 +135,7 @@ fn shutdown_invalidated_connection(key: ConnectionKey, handle: Arc<ConnectionHan
 use std::collections::HashMap;
 use std::io;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, OnceLock, Weak};
 use std::time::Duration;
 
 use dashmap::DashMap;
@@ -200,6 +200,9 @@ impl From<&str> for UpstreamId {
         UpstreamId::String(s.to_string())
     }
 }
+
+type UpstreamCancelHandles =
+    HashMap<UpstreamId, HashMap<ConnectionKey, Vec<Weak<ConnectionHandle>>>>;
 
 /// Metrics for cancel request forwarding.
 ///
@@ -427,6 +430,10 @@ pub struct LanguageServerPool {
     /// entries dangling to avoid a router→pool back-reference — stale lookups
     /// fail gracefully and IDs get reused.
     upstream_request_registry: std::sync::Mutex<HashMap<UpstreamId, HashMap<ConnectionKey, usize>>>,
+    /// Exact producer handles for synchronous cancel capture at middleware
+    /// ingress. Kept separate so key-only registry tests retain their compact
+    /// count model; production registrations always populate both maps.
+    upstream_cancel_handles: std::sync::Mutex<UpstreamCancelHandles>,
     /// Metrics for cancel forwarding observability.
     cancel_metrics: CancelForwardingMetrics,
     /// Consecutive handshake-task panics per connection (reset to 0 on success).
@@ -545,6 +552,7 @@ impl LanguageServerPool {
             diagnostic_host_epoch: AtomicU64::new(1),
             diagnostic_host_generations: DashMap::new(),
             upstream_request_registry: std::sync::Mutex::new(HashMap::new()),
+            upstream_cancel_handles: std::sync::Mutex::new(HashMap::new()),
             cancel_metrics: CancelForwardingMetrics::default(),
             consecutive_panic_counts: std::sync::Mutex::new(HashMap::new()),
             root_uri: arc_swap::ArcSwap::new(Arc::new(None)),
@@ -3693,6 +3701,7 @@ impl LanguageServerPool {
     /// validity check runs while the upstream registry is locked, so request-ID
     /// reuse cannot replace the old request's downstream mappings between the
     /// check and target capture.
+    #[cfg(test)]
     pub(crate) async fn forward_cancel_by_upstream_id_if_current(
         &self,
         upstream_id: UpstreamId,
@@ -3785,6 +3794,74 @@ impl LanguageServerPool {
         Ok(())
     }
 
+    /// Synchronous production path used from `RequestIdCapture::call` before
+    /// tower-lsp can process the raw-ID cancellation. Production request
+    /// registration retains a weak reference to each exact producer handle, so
+    /// target capture does not need the async connections mutex.
+    pub(crate) fn forward_cancel_by_upstream_id_if_current_sync(
+        &self,
+        upstream_id: UpstreamId,
+        is_current: impl FnOnce() -> bool,
+        notify: impl FnOnce(),
+    ) -> io::Result<()> {
+        let registry = self
+            .upstream_request_registry
+            .lock()
+            .recover_poison("LanguageServerPool::forward_cancel_by_upstream_id_if_current_sync");
+        if !is_current() {
+            return Ok(());
+        }
+        let handles = self
+            .upstream_cancel_handles
+            .lock()
+            .recover_poison("LanguageServerPool::forward_cancel_by_upstream_id_if_current_sync");
+        let mut targets = Vec::new();
+        if let Some(connection_counts) = registry.get(&upstream_id) {
+            for connection_key in connection_counts.keys() {
+                let Some(producers) = handles
+                    .get(&upstream_id)
+                    .and_then(|by_key| by_key.get(connection_key))
+                else {
+                    continue;
+                };
+                for handle in producers
+                    .iter()
+                    .filter_map(Weak::upgrade)
+                    .filter(|handle| handle.state() == ConnectionState::Ready)
+                {
+                    let (known, downstream_ids) =
+                        handle.router().prepare_cancel_by_upstream(&upstream_id);
+                    if !known {
+                        self.cancel_metrics.record_unknown_id();
+                        continue;
+                    }
+                    targets.push((connection_key.clone(), handle, downstream_ids));
+                }
+            }
+        } else {
+            self.cancel_metrics.record_not_in_registry();
+        }
+        drop(handles);
+        drop(registry);
+
+        notify();
+        for (connection_key, handle, downstream_ids) in targets {
+            for downstream_id in downstream_ids {
+                if let Err(error) =
+                    self.send_cancel_notification(&handle, &connection_key, downstream_id)
+                {
+                    log::warn!(
+                        target: "kakehashi::bridge::cancel",
+                        "Error forwarding cancel for upstream_id {}: {}",
+                        upstream_id,
+                        error
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Forward a client `window/workDoneProgress/cancel` to the downstream that
     /// owns the (bridge-minted) `upstream_token`, rewriting it back to that
     /// downstream's original token. Best-effort, mirroring `$/cancelRequest`:
@@ -3843,6 +3920,7 @@ impl LanguageServerPool {
     /// Callers MUST call `unregister_upstream_request` per request on completion
     /// (success, error, or timeout) — typically after `wait_for_response()` or
     /// in `ensure_document_opened()` error cleanup — to avoid leaking entries.
+    #[cfg(test)]
     pub(crate) fn register_upstream_request(
         &self,
         upstream_id: UpstreamId,
@@ -3859,6 +3937,43 @@ impl LanguageServerPool {
             .or_insert(0) += 1;
     }
 
+    /// Production registration retaining the exact connection handle so
+    /// cancellation targets can be captured synchronously before tower-lsp's
+    /// raw-ID cancel handler runs.
+    pub(crate) fn register_upstream_request_for_handle(
+        &self,
+        upstream_id: UpstreamId,
+        handle: &Arc<ConnectionHandle>,
+    ) {
+        let connection_key = handle.key();
+        let mut registry = self
+            .upstream_request_registry
+            .lock()
+            .recover_poison("LanguageServerPool::register_upstream_request_for_handle");
+        let mut handles = self
+            .upstream_cancel_handles
+            .lock()
+            .recover_poison("LanguageServerPool::register_upstream_request_for_handle");
+        *registry
+            .entry(upstream_id.clone())
+            .or_default()
+            .entry(connection_key.clone())
+            .or_insert(0) += 1;
+        let producers = handles
+            .entry(upstream_id)
+            .or_default()
+            .entry(connection_key.clone())
+            .or_default();
+        producers.retain(|producer| producer.strong_count() > 0);
+        if !producers
+            .iter()
+            .filter_map(Weak::upgrade)
+            .any(|producer| Arc::ptr_eq(&producer, handle))
+        {
+            producers.push(Arc::downgrade(handle));
+        }
+    }
+
     /// Unregister one in-flight request for `(upstream_id, connection_key)`.
     /// The connection is removed once its count reaches zero; the upstream entry
     /// is fully removed once all connections have been unregistered.
@@ -3872,14 +3987,28 @@ impl LanguageServerPool {
             .lock()
             .recover_poison("LanguageServerPool::unregister_upstream_request");
         if let Some(connections) = registry.get_mut(upstream_id) {
+            let mut remove_handle = false;
             if let Some(count) = connections.get_mut(connection_key) {
                 *count = count.saturating_sub(1);
                 if *count == 0 {
                     connections.remove(connection_key);
+                    remove_handle = true;
                 }
             }
             if connections.is_empty() {
                 registry.remove(upstream_id);
+            }
+            if remove_handle {
+                let mut handles = self
+                    .upstream_cancel_handles
+                    .lock()
+                    .recover_poison("LanguageServerPool::unregister_upstream_request");
+                if let Some(by_key) = handles.get_mut(upstream_id) {
+                    by_key.remove(connection_key);
+                    if by_key.is_empty() {
+                        handles.remove(upstream_id);
+                    }
+                }
             }
         }
     }
@@ -3897,6 +4026,10 @@ impl LanguageServerPool {
             .lock()
             .recover_poison("LanguageServerPool::unregister_all_for_upstream_id");
         registry.remove(upstream_id);
+        self.upstream_cancel_handles
+            .lock()
+            .recover_poison("LanguageServerPool::unregister_all_for_upstream_id")
+            .remove(upstream_id);
     }
 }
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -7899,6 +7899,10 @@ mod tests {
         let pool = LanguageServerPool::new();
 
         // No live producer: the registration outlives the handle it named.
+        // The scope is load-bearing — the registry keeps only a `Weak`, so
+        // dropping the last `Arc` here is what makes the upgrade fail. If a
+        // future helper retains the handle, this case silently becomes
+        // `not_ready` or `unknown_id` instead.
         {
             let gone = create_handle_with_key(
                 ConnectionState::Ready,

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -698,6 +698,7 @@ impl ConnectionHandle {
         let dynamic_resolve_parent = match method {
             "completionItem/resolve" => Some("textDocument/completion"),
             "codeLens/resolve" => Some("textDocument/codeLens"),
+            "documentLink/resolve" => Some("textDocument/documentLink"),
             _ => None,
         };
         if let Some(parent) = dynamic_resolve_parent
@@ -820,6 +821,11 @@ impl ConnectionHandle {
                 .and_then(|opts| opts.resolve_provider)
                 .unwrap_or(false),
             "textDocument/documentLink" => caps.document_link_provider.is_some(),
+            "documentLink/resolve" => caps
+                .document_link_provider
+                .as_ref()
+                .and_then(|opts| opts.resolve_provider)
+                .unwrap_or(false),
             "textDocument/foldingRange" => matches!(
                 caps.folding_range_provider,
                 Some(
@@ -2921,5 +2927,51 @@ mod tests {
 
         assert!(!handle.has_capability("codeLens/resolve"));
         assert!(handle.has_capability("textDocument/codeLens"));
+    }
+
+    // ============================================
+    // documentLink/resolve capability tests
+    // ============================================
+
+    #[tokio::test]
+    async fn document_link_resolve_capability_follows_static_resolve_provider() {
+        use tower_lsp_server::ls_types::DocumentLinkOptions;
+
+        let handle = spawn_sink_handle().await;
+        handle.set_server_capabilities(ServerCapabilities {
+            document_link_provider: Some(DocumentLinkOptions {
+                resolve_provider: Some(true),
+                work_done_progress_options: Default::default(),
+            }),
+            ..Default::default()
+        });
+
+        assert!(handle.has_capability("documentLink/resolve"));
+
+        let no_resolve_handle = spawn_sink_handle().await;
+        no_resolve_handle.set_server_capabilities(ServerCapabilities {
+            document_link_provider: Some(DocumentLinkOptions {
+                resolve_provider: Some(false),
+                work_done_progress_options: Default::default(),
+            }),
+            ..Default::default()
+        });
+        assert!(!no_resolve_handle.has_capability("documentLink/resolve"));
+        assert!(no_resolve_handle.has_capability("textDocument/documentLink"));
+    }
+
+    #[tokio::test]
+    async fn document_link_resolve_capability_follows_dynamic_resolve_provider() {
+        use tower_lsp_server::ls_types::Registration;
+
+        let handle = spawn_sink_handle().await;
+        handle.set_server_capabilities(ServerCapabilities::default());
+        handle.dynamic_capabilities().register(vec![Registration {
+            id: "document-link-1".to_string(),
+            method: "textDocument/documentLink".to_string(),
+            register_options: Some(serde_json::json!({ "resolveProvider": true })),
+        }]);
+
+        assert!(handle.has_capability("documentLink/resolve"));
     }
 }

--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -37,8 +37,8 @@ pub(crate) struct BridgeResponseContext<'a> {
 pub(crate) struct RequestHostLifecycle<'a> {
     pool: &'a LanguageServerPool,
     host_uri: &'a Url,
-    lifecycle: Arc<tokio::sync::Mutex<()>>,
-    guard: Option<tokio::sync::OwnedMutexGuard<()>>,
+    lifecycle: Arc<tokio::sync::RwLock<()>>,
+    guard: Option<tokio::sync::OwnedRwLockReadGuard<()>>,
     incarnation: u64,
 }
 
@@ -67,7 +67,9 @@ impl LanguageServerPool {
                 format!("bridge: host document is closed: {host_uri}"),
             )
         })?;
-        let guard = Arc::clone(&lifecycle).lock_owned().await;
+        // SHARED: concurrent requests on one document must overlap. Only
+        // lifecycle transitions take this exclusively.
+        let guard = Arc::clone(&lifecycle).read_owned().await;
         let Some(incarnation) = self.current_host_incarnation(host_uri) else {
             drop(guard);
             self.remove_host_lifecycle_lock_if_unshared(host_uri, &lifecycle);
@@ -558,6 +560,51 @@ mod tests {
             panic!("closed host must reject a late request");
         };
         assert_eq!(error.kind(), io::ErrorKind::NotConnected);
+    }
+
+    /// The host and virt layers of one document race under `try_join!`, and
+    /// each takes this lock for its whole downstream round trip. If it were
+    /// exclusive, the second layer could not even send its request until the
+    /// first answered — a client `$/cancelRequest` would then have nothing to
+    /// forward to the layer that had not started, which is exactly what
+    /// `e2e_whole_document_link_cancel_forwards_to_concatenated_layers` saw.
+    #[tokio::test]
+    async fn concurrent_requests_on_one_document_hold_the_lifecycle_together() {
+        let pool = Arc::new(LanguageServerPool::new());
+        let host_uri = Url::parse("file:///test/concurrent-layers.md").unwrap();
+        pool.open_host_incarnation(&host_uri, 1).await;
+
+        let first = pool.request_host_lifecycle(&host_uri).await.unwrap();
+        let second = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            pool.request_host_lifecycle(&host_uri),
+        )
+        .await
+        .expect("a second in-flight request must not wait out the first")
+        .expect("the document is still open");
+
+        assert_eq!(first.incarnation(), 1);
+        assert_eq!(second.incarnation(), 1);
+
+        // A close still waits for BOTH to finish.
+        let close = {
+            let pool = Arc::clone(&pool);
+            let host_uri = host_uri.clone();
+            tokio::spawn(async move { pool.close_host_incarnation(&host_uri, 1).await })
+        };
+        tokio::task::yield_now().await;
+        assert!(
+            !close.is_finished(),
+            "close must not pass an in-flight request"
+        );
+        drop(first);
+        tokio::task::yield_now().await;
+        assert!(
+            !close.is_finished(),
+            "close must wait for the last in-flight request, not just the first"
+        );
+        drop(second);
+        close.await.unwrap();
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -187,7 +187,7 @@ impl LanguageServerPool {
         // the cancel will fail at the router lookup (which is acceptable for best-effort
         // cancel semantics) rather than finding the server but no downstream ID.
         if let Some(ref id) = upstream_request_id {
-            self.register_upstream_request(id.clone(), connection_key);
+            self.register_upstream_request_for_handle(id.clone(), &handle);
         }
 
         // Register request with upstream ID mapping for cancel forwarding

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -29,6 +29,9 @@ pub(crate) use did_open::{OpenExpectation, OpenOutcome};
 mod document_color;
 mod document_highlight;
 mod document_link;
+pub(crate) use document_link::{
+    DocumentLinkEnvelope, envelope_host_document_links, extract_document_link_envelope,
+};
 mod document_symbol;
 mod folding_range;
 mod formatting;

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -1027,7 +1027,7 @@ impl LanguageServerPool {
     ) -> Option<CodeAction> {
         let connection_key = handle.key();
         if let Some(ref id) = upstream_id {
-            self.register_upstream_request(id.clone(), connection_key);
+            self.register_upstream_request_for_handle(id.clone(), handle);
         }
         let (request_id, response_rx) =
             match handle.register_request_with_upstream(upstream_id.clone()) {

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -394,7 +394,7 @@ impl LanguageServerPool {
 
         // Register in the upstream request registry FIRST for cancel lookup.
         if let Some(ref id) = upstream_id {
-            self.register_upstream_request(id.clone(), connection_key);
+            self.register_upstream_request_for_handle(id.clone(), &handle);
         }
 
         let (request_id, response_rx) =

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -292,7 +292,7 @@ impl LanguageServerPool {
 
         // Register in the upstream request registry FIRST for cancel lookup.
         if let Some(ref id) = upstream_id {
-            self.register_upstream_request(id.clone(), connection_key);
+            self.register_upstream_request_for_handle(id.clone(), handle);
         }
 
         let (request_id, response_rx) = match handle

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -70,7 +70,7 @@ pub(crate) struct OpenExpectation<'a> {
 struct LifecycleCleanup<'a> {
     pool: &'a LanguageServerPool,
     host_uri: &'a url::Url,
-    lifecycle: &'a Arc<tokio::sync::Mutex<()>>,
+    lifecycle: &'a Arc<tokio::sync::RwLock<()>>,
 }
 
 impl Drop for LifecycleCleanup<'_> {
@@ -238,7 +238,9 @@ impl LanguageServerPool {
             // this entry, so it either linearizes after this open (and closes the
             // tracked virtual document) or wins first and makes this stale batch
             // stop without opening old content.
-            let lifecycle_guard = lifecycle.lock().await;
+            // EXCLUSIVE: this opens virtual documents, so it must linearize
+            // against close/reopen the same way the transitions do.
+            let lifecycle_guard = lifecycle.write().await;
             let current_incarnation = self.current_host_incarnation(host_uri);
             if current_incarnation != Some(expected_incarnation) {
                 drop(lifecycle_guard);
@@ -353,7 +355,7 @@ impl LanguageServerPool {
         live_text_reader: Option<&(dyn Fn() -> Option<Arc<str>> + Send + Sync)>,
     ) {
         let lifecycle = self.host_lifecycle_lock(host_uri);
-        let _lifecycle_guard = lifecycle.lock().await;
+        let _lifecycle_guard = lifecycle.write().await;
         let handle = match self
             .get_or_create_connection_wait_ready(
                 server_name,

--- a/src/lsp/bridge/text_document/document_link.rs
+++ b/src/lsp/bridge/text_document/document_link.rs
@@ -115,6 +115,19 @@ fn re_envelope_link(link: &mut DocumentLink, envelope: &DocumentLinkEnvelope) {
     );
 }
 
+/// A downstream that cannot resolve gains nothing from the routing envelope,
+/// so its opaque `data` passes through untouched — except when that data
+/// carries the reserved key itself, which would otherwise let a downstream
+/// present a payload of its own choosing as kakehashi routing metadata. Those
+/// are wrapped anyway, with the foreign object nested as `inner`.
+fn should_envelope_link(link: &DocumentLink, server_resolves: bool) -> bool {
+    server_resolves
+        || link
+            .data
+            .as_ref()
+            .is_some_and(|data| data.get(ENVELOPE_KEY).is_some())
+}
+
 pub(crate) fn envelope_host_document_links(
     links: &mut [DocumentLink],
     server_name: &str,
@@ -137,12 +150,7 @@ pub(crate) fn envelope_host_document_links(
         host_layer: true,
     };
     for link in links {
-        if server_resolves
-            || link
-                .data
-                .as_ref()
-                .is_some_and(|data| data.get(ENVELOPE_KEY).is_some())
-        {
+        if should_envelope_link(link, server_resolves) {
             envelope_link_data(link, &ctx);
         }
     }
@@ -181,6 +189,7 @@ impl LanguageServerPool {
         }
         let connection_key = handle.key().clone();
         let connection_generation = self.document_connection_generation(&connection_key);
+        let server_resolves = handle.has_capability("documentLink/resolve");
         self.execute_bridge_request_with_handle(
             handle,
             host_uri,
@@ -194,6 +203,7 @@ impl LanguageServerPool {
                 transform_document_link_response_to_host(
                     response,
                     ctx.offset,
+                    server_resolves,
                     &DocumentLinkEnvelopeContext {
                         server_name,
                         host_uri: host_uri.as_str(),
@@ -450,6 +460,7 @@ fn parse_document_link_resolve_response(mut response: serde_json::Value) -> Opti
 fn transform_document_link_response_to_host(
     mut response: serde_json::Value,
     offset: &RegionOffset,
+    server_resolves: bool,
     envelope_ctx: &DocumentLinkEnvelopeContext<'_>,
 ) -> Option<Vec<DocumentLink>> {
     if response_has_jsonrpc_error(&response, "textDocument/documentLink") {
@@ -467,7 +478,9 @@ fn transform_document_link_response_to_host(
     // Transform ranges to host coordinates
     for link in &mut links {
         translate_virtual_range_to_host(&mut link.range, offset);
-        envelope_link_data(link, envelope_ctx);
+        if should_envelope_link(link, server_resolves) {
+            envelope_link_data(link, envelope_ctx);
+        }
     }
 
     Some(links)
@@ -484,10 +497,19 @@ mod tests {
         response: serde_json::Value,
         offset: &RegionOffset,
     ) -> Option<Vec<DocumentLink>> {
+        transform_for_resolving_server(response, offset, true)
+    }
+
+    fn transform_for_resolving_server(
+        response: serde_json::Value,
+        offset: &RegionOffset,
+        server_resolves: bool,
+    ) -> Option<Vec<DocumentLink>> {
         let connection_key = ConnectionKey::shared("lua-ls");
         transform_document_link_response_to_host(
             response,
             offset,
+            server_resolves,
             &DocumentLinkEnvelopeContext {
                 server_name: "lua-ls",
                 host_uri: "file:///test.md",
@@ -574,6 +596,55 @@ mod tests {
         );
         assert_eq!(links[0].range.start.line, 3);
         assert_eq!(links[0].range.start.character, 3);
+    }
+
+    /// A downstream that cannot resolve gains nothing from the envelope, and
+    /// wrapping its `data` anyway hides the payload it asked to get back. The
+    /// host helper already gates on the capability; the virtual layer must use
+    /// the same rule — including the reserved-key exception, so a downstream
+    /// cannot smuggle its own `kakehashi` object through as routing metadata.
+    #[test]
+    fn virtual_links_are_enveloped_only_when_the_server_resolves() {
+        let response = |data: serde_json::Value| {
+            json!({
+                "jsonrpc": "2.0",
+                "id": 42,
+                "result": [{
+                    "range": {
+                        "start": { "line": 0, "character": 1 },
+                        "end": { "line": 0, "character": 4 }
+                    },
+                    "data": data
+                }]
+            })
+        };
+
+        let bare = transform_for_resolving_server(
+            response(json!({"token": 1})),
+            &RegionOffset::new(3, 2),
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            bare[0].data,
+            Some(json!({"token": 1})),
+            "a non-resolving server's payload must pass through untouched"
+        );
+        assert_eq!(bare[0].range.start.line, 3, "ranges are still translated");
+
+        let forged = transform_for_resolving_server(
+            response(json!({ ENVELOPE_KEY: { "origin": "spoofed" } })),
+            &RegionOffset::new(3, 2),
+            false,
+        )
+        .unwrap();
+        let envelope = extract_document_link_envelope(&forged[0]).expect("collision envelope");
+        assert_eq!(envelope.origin, "lua-ls");
+        assert_eq!(
+            envelope.inner,
+            Some(json!({ ENVELOPE_KEY: { "origin": "spoofed" } })),
+            "the foreign payload must be nested, not honored as routing metadata"
+        );
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/document_link.rs
+++ b/src/lsp/bridge/text_document/document_link.rs
@@ -321,7 +321,7 @@ impl LanguageServerPool {
 
         let connection_key = handle.key();
         if let Some(ref id) = upstream_id {
-            self.register_upstream_request(id.clone(), connection_key);
+            self.register_upstream_request_for_handle(id.clone(), &handle);
         }
         let (request_id, response_rx) = match handle
             .register_request_with_upstream(upstream_id.clone())

--- a/src/lsp/bridge/text_document/document_link.rs
+++ b/src/lsp/bridge/text_document/document_link.rs
@@ -8,17 +8,145 @@
 //! FIFO ordering with other messages (ls-bridge-message-ordering single-writer loop).
 
 use std::io;
+use std::sync::Arc;
 
 use crate::config::settings::BridgeServerConfig;
+use log::warn;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use tower_lsp_server::ls_types::DocumentLink;
 use url::Url;
 
-use super::super::pool::{LanguageServerPool, UpstreamId};
-use super::super::protocol::translate_virtual_range_to_host;
+use super::super::pool::{ConnectionKey, LanguageServerPool, UpstreamId};
 use super::super::protocol::{
     DocumentParams, JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri,
     build_whole_document_request, response_has_jsonrpc_error,
 };
+use super::super::protocol::{translate_host_range_to_virtual, translate_virtual_range_to_host};
+use super::completion::EnvelopeOffset;
+use crate::config::{merge_bridge_server_configs, resolve_with_wildcard};
+use crate::lsp::bridge::actor::RouterCleanupGuard;
+
+const ENVELOPE_KEY: &str = "kakehashi";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct DocumentLinkEnvelope {
+    pub(crate) origin: String,
+    pub(crate) host_uri: String,
+    pub(crate) region_id: String,
+    pub(crate) injection_language: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) incarnation: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) connection_generation: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) connection_key: Option<ConnectionKey>,
+    pub(crate) offset: EnvelopeOffset,
+    pub(crate) inner: Option<Value>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub(crate) host_layer: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+impl DocumentLinkEnvelope {
+    pub(crate) fn is_host_layer(&self) -> bool {
+        self.host_layer && self.region_id.is_empty()
+    }
+}
+
+struct DocumentLinkEnvelopeContext<'a> {
+    server_name: &'a str,
+    host_uri: &'a str,
+    region_id: &'a str,
+    injection_language: &'a str,
+    incarnation: Option<u64>,
+    connection_generation: Option<u64>,
+    connection_key: Option<&'a ConnectionKey>,
+    offset: &'a RegionOffset,
+    host_layer: bool,
+}
+
+fn envelope_link_data(link: &mut DocumentLink, ctx: &DocumentLinkEnvelopeContext<'_>) {
+    let inner = link.data.take();
+    let envelope = DocumentLinkEnvelope {
+        origin: ctx.server_name.to_string(),
+        host_uri: ctx.host_uri.to_string(),
+        region_id: ctx.region_id.to_string(),
+        injection_language: ctx.injection_language.to_string(),
+        incarnation: ctx.incarnation,
+        connection_generation: ctx.connection_generation,
+        connection_key: ctx.connection_key.cloned(),
+        offset: EnvelopeOffset::from(ctx.offset),
+        inner,
+        host_layer: ctx.host_layer,
+    };
+    link.data = Some(serde_json::json!({ ENVELOPE_KEY: envelope }));
+}
+
+pub(crate) fn extract_document_link_envelope(link: &DocumentLink) -> Option<DocumentLinkEnvelope> {
+    let wrapper = link.data.as_ref()?.get(ENVELOPE_KEY)?;
+    serde_json::from_value(wrapper.clone()).ok()
+}
+
+fn strip_document_link_envelope(link: &mut DocumentLink) -> Option<DocumentLinkEnvelope> {
+    let mut envelope = extract_document_link_envelope(link)?;
+    link.data = envelope.inner.take();
+    Some(envelope)
+}
+
+fn re_envelope_link(link: &mut DocumentLink, envelope: &DocumentLinkEnvelope) {
+    let offset = RegionOffset::from(&envelope.offset);
+    envelope_link_data(
+        link,
+        &DocumentLinkEnvelopeContext {
+            server_name: &envelope.origin,
+            host_uri: &envelope.host_uri,
+            region_id: &envelope.region_id,
+            injection_language: &envelope.injection_language,
+            incarnation: envelope.incarnation,
+            connection_generation: envelope.connection_generation,
+            connection_key: envelope.connection_key.as_ref(),
+            offset: &offset,
+            host_layer: envelope.host_layer,
+        },
+    );
+}
+
+pub(crate) fn envelope_host_document_links(
+    links: &mut [DocumentLink],
+    server_name: &str,
+    host_uri: &str,
+    incarnation: Option<u64>,
+    connection_generation: u64,
+    connection_key: &ConnectionKey,
+    server_resolves: bool,
+) {
+    let offset = RegionOffset::new(0, 0);
+    let ctx = DocumentLinkEnvelopeContext {
+        server_name,
+        host_uri,
+        region_id: "",
+        injection_language: "",
+        incarnation,
+        connection_generation: Some(connection_generation),
+        connection_key: Some(connection_key),
+        offset: &offset,
+        host_layer: true,
+    };
+    for link in links {
+        if server_resolves
+            || link
+                .data
+                .as_ref()
+                .is_some_and(|data| data.get(ENVELOPE_KEY).is_some())
+        {
+            envelope_link_data(link, &ctx);
+        }
+    }
+}
 
 impl LanguageServerPool {
     /// Send a document link request and wait for the response.
@@ -38,6 +166,7 @@ impl LanguageServerPool {
         virtual_content: &str,
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Option<Vec<DocumentLink>>> {
+        let host_incarnation = self.current_host_incarnation(host_uri);
         let handle = self
             .get_or_create_virtual_connection(
                 server_name,
@@ -59,9 +188,241 @@ impl LanguageServerPool {
             virtual_content,
             upstream_request_id,
             build_document_link_request,
-            |response, ctx| transform_document_link_response_to_host(response, ctx.offset),
+            |response, ctx| {
+                transform_document_link_response_to_host(
+                    response,
+                    ctx.offset,
+                    &DocumentLinkEnvelopeContext {
+                        server_name,
+                        host_uri: host_uri.as_str(),
+                        region_id,
+                        injection_language,
+                        incarnation: host_incarnation,
+                        connection_generation: None,
+                        connection_key: None,
+                        offset: ctx.offset,
+                        host_layer: false,
+                    },
+                )
+            },
         )
         .await
+    }
+
+    pub(crate) async fn dispatch_document_link_resolve(
+        &self,
+        mut link: DocumentLink,
+        settings: &crate::config::settings::WorkspaceSettings,
+        upstream_id: Option<UpstreamId>,
+    ) -> DocumentLink {
+        let Some(envelope) = strip_document_link_envelope(&mut link) else {
+            return link;
+        };
+
+        if !crate::config::is_server_spawnable(&settings.language_servers, &envelope.origin) {
+            re_envelope_link(&mut link, &envelope);
+            return link;
+        }
+        let Some(config) = resolve_with_wildcard(
+            &settings.language_servers,
+            &envelope.origin,
+            merge_bridge_server_configs,
+        ) else {
+            re_envelope_link(&mut link, &envelope);
+            return link;
+        };
+
+        self.send_document_link_resolve_request(&config, link, envelope, upstream_id)
+            .await
+    }
+
+    async fn send_document_link_resolve_request(
+        &self,
+        server_config: &BridgeServerConfig,
+        mut link: DocumentLink,
+        envelope: DocumentLinkEnvelope,
+        upstream_id: Option<UpstreamId>,
+    ) -> DocumentLink {
+        let server_name = &envelope.origin;
+        let Ok(host_uri) = Url::parse(&envelope.host_uri) else {
+            re_envelope_link(&mut link, &envelope);
+            return link;
+        };
+        if envelope
+            .incarnation
+            .is_some_and(|expected| self.current_host_incarnation(&host_uri) != Some(expected))
+        {
+            re_envelope_link(&mut link, &envelope);
+            return link;
+        }
+
+        let handle_result = if envelope.is_host_layer() {
+            let Some(expected_generation) = envelope.connection_generation else {
+                re_envelope_link(&mut link, &envelope);
+                return link;
+            };
+            let Some(connection_key) = envelope
+                .connection_key
+                .as_ref()
+                .filter(|key| key.server() == server_name)
+            else {
+                re_envelope_link(&mut link, &envelope);
+                return link;
+            };
+            if self.document_connection_generation(connection_key) != expected_generation {
+                re_envelope_link(&mut link, &envelope);
+                return link;
+            }
+            self.ready_connection_by_key_for_config(connection_key, Some(server_config))
+                .await
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotConnected,
+                        "producer connection is no longer live",
+                    )
+                })
+        } else {
+            self.get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                &host_uri,
+                &envelope.injection_language,
+                &envelope.region_id,
+            )
+            .await
+        };
+        let handle = match handle_result {
+            Ok(handle) => handle,
+            Err(error) => {
+                warn!(
+                    target: "kakehashi::bridge",
+                    "documentLink/resolve: failed to connect to {server_name}: {error}"
+                );
+                re_envelope_link(&mut link, &envelope);
+                return link;
+            }
+        };
+
+        if !handle.has_capability("documentLink/resolve") {
+            re_envelope_link(&mut link, &envelope);
+            return link;
+        }
+
+        let _host_lifecycle = if envelope.is_host_layer() {
+            let Some(expected_incarnation) = envelope.incarnation else {
+                re_envelope_link(&mut link, &envelope);
+                return link;
+            };
+            match self
+                .request_host_lifecycle_for_incarnation(&host_uri, expected_incarnation)
+                .await
+            {
+                Ok(lifecycle) => Some(lifecycle),
+                Err(_) => {
+                    re_envelope_link(&mut link, &envelope);
+                    return link;
+                }
+            }
+        } else {
+            None
+        };
+
+        let connection_key = handle.key();
+        if let Some(ref id) = upstream_id {
+            self.register_upstream_request(id.clone(), connection_key);
+        }
+        let (request_id, response_rx) = match handle
+            .register_request_with_upstream(upstream_id.clone())
+        {
+            Ok(pair) => pair,
+            Err(error) => {
+                warn!(
+                    target: "kakehashi::bridge",
+                    "documentLink/resolve: failed to register request for {server_name}: {error}"
+                );
+                if let Some(ref id) = upstream_id {
+                    self.unregister_upstream_request(id, connection_key);
+                }
+                re_envelope_link(&mut link, &envelope);
+                return link;
+            }
+        };
+
+        let mut outgoing = link.clone();
+        if !envelope.is_host_layer() {
+            translate_host_range_to_virtual(
+                &mut outgoing.range,
+                &RegionOffset::from(&envelope.offset),
+            );
+        }
+        let request = build_document_link_resolve_request(&outgoing, request_id);
+        let mut router_guard = RouterCleanupGuard::new(Arc::clone(handle.router()), request_id);
+
+        let send_result = {
+            let connections = self.connections().await;
+            let producer_is_live = connections
+                .get(connection_key)
+                .is_some_and(|current| Arc::ptr_eq(current, &handle));
+            let generation_matches = !envelope.is_host_layer()
+                || envelope.connection_generation.is_some_and(|expected| {
+                    self.document_connection_generation(connection_key) == expected
+                });
+            if !producer_is_live || !generation_matches {
+                Err(io::Error::new(
+                    io::ErrorKind::NotConnected,
+                    "producer connection was replaced before resolve send",
+                ))
+            } else {
+                handle.send_request(request, request_id).map_err(Into::into)
+            }
+        };
+        if let Err(error) = send_result {
+            warn!(
+                target: "kakehashi::bridge",
+                "documentLink/resolve: failed to send request for {server_name}: {error}"
+            );
+            if let Some(ref id) = upstream_id {
+                self.unregister_upstream_request(id, connection_key);
+            }
+            re_envelope_link(&mut link, &envelope);
+            return link;
+        }
+
+        let response = handle.wait_for_response(request_id, response_rx).await;
+        router_guard.disarm();
+        if let Some(ref id) = upstream_id {
+            self.unregister_upstream_request(id, connection_key);
+        }
+
+        let response = match response {
+            Ok(response) => response,
+            Err(error) => {
+                warn!(
+                    target: "kakehashi::bridge",
+                    "documentLink/resolve failed for server {server_name}: {error}"
+                );
+                re_envelope_link(&mut link, &envelope);
+                return link;
+            }
+        };
+
+        match parse_document_link_resolve_response(response) {
+            Some(mut resolved) => {
+                // Resolve materializes target/tooltip; the range belongs to the
+                // original document-link result and was already translated and
+                // freshness-checked.
+                resolved.range = link.range;
+                if resolved.data.is_none() {
+                    resolved.data = link.data.take();
+                }
+                re_envelope_link(&mut resolved, &envelope);
+                resolved
+            }
+            None => {
+                re_envelope_link(&mut link, &envelope);
+                link
+            }
+        }
     }
 }
 
@@ -73,6 +434,24 @@ fn build_document_link_request(
     build_whole_document_request(virtual_uri, request_id, "textDocument/documentLink")
 }
 
+fn build_document_link_resolve_request(
+    link: &DocumentLink,
+    request_id: RequestId,
+) -> JsonRpcRequest<&DocumentLink> {
+    JsonRpcRequest::new(request_id.as_i64(), "documentLink/resolve", link)
+}
+
+fn parse_document_link_resolve_response(mut response: serde_json::Value) -> Option<DocumentLink> {
+    if response_has_jsonrpc_error(&response, "documentLink/resolve") {
+        return None;
+    }
+    let result = response.get_mut("result").map(serde_json::Value::take)?;
+    if result.is_null() {
+        return None;
+    }
+    serde_json::from_value(result).ok()
+}
+
 /// Transform a document link response from virtual to host document coordinates.
 ///
 /// Only each link's `range` is translated by `offset`; target, tooltip, and
@@ -80,6 +459,7 @@ fn build_document_link_request(
 fn transform_document_link_response_to_host(
     mut response: serde_json::Value,
     offset: &RegionOffset,
+    envelope_ctx: &DocumentLinkEnvelopeContext<'_>,
 ) -> Option<Vec<DocumentLink>> {
     if response_has_jsonrpc_error(&response, "textDocument/documentLink") {
         return None;
@@ -96,6 +476,7 @@ fn transform_document_link_response_to_host(
     // Transform ranges to host coordinates
     for link in &mut links {
         translate_virtual_range_to_host(&mut link.range, offset);
+        envelope_link_data(link, envelope_ctx);
     }
 
     Some(links)
@@ -107,6 +488,36 @@ mod tests {
     use super::*;
     use rstest::rstest;
     use serde_json::json;
+
+    fn transform_for_test(
+        response: serde_json::Value,
+        offset: &RegionOffset,
+    ) -> Option<Vec<DocumentLink>> {
+        transform_document_link_response_to_host(
+            response,
+            offset,
+            &DocumentLinkEnvelopeContext {
+                server_name: "lua-ls",
+                host_uri: "file:///test.md",
+                region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                injection_language: "lua",
+                incarnation: Some(1),
+                connection_generation: None,
+                connection_key: None,
+                offset,
+                host_layer: false,
+            },
+        )
+    }
+
+    fn unresolved_link(data: Option<serde_json::Value>) -> DocumentLink {
+        DocumentLink {
+            range: tower_lsp_server::ls_types::Range::default(),
+            target: None,
+            tooltip: None,
+            data,
+        }
+    }
 
     // ==========================================================================
     // Document link request tests
@@ -133,6 +544,70 @@ mod tests {
             json["params"].get("position").is_none(),
             "DocumentLink request should not have position parameter"
         );
+    }
+
+    #[test]
+    fn document_link_resolve_request_carries_the_link_as_params() {
+        let link = unresolved_link(Some(json!({"token": 7})));
+        let request = build_document_link_resolve_request(&link, RequestId::new(9));
+        let value = serde_json::to_value(request).expect("request should serialize");
+
+        assert_eq!(value["method"], "documentLink/resolve");
+        assert_eq!(value["params"]["data"]["token"], 7);
+    }
+
+    #[test]
+    fn document_link_response_wraps_downstream_data_for_resolve_routing() {
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "result": [{
+                "range": {
+                    "start": { "line": 0, "character": 1 },
+                    "end": { "line": 0, "character": 4 }
+                },
+                "data": { "token": "link-1" }
+            }]
+        });
+
+        let links = transform_for_test(response, &RegionOffset::new(3, 2)).unwrap();
+        let envelope = extract_document_link_envelope(&links[0]).expect("routing envelope");
+        assert_eq!(envelope.origin, "lua-ls");
+        assert_eq!(envelope.host_uri, "file:///test.md");
+        assert_eq!(envelope.inner, Some(json!({"token": "link-1"})));
+        assert_eq!(links[0].range.start.line, 3);
+        assert_eq!(links[0].range.start.character, 3);
+    }
+
+    #[test]
+    fn host_links_are_enveloped_only_when_the_server_resolves() {
+        let key = ConnectionKey::shared("lua-ls");
+        let mut resolvable = vec![unresolved_link(Some(json!({"token": 1})))];
+        envelope_host_document_links(
+            &mut resolvable,
+            "lua-ls",
+            "file:///test.lua",
+            Some(2),
+            5,
+            &key,
+            true,
+        );
+        let envelope = extract_document_link_envelope(&resolvable[0]).unwrap();
+        assert!(envelope.is_host_layer());
+        assert_eq!(envelope.connection_generation, Some(5));
+        assert_eq!(envelope.connection_key, Some(key));
+
+        let mut bare = vec![unresolved_link(Some(json!({"token": 2})))];
+        envelope_host_document_links(
+            &mut bare,
+            "lua-ls",
+            "file:///test.lua",
+            Some(2),
+            5,
+            &ConnectionKey::shared("lua-ls"),
+            false,
+        );
+        assert_eq!(bare[0].data, Some(json!({"token": 2})));
     }
 
     // ==========================================================================
@@ -162,10 +637,7 @@ mod tests {
         });
         let region_start_line = 5;
 
-        let transformed = transform_document_link_response_to_host(
-            response,
-            &RegionOffset::new(region_start_line, 0),
-        );
+        let transformed = transform_for_test(response, &RegionOffset::new(region_start_line, 0));
 
         assert!(transformed.is_some());
         let links = transformed.unwrap();
@@ -188,8 +660,7 @@ mod tests {
     fn document_link_response_returns_none_for_invalid_response(
         #[case] response: serde_json::Value,
     ) {
-        let transformed =
-            transform_document_link_response_to_host(response, &RegionOffset::new(5, 0));
+        let transformed = transform_for_test(response, &RegionOffset::new(5, 0));
         assert!(transformed.is_none());
     }
 
@@ -197,8 +668,7 @@ mod tests {
     fn document_link_response_with_empty_array_returns_empty_vec() {
         let response = json!({ "jsonrpc": "2.0", "id": 42, "result": [] });
 
-        let transformed =
-            transform_document_link_response_to_host(response, &RegionOffset::new(5, 0));
+        let transformed = transform_for_test(response, &RegionOffset::new(5, 0));
         assert!(transformed.is_some());
         let links = transformed.unwrap();
         assert!(links.is_empty());
@@ -220,10 +690,7 @@ mod tests {
         });
         let region_start_line = 3;
 
-        let transformed = transform_document_link_response_to_host(
-            response,
-            &RegionOffset::new(region_start_line, 0),
-        );
+        let transformed = transform_for_test(response, &RegionOffset::new(region_start_line, 0));
 
         assert!(transformed.is_some());
         let links = transformed.unwrap();
@@ -249,10 +716,7 @@ mod tests {
         });
         let region_start_line = 10;
 
-        let transformed = transform_document_link_response_to_host(
-            response,
-            &RegionOffset::new(region_start_line, 0),
-        );
+        let transformed = transform_for_test(response, &RegionOffset::new(region_start_line, 0));
 
         assert!(transformed.is_some());
         let links = transformed.unwrap();
@@ -275,10 +739,7 @@ mod tests {
         });
         let region_start_line = 10;
 
-        let transformed = transform_document_link_response_to_host(
-            response,
-            &RegionOffset::new(region_start_line, 0),
-        );
+        let transformed = transform_for_test(response, &RegionOffset::new(region_start_line, 0));
 
         assert!(transformed.is_some());
         let links = transformed.unwrap();
@@ -287,5 +748,57 @@ mod tests {
             u32::MAX,
             "Overflow should saturate at u32::MAX, not panic"
         );
+    }
+
+    #[test]
+    fn parse_document_link_resolve_response_materializes_target_and_tooltip() {
+        let resolved = parse_document_link_resolve_response(json!({
+            "jsonrpc": "2.0",
+            "id": 9,
+            "result": {
+                "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 0, "character": 3 }
+                },
+                "target": "file:///resolved.lua",
+                "tooltip": "resolved"
+            }
+        }))
+        .expect("valid resolve response");
+
+        assert_eq!(
+            resolved.target.as_ref().map(|uri| uri.as_str()),
+            Some("file:///resolved.lua")
+        );
+        assert_eq!(resolved.tooltip.as_deref(), Some("resolved"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_re_envelopes_when_origin_server_is_not_configured() {
+        let pool = LanguageServerPool::new();
+        let settings = crate::config::settings::WorkspaceSettings::default();
+        let offset = RegionOffset::new(3, 2);
+        let mut link = unresolved_link(Some(json!({"token": "link-1"})));
+        envelope_link_data(
+            &mut link,
+            &DocumentLinkEnvelopeContext {
+                server_name: "lua-ls",
+                host_uri: "file:///test.md",
+                region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                injection_language: "lua",
+                incarnation: Some(1),
+                connection_generation: None,
+                connection_key: None,
+                offset: &offset,
+                host_layer: false,
+            },
+        );
+
+        let result = pool
+            .dispatch_document_link_resolve(link, &settings, None)
+            .await;
+        let envelope = extract_document_link_envelope(&result).expect("envelope restored");
+        assert_eq!(envelope.inner, Some(json!({"token": "link-1"})));
+        assert!(result.target.is_none());
     }
 }

--- a/src/lsp/bridge/text_document/document_link.rs
+++ b/src/lsp/bridge/text_document/document_link.rs
@@ -179,6 +179,8 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/documentLink") {
             return Ok(None);
         }
+        let connection_key = handle.key().clone();
+        let connection_generation = self.document_connection_generation(&connection_key);
         self.execute_bridge_request_with_handle(
             handle,
             host_uri,
@@ -198,8 +200,8 @@ impl LanguageServerPool {
                         region_id,
                         injection_language,
                         incarnation: host_incarnation,
-                        connection_generation: None,
-                        connection_key: None,
+                        connection_generation: Some(connection_generation),
+                        connection_key: Some(&connection_key),
                         offset: ctx.offset,
                         host_layer: false,
                     },
@@ -256,41 +258,31 @@ impl LanguageServerPool {
             return link;
         }
 
-        let handle_result = if envelope.is_host_layer() {
-            let Some(expected_generation) = envelope.connection_generation else {
-                re_envelope_link(&mut link, &envelope);
-                return link;
-            };
-            let Some(connection_key) = envelope
-                .connection_key
-                .as_ref()
-                .filter(|key| key.server() == server_name)
-            else {
-                re_envelope_link(&mut link, &envelope);
-                return link;
-            };
-            if self.document_connection_generation(connection_key) != expected_generation {
-                re_envelope_link(&mut link, &envelope);
-                return link;
-            }
-            self.ready_connection_by_key_for_config(connection_key, Some(server_config))
-                .await
-                .ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::NotConnected,
-                        "producer connection is no longer live",
-                    )
-                })
-        } else {
-            self.get_or_create_virtual_connection(
-                server_name,
-                server_config,
-                &host_uri,
-                &envelope.injection_language,
-                &envelope.region_id,
-            )
-            .await
+        let Some(expected_generation) = envelope.connection_generation else {
+            re_envelope_link(&mut link, &envelope);
+            return link;
         };
+        let Some(connection_key) = envelope
+            .connection_key
+            .as_ref()
+            .filter(|key| key.server() == server_name)
+        else {
+            re_envelope_link(&mut link, &envelope);
+            return link;
+        };
+        if self.document_connection_generation(connection_key) != expected_generation {
+            re_envelope_link(&mut link, &envelope);
+            return link;
+        }
+        let handle_result = self
+            .ready_connection_by_key_for_config(connection_key, Some(server_config))
+            .await
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotConnected,
+                    "producer connection is no longer live",
+                )
+            });
         let handle = match handle_result {
             Ok(handle) => handle,
             Err(error) => {
@@ -363,10 +355,9 @@ impl LanguageServerPool {
             let producer_is_live = connections
                 .get(connection_key)
                 .is_some_and(|current| Arc::ptr_eq(current, &handle));
-            let generation_matches = !envelope.is_host_layer()
-                || envelope.connection_generation.is_some_and(|expected| {
-                    self.document_connection_generation(connection_key) == expected
-                });
+            let generation_matches = envelope.connection_generation.is_some_and(|expected| {
+                self.document_connection_generation(connection_key) == expected
+            });
             if !producer_is_live || !generation_matches {
                 Err(io::Error::new(
                     io::ErrorKind::NotConnected,
@@ -493,6 +484,7 @@ mod tests {
         response: serde_json::Value,
         offset: &RegionOffset,
     ) -> Option<Vec<DocumentLink>> {
+        let connection_key = ConnectionKey::shared("lua-ls");
         transform_document_link_response_to_host(
             response,
             offset,
@@ -502,8 +494,8 @@ mod tests {
                 region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
                 injection_language: "lua",
                 incarnation: Some(1),
-                connection_generation: None,
-                connection_key: None,
+                connection_generation: Some(4),
+                connection_key: Some(&connection_key),
                 offset,
                 host_layer: false,
             },
@@ -575,6 +567,11 @@ mod tests {
         assert_eq!(envelope.origin, "lua-ls");
         assert_eq!(envelope.host_uri, "file:///test.md");
         assert_eq!(envelope.inner, Some(json!({"token": "link-1"})));
+        assert_eq!(envelope.connection_generation, Some(4));
+        assert_eq!(
+            envelope.connection_key,
+            Some(ConnectionKey::shared("lua-ls"))
+        );
         assert_eq!(links[0].range.start.line, 3);
         assert_eq!(links[0].range.start.character, 3);
     }

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -211,7 +211,7 @@ impl LanguageServerPool {
     pub(crate) async fn close_host_bridge_document(&self, uri: &Url) {
         self.finish_all_host_routing(uri);
         let lifecycle = self.host_lifecycle_lock(uri);
-        let _lifecycle_guard = lifecycle.lock().await;
+        let _lifecycle_guard = lifecycle.write().await;
         self.invalidate_diagnostic_host(uri);
         let Ok(uri_lsp) = host_url_to_lsp_uri(uri) else {
             return;

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -596,7 +596,7 @@ impl LanguageServerPool {
             ));
         }
         if let Some(ref id) = upstream_request_id {
-            self.register_upstream_request(id.clone(), connection_key);
+            self.register_upstream_request_for_handle(id.clone(), &handle);
         }
 
         let (request_id, response_rx) =

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -582,7 +582,7 @@ impl LanguageServerPool {
     ) -> Option<Value> {
         let connection_key = handle.key();
         if let Some(ref id) = upstream_id {
-            self.register_upstream_request(id.clone(), connection_key);
+            self.register_upstream_request_for_handle(id.clone(), handle);
         }
         let (request_id, response_rx) =
             match handle.register_request_with_upstream(upstream_id.clone()) {

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -306,8 +306,8 @@ enum Role {
 /// document), and pull diagnostics.
 /// `textDocument/codeAction` is in the same class: its
 /// `context.diagnostics` and returned edits are computed against the
-/// document snapshot (#568). `codeLens/resolve` and `codeAction/resolve` are
-/// readers too (#355, #568): their freshness gates read tracker/document
+/// document snapshot (#568). `codeLens/resolve`, `codeAction/resolve`, and
+/// `documentLink/resolve` are readers too (#355, #568): their freshness gates read tracker/document
 /// state, so they must observe every `didChange` that preceded them on the
 /// wire — but their params carry no `textDocument`, so the URI comes from the
 /// routing envelope in `params.data.kakehashi.host_uri` (unenveloped items
@@ -358,7 +358,7 @@ fn classify(req: &Request) -> Option<Role> {
             let uri = text_document_uri(req)?;
             Some(Role::Reader { uri })
         }
-        "codeLens/resolve" | "codeAction/resolve" => {
+        "codeLens/resolve" | "codeAction/resolve" | "documentLink/resolve" => {
             let raw = req.params()?["data"]["kakehashi"]["host_uri"].as_str()?;
             Some(Role::Reader {
                 uri: normalize_uri(raw),
@@ -833,6 +833,18 @@ mod tests {
         assert!(
             classify(&unenveloped).is_none(),
             "unenveloped codeLens/resolve passes through ungated"
+        );
+
+        let enveloped_link = Request::build("documentLink/resolve")
+            .params(serde_json::json!({
+                "range": { "start": { "line": 0, "character": 0 },
+                           "end": { "line": 0, "character": 5 } },
+                "data": { "kakehashi": { "host_uri": URI } }
+            }))
+            .finish();
+        assert!(
+            matches!(classify(&enveloped_link), Some(Role::Reader { ref uri }) if uri == URI),
+            "enveloped documentLink/resolve must be keyed by the envelope's host_uri"
         );
 
         // codeAction/resolve is classified the same way (#568): the URI comes

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -959,6 +959,10 @@ impl LanguageServer for Kakehashi {
         self.document_link_impl(params).await
     }
 
+    async fn document_link_resolve(&self, params: DocumentLink) -> Result<DocumentLink> {
+        self.document_link_resolve_impl(params).await
+    }
+
     async fn code_lens(&self, params: CodeLensParams) -> Result<Option<Vec<CodeLens>>> {
         self.code_lens_impl(params).await
     }

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -2742,7 +2742,6 @@ mod tests {
             .bridge
             .cancel_forwarder()
             .forward_cancel(crate::lsp::bridge::UpstreamId::Number(77))
-            .await
             .expect("cancel forward must not error");
 
         let result = request.await.expect("handler task must not panic");

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -587,7 +587,7 @@ impl Kakehashi {
                 })),
                 document_highlight_provider: Some(OneOf::Left(true)),
                 document_link_provider: Some(DocumentLinkOptions {
-                    resolve_provider: None,
+                    resolve_provider: Some(true),
                     work_done_progress_options: WorkDoneProgressOptions::default(),
                 }),
                 // Advertise workDoneProgress so spec-compliant clients attach a

--- a/src/lsp/lsp_impl/text_document/document_link.rs
+++ b/src/lsp/lsp_impl/text_document/document_link.rs
@@ -2,8 +2,15 @@
 
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{DocumentLink, DocumentLinkParams};
+use ulid::Ulid;
+use url::Url;
 
 use super::super::Kakehashi;
+use crate::lsp::bridge::{
+    DocumentLinkEnvelope, envelope_host_document_links, extract_document_link_envelope,
+};
+use crate::lsp::current_upstream_id;
+use crate::text::PositionMapper;
 
 impl Kakehashi {
     pub(crate) async fn document_link_impl(
@@ -32,8 +39,76 @@ impl Kakehashi {
                     )
                     .await
             },
-            |won| Some(won.items),
+            |mut won| {
+                let server_resolves = won.handle.has_capability("documentLink/resolve");
+                envelope_host_document_links(
+                    &mut won.items,
+                    &won.server_name,
+                    won.host_uri.as_str(),
+                    won.incarnation,
+                    won.connection_generation,
+                    won.handle.key(),
+                    server_resolves,
+                );
+                Some(won.items)
+            },
         )
         .await
+    }
+
+    pub(crate) async fn document_link_resolve_impl(
+        &self,
+        link: DocumentLink,
+    ) -> Result<DocumentLink> {
+        let Some(envelope) = extract_document_link_envelope(&link) else {
+            return Ok(link);
+        };
+        if !envelope.is_host_layer() && !self.document_link_region_is_fresh(&envelope) {
+            return Ok(link);
+        }
+
+        let settings = self.settings_manager.load_settings();
+        let pool = self.bridge.pool_arc();
+        let upstream_id = current_upstream_id();
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_id.as_ref());
+        let sweep_id = upstream_id.clone();
+        let dispatch = pool.dispatch_document_link_resolve(link, &settings, upstream_id);
+        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard::new(
+            std::sync::Arc::clone(&pool),
+            sweep_id,
+        );
+        match cancel_rx {
+            Some(rx) => tokio::select! {
+                biased;
+                _ = rx => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
+                link = dispatch => Ok(link),
+            },
+            None => Ok(dispatch.await),
+        }
+    }
+
+    fn document_link_region_is_fresh(&self, envelope: &DocumentLinkEnvelope) -> bool {
+        let Ok(uri) = Url::parse(&envelope.host_uri) else {
+            return false;
+        };
+        let Ok(ulid) = envelope.region_id.parse::<Ulid>() else {
+            return false;
+        };
+        let Some((start_byte, _end, _kind, tracked_incarnation)) =
+            self.bridge.node_tracker().lookup_position(&uri, &ulid)
+        else {
+            return false;
+        };
+        let Some(doc) = self.documents.get(&uri) else {
+            return false;
+        };
+        if doc.incarnation() != tracked_incarnation {
+            return false;
+        }
+        let mapper = PositionMapper::new(doc.text());
+        let Some(position) = mapper.byte_to_position(start_byte) else {
+            return false;
+        };
+        position.line == envelope.offset.line && position.character == envelope.offset.column
     }
 }

--- a/src/lsp/lsp_impl/text_document/document_link.rs
+++ b/src/lsp/lsp_impl/text_document/document_link.rs
@@ -2,15 +2,14 @@
 
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{DocumentLink, DocumentLinkParams};
-use ulid::Ulid;
 use url::Url;
 
 use super::super::Kakehashi;
+use super::super::region_offset::resolve_region_offset;
 use crate::lsp::bridge::{
     DocumentLinkEnvelope, envelope_host_document_links, extract_document_link_envelope,
 };
 use crate::lsp::current_upstream_id;
-use crate::text::PositionMapper;
 
 impl Kakehashi {
     pub(crate) async fn document_link_impl(
@@ -91,24 +90,15 @@ impl Kakehashi {
         let Ok(uri) = Url::parse(&envelope.host_uri) else {
             return false;
         };
-        let Ok(ulid) = envelope.region_id.parse::<Ulid>() else {
-            return false;
-        };
-        let Some((start_byte, _end, _kind, tracked_incarnation)) =
-            self.bridge.node_tracker().lookup_position(&uri, &ulid)
-        else {
-            return false;
-        };
-        let Some(doc) = self.documents.get(&uri) else {
-            return false;
-        };
-        if doc.incarnation() != tracked_incarnation {
-            return false;
-        }
-        let mapper = PositionMapper::new(doc.text());
-        let Some(position) = mapper.byte_to_position(start_byte) else {
-            return false;
-        };
-        position.line == envelope.offset.line && position.character == envelope.offset.column
+        resolve_region_offset(
+            &self.documents,
+            &self.language,
+            &self.bridge,
+            &uri,
+            &envelope.region_id,
+        )
+        .is_some_and(|(offset, _, _)| {
+            offset == crate::lsp::bridge::RegionOffset::from(&envelope.offset)
+        })
     }
 }

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -1563,7 +1563,6 @@ mod tests {
             .bridge
             .cancel_forwarder()
             .forward_cancel(crate::lsp::bridge::UpstreamId::Number(42))
-            .await
             .expect("cancel forward must not error");
 
         let result = request.await.expect("handler task must not panic");

--- a/src/lsp/request_id.rs
+++ b/src/lsp/request_id.rs
@@ -432,7 +432,7 @@ where
                 Some(ActiveRequestGuard::new(forwarder, upstream_id))
             })
         };
-        if req.method() == "$/cancelRequest"
+        let cancel_request = if req.method() == "$/cancelRequest"
             && let Some(forwarder) = cancel_forwarder.as_ref()
             && let Some(params) = req.params()
         {
@@ -451,36 +451,13 @@ where
             if let Some(upstream_id) = id_to_cancel
                 && let Some(generation) = forwarder.request_generation(&upstream_id)
             {
-                let forwarder = forwarder.clone();
-                // Fire-and-forget: spawn without tracking JoinHandle.
-                //
-                // This is intentional for $/cancelRequest because:
-                // 1. LSP notifications don't expect responses (fire-and-forget by spec)
-                // 2. Cancel is "best effort" - failures are logged but non-fatal
-                // 3. We must not block the main request flow
-                // 4. Graceful shutdown doesn't need to wait for cancels - the downstream
-                //    server will clean up its own state when it shuts down
-                //
-                // Upstream subscribers are notified inside forward_cancel, AFTER
-                // it captures the downstream targets — notifying here first would
-                // let the woken handler tear down the registry/router state the
-                // forwarding pass is about to read (capture-before-notify).
-                tokio::spawn(async move {
-                    if let Err(e) = forwarder
-                        .forward_cancel_for_generation(upstream_id.clone(), Some(generation))
-                        .await
-                    {
-                        // Log the error but don't fail - cancel forwarding is best-effort
-                        log::debug!(
-                            target: "kakehashi::cancel",
-                            "Failed to forward cancel for request {}: {}",
-                            upstream_id,
-                            e
-                        );
-                    }
-                });
+                Some((forwarder.clone(), upstream_id, generation))
+            } else {
+                None
             }
-        }
+        } else {
+            None
+        };
 
         // Intercept window/workDoneProgress/cancel and route it to the downstream
         // that owns the progress token (window-work-done-progress bridging).
@@ -505,6 +482,24 @@ where
 
         Box::pin(async move {
             let _active_request = active_request;
+            // Capture downstream targets and queue their cancels before tower-lsp
+            // observes the client notification. Polling the inner future first can
+            // abort the request handler, whose guards remove the registry/router
+            // state needed to translate the upstream request ID.
+            if let Some((forwarder, upstream_id, generation)) = cancel_request
+                && let Err(e) = forwarder
+                    .forward_cancel_for_generation(upstream_id.clone(), Some(generation))
+                    .await
+            {
+                // Cancellation is best-effort: an unavailable downstream must
+                // not prevent tower-lsp from handling the client notification.
+                log::debug!(
+                    target: "kakehashi::cancel",
+                    "Failed to forward cancel for request {}: {}",
+                    upstream_id,
+                    e
+                );
+            }
             // Set the task-local request ID and await the inner future
             CURRENT_REQUEST_ID.scope(request_id, inner_fut).await
         })

--- a/src/lsp/request_id.rs
+++ b/src/lsp/request_id.rs
@@ -120,34 +120,12 @@ impl CancelForwarder {
     /// downstream `$/cancelRequest` (capture-before-notify; see
     /// `forward_cancel_by_upstream_id_with_notify`).
     #[cfg(test)]
-    pub(crate) async fn forward_cancel(&self, upstream_id: UpstreamId) -> std::io::Result<()> {
+    pub(crate) fn forward_cancel(&self, upstream_id: UpstreamId) -> std::io::Result<()> {
         let generation = self.request_generation(&upstream_id);
         self.forward_cancel_for_generation(upstream_id, generation)
-            .await
     }
 
-    #[cfg(test)]
-    async fn forward_cancel_for_generation(
-        &self,
-        upstream_id: UpstreamId,
-        generation: Option<u64>,
-    ) -> std::io::Result<()> {
-        let validate_forwarder = self.clone();
-        let notify_forwarder = self.clone();
-        let validate_id = upstream_id.clone();
-        let notify_id = upstream_id.clone();
-        self.pool
-            .forward_cancel_by_upstream_id_if_current(
-                upstream_id,
-                move || validate_forwarder.request_generation(&validate_id) == generation,
-                move || {
-                    notify_forwarder.notify_cancel_for_generation(&notify_id, generation);
-                },
-            )
-            .await
-    }
-
-    fn forward_cancel_for_generation_sync(
+    fn forward_cancel_for_generation(
         &self,
         upstream_id: UpstreamId,
         generation: Option<u64>,
@@ -512,7 +490,7 @@ where
         // exact handles needed to do this without awaiting the connections map.
         if let Some((forwarder, upstream_id, generation)) = cancel_request
             && let Err(error) =
-                forwarder.forward_cancel_for_generation_sync(upstream_id.clone(), Some(generation))
+                forwarder.forward_cancel_for_generation(upstream_id.clone(), Some(generation))
         {
             log::debug!(
                 target: "kakehashi::cancel",
@@ -947,7 +925,6 @@ mod tests {
         let mut new_request_cancel = forwarder.subscribe(upstream_id.clone()).unwrap();
         forwarder
             .forward_cancel_for_generation(upstream_id, old_generation)
-            .await
             .unwrap();
 
         assert!(matches!(

--- a/src/lsp/request_id.rs
+++ b/src/lsp/request_id.rs
@@ -88,6 +88,9 @@ type CancelSubscriberRegistry = std::sync::Mutex<CancelSubscriberState>;
 #[derive(Clone)]
 pub struct CancelForwarder {
     pool: Arc<LanguageServerPool>,
+    /// Serializes synchronous middleware admission/cancellation so a raw JSON-RPC
+    /// ID cannot be reused between generation validation and tower-lsp's `call`.
+    dispatch_gate: Arc<std::sync::Mutex<()>>,
     /// Registry of subscribers waiting for cancel notifications.
     ///
     /// When a `$/cancelRequest` arrives, we look up the sender and notify it.
@@ -100,6 +103,7 @@ impl CancelForwarder {
     pub fn new(pool: Arc<LanguageServerPool>) -> Self {
         Self {
             pool,
+            dispatch_gate: Arc::new(std::sync::Mutex::new(())),
             subscribers: Arc::new(std::sync::Mutex::new(CancelSubscriberState::default())),
         }
     }
@@ -122,6 +126,7 @@ impl CancelForwarder {
             .await
     }
 
+    #[cfg(test)]
     async fn forward_cancel_for_generation(
         &self,
         upstream_id: UpstreamId,
@@ -140,6 +145,24 @@ impl CancelForwarder {
                 },
             )
             .await
+    }
+
+    fn forward_cancel_for_generation_sync(
+        &self,
+        upstream_id: UpstreamId,
+        generation: Option<u64>,
+    ) -> std::io::Result<()> {
+        let validate_forwarder = self.clone();
+        let notify_forwarder = self.clone();
+        let validate_id = upstream_id.clone();
+        let notify_id = upstream_id.clone();
+        self.pool.forward_cancel_by_upstream_id_if_current_sync(
+            upstream_id,
+            move || validate_forwarder.request_generation(&validate_id) == generation,
+            move || {
+                notify_forwarder.notify_cancel_for_generation(&notify_id, generation);
+            },
+        )
     }
 
     /// Forward a client `window/workDoneProgress/cancel` to the downstream that
@@ -410,12 +433,18 @@ where
     }
 
     fn call(&mut self, req: Request) -> Self::Future {
+        let cancel_forwarder = self.cancel_forwarder.clone();
+        let _dispatch_guard = cancel_forwarder.as_ref().map(|forwarder| {
+            forwarder
+                .dispatch_gate
+                .lock()
+                .recover_poison("RequestIdCapture::call")
+        });
         // Extract the request ID before delegating
         let request_id = req.id().cloned();
 
         // Check if this is a $/cancelRequest notification and forward to downstream
         // Per LSP spec, cancel params.id can be either integer or string
-        let cancel_forwarder = self.cancel_forwarder.clone();
         let is_cancel_notification = matches!(
             req.method(),
             "$/cancelRequest" | "window/workDoneProgress/cancel"
@@ -477,41 +506,25 @@ where
             });
         }
 
-        // Call inner service and get the future
+        // tower-lsp applies raw-ID cancellation synchronously inside `call`.
+        // Capture downstream targets, notify generation-scoped subscribers, and
+        // enqueue downstream cancels first; production registrations retain the
+        // exact handles needed to do this without awaiting the connections map.
+        if let Some((forwarder, upstream_id, generation)) = cancel_request
+            && let Err(error) =
+                forwarder.forward_cancel_for_generation_sync(upstream_id.clone(), Some(generation))
+        {
+            log::debug!(
+                target: "kakehashi::cancel",
+                "Failed to forward cancel for request {}: {}",
+                upstream_id,
+                error
+            );
+        }
         let inner_fut = self.inner.call(req);
 
         Box::pin(async move {
             let _active_request = active_request;
-            // Capture downstream targets and queue their cancels before tower-lsp
-            // observes the client notification. Polling the inner future first can
-            // abort the request handler, whose guards remove the registry/router
-            // state needed to translate the upstream request ID.
-            if let Some((forwarder, upstream_id, generation)) = cancel_request {
-                if let Err(e) = forwarder
-                    .forward_cancel_for_generation(upstream_id.clone(), Some(generation))
-                    .await
-                {
-                    // Cancellation is best-effort: an unavailable downstream must
-                    // not prevent tower-lsp from handling the client notification.
-                    log::debug!(
-                        target: "kakehashi::cancel",
-                        "Failed to forward cancel for request {}: {}",
-                        upstream_id,
-                        e
-                    );
-                }
-                // The pool lookup above may have waited while the old request
-                // completed and the client reused its raw JSON-RPC ID. In that
-                // case the generation-aware forwarder correctly ignored the stale
-                // cancel; do not then let tower-lsp apply that same raw ID to the
-                // replacement request. With no await between this check and the
-                // inner future's first poll, a still-current cancel reaches tower
-                // before another task can reuse the ID.
-                if forwarder.request_generation(&upstream_id) != Some(generation) {
-                    return Ok(None);
-                }
-            }
-            // Set the task-local request ID and await the inner future
             CURRENT_REQUEST_ID.scope(request_id, inner_fut).await
         })
     }
@@ -541,6 +554,7 @@ pub(crate) fn current_upstream_id() -> Option<UpstreamId> {
 mod tests {
     use super::*;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::sync::Mutex;
 
     /// Mock service that records whether it was called and captures the request ID
@@ -579,6 +593,34 @@ mod tests {
                 *captured_id.lock().await = Some(id);
                 Ok(None)
             })
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct SynchronousCallService {
+        calls: Arc<AtomicUsize>,
+        cancel_rx: Arc<std::sync::Mutex<Option<CancelReceiver>>>,
+        cancel_was_forwarded_before_inner: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl Service<Request> for SynchronousCallService {
+        type Response = Option<Response>;
+        type Error = std::convert::Infallible;
+        type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, req: Request) -> Self::Future {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if req.method() == "$/cancelRequest"
+                && let Some(mut cancel_rx) = self.cancel_rx.lock().unwrap().take()
+            {
+                self.cancel_was_forwarded_before_inner
+                    .store(matches!(cancel_rx.try_recv(), Ok(())), Ordering::SeqCst);
+            }
+            std::future::ready(Ok(None))
         }
     }
 
@@ -695,7 +737,7 @@ mod tests {
         // The notification should be processed (no error)
         assert!(result.is_ok());
 
-        // The inner service was still called (tower-lsp needs to see it too)
+        // The inner service is still called after synchronous forwarding.
         let captured = mock.get_captured_id().await;
         assert!(captured.is_some(), "Inner service should still be called");
 
@@ -916,11 +958,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn middleware_delayed_cancel_does_not_reach_tower_for_reused_id() {
-        let mock = MockService::new();
+    async fn middleware_forwards_before_synchronous_inner_cancel() {
+        let inner = SynchronousCallService::default();
+        let calls = Arc::clone(&inner.calls);
+        let cancel_rx_slot = Arc::clone(&inner.cancel_rx);
+        let forwarded_before_inner = Arc::clone(&inner.cancel_was_forwarded_before_inner);
         let pool = Arc::new(LanguageServerPool::new());
         let forwarder = CancelForwarder::new(pool);
-        let mut service = RequestIdCapture::with_cancel_forwarder(mock.clone(), forwarder.clone());
+        let mut service = RequestIdCapture::with_cancel_forwarder(inner, forwarder.clone());
         let upstream_id = UpstreamId::Number(123);
         let request = || {
             Request::build("textDocument/hover")
@@ -930,10 +975,20 @@ mod tests {
         };
 
         let old_request = service.call(request());
+        *cancel_rx_slot.lock().unwrap() = Some(forwarder.subscribe(upstream_id.clone()).unwrap());
         let delayed_cancel = service.call(
             Request::build("$/cancelRequest")
                 .params(serde_json::json!({ "id": 123 }))
                 .finish(),
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "the inner cancel call must run synchronously after forwarding"
+        );
+        assert!(
+            forwarded_before_inner.load(Ordering::SeqCst),
+            "generation-scoped forwarding must notify before the inner cancel call"
         );
         drop(old_request);
 
@@ -941,11 +996,6 @@ mod tests {
         let mut new_request_cancel = forwarder.subscribe(upstream_id).unwrap();
         delayed_cancel.await.unwrap();
 
-        assert_eq!(
-            mock.get_captured_id().await,
-            None,
-            "stale cancel must not poll tower-lsp's raw-ID cancellation future"
-        );
         assert!(matches!(
             new_request_cancel.try_recv(),
             Err(tokio::sync::oneshot::error::TryRecvError::Empty)

--- a/src/lsp/request_id.rs
+++ b/src/lsp/request_id.rs
@@ -486,19 +486,30 @@ where
             // observes the client notification. Polling the inner future first can
             // abort the request handler, whose guards remove the registry/router
             // state needed to translate the upstream request ID.
-            if let Some((forwarder, upstream_id, generation)) = cancel_request
-                && let Err(e) = forwarder
+            if let Some((forwarder, upstream_id, generation)) = cancel_request {
+                if let Err(e) = forwarder
                     .forward_cancel_for_generation(upstream_id.clone(), Some(generation))
                     .await
-            {
-                // Cancellation is best-effort: an unavailable downstream must
-                // not prevent tower-lsp from handling the client notification.
-                log::debug!(
-                    target: "kakehashi::cancel",
-                    "Failed to forward cancel for request {}: {}",
-                    upstream_id,
-                    e
-                );
+                {
+                    // Cancellation is best-effort: an unavailable downstream must
+                    // not prevent tower-lsp from handling the client notification.
+                    log::debug!(
+                        target: "kakehashi::cancel",
+                        "Failed to forward cancel for request {}: {}",
+                        upstream_id,
+                        e
+                    );
+                }
+                // The pool lookup above may have waited while the old request
+                // completed and the client reused its raw JSON-RPC ID. In that
+                // case the generation-aware forwarder correctly ignored the stale
+                // cancel; do not then let tower-lsp apply that same raw ID to the
+                // replacement request. With no await between this check and the
+                // inner future's first poll, a still-current cancel reaches tower
+                // before another task can reuse the ID.
+                if forwarder.request_generation(&upstream_id) != Some(generation) {
+                    return Ok(None);
+                }
             }
             // Set the task-local request ID and await the inner future
             CURRENT_REQUEST_ID.scope(request_id, inner_fut).await
@@ -897,6 +908,44 @@ mod tests {
             .await
             .unwrap();
 
+        assert!(matches!(
+            new_request_cancel.try_recv(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+        ));
+        drop(new_request);
+    }
+
+    #[tokio::test]
+    async fn middleware_delayed_cancel_does_not_reach_tower_for_reused_id() {
+        let mock = MockService::new();
+        let pool = Arc::new(LanguageServerPool::new());
+        let forwarder = CancelForwarder::new(pool);
+        let mut service = RequestIdCapture::with_cancel_forwarder(mock.clone(), forwarder.clone());
+        let upstream_id = UpstreamId::Number(123);
+        let request = || {
+            Request::build("textDocument/hover")
+                .params(serde_json::json!({}))
+                .id(123i64)
+                .finish()
+        };
+
+        let old_request = service.call(request());
+        let delayed_cancel = service.call(
+            Request::build("$/cancelRequest")
+                .params(serde_json::json!({ "id": 123 }))
+                .finish(),
+        );
+        drop(old_request);
+
+        let new_request = service.call(request());
+        let mut new_request_cancel = forwarder.subscribe(upstream_id).unwrap();
+        delayed_cancel.await.unwrap();
+
+        assert_eq!(
+            mock.get_captured_id().await,
+            None,
+            "stale cancel must not poll tower-lsp's raw-ID cancellation future"
+        );
         assert!(matches!(
             new_request_cancel.try_recv(),
             Err(tokio::sync::oneshot::error::TryRecvError::Empty)

--- a/src/lsp/request_id.rs
+++ b/src/lsp/request_id.rs
@@ -88,9 +88,6 @@ type CancelSubscriberRegistry = std::sync::Mutex<CancelSubscriberState>;
 #[derive(Clone)]
 pub struct CancelForwarder {
     pool: Arc<LanguageServerPool>,
-    /// Serializes synchronous middleware admission/cancellation so a raw JSON-RPC
-    /// ID cannot be reused between generation validation and tower-lsp's `call`.
-    dispatch_gate: Arc<std::sync::Mutex<()>>,
     /// Registry of subscribers waiting for cancel notifications.
     ///
     /// When a `$/cancelRequest` arrives, we look up the sender and notify it.
@@ -103,7 +100,6 @@ impl CancelForwarder {
     pub fn new(pool: Arc<LanguageServerPool>) -> Self {
         Self {
             pool,
-            dispatch_gate: Arc::new(std::sync::Mutex::new(())),
             subscribers: Arc::new(std::sync::Mutex::new(CancelSubscriberState::default())),
         }
     }
@@ -411,13 +407,13 @@ where
     }
 
     fn call(&mut self, req: Request) -> Self::Future {
+        // Everything below runs synchronously inside `call`, which tower-lsp's
+        // transport invokes from its single stdin reader task in wire order
+        // (`concurrency_level` bounds the returned futures, not `call`). That
+        // alone orders generation registration, cancel capture, and tower-lsp's
+        // raw-ID cancellation against a reused JSON-RPC ID; no extra lock is
+        // needed here, and one would only sit uncontended on the hot path.
         let cancel_forwarder = self.cancel_forwarder.clone();
-        let _dispatch_guard = cancel_forwarder.as_ref().map(|forwarder| {
-            forwarder
-                .dispatch_gate
-                .lock()
-                .recover_poison("RequestIdCapture::call")
-        });
         // Extract the request ID before delegating
         let request_id = req.id().cloned();
 

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -44,7 +44,12 @@
 //!   answers `textDocument/codeLens` with one UNRESOLVED lens (data only) and
 //!   `codeLens/resolve` by materializing a command that echoes the lens data.
 //!   Used by `tests/e2e/e2e_code_lens_resolve.rs` (#355).
-//! - `document-link` / `document-link-resolve` / `document-link-resolve-replacement` — advertise `documentLinkProvider`; answers
+//! - `document-link-no-resolve-plain-data` /
+//!   `document-link-no-resolve-reserved-data` — advertise
+//!   `documentLinkProvider` with `resolveProvider: false` and answer with a
+//!   link carrying opaque `data`: an ordinary payload, and one that occupies
+//!   the reserved `kakehashi` key.
+//! - `document-link` / `document-link-resolve` / `document-link-resolve-replacement` — advertise
 //!   `textDocument/documentLink` with one link whose tooltip identifies the
 //!   requested URI. The resolve mode initially returns data only and materializes
 //!   target/tooltip on `documentLink/resolve`.
@@ -210,7 +215,8 @@ fn main() {
                             "textDocumentSync": 1
                         })
                     }
-                    "document-link-no-resolve-reserved-data" => json!({
+                    "document-link-no-resolve-reserved-data"
+                    | "document-link-no-resolve-plain-data" => json!({
                         "documentLinkProvider": { "resolveProvider": false },
                         "textDocumentSync": 1
                     }),
@@ -1395,6 +1401,8 @@ fn main() {
                             link["data"] = json!({ "mock": "link-1", "uri": uri });
                         } else if mode == "document-link-no-resolve-reserved-data" {
                             link["data"] = json!({ "kakehashi": { "origin": "forged" } });
+                        } else if mode == "document-link-no-resolve-plain-data" {
+                            link["data"] = json!({ "mock": "link-1", "uri": uri });
                         } else {
                             link["tooltip"] = json!(format!("mock-link:{uri}"));
                             link["target"] = json!(uri);

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -44,9 +44,10 @@
 //!   answers `textDocument/codeLens` with one UNRESOLVED lens (data only) and
 //!   `codeLens/resolve` by materializing a command that echoes the lens data.
 //!   Used by `tests/e2e/e2e_code_lens_resolve.rs` (#355).
-//! - `document-link` — advertises `documentLinkProvider`; answers
+//! - `document-link` / `document-link-resolve` — advertise `documentLinkProvider`; answers
 //!   `textDocument/documentLink` with one link whose tooltip identifies the
-//!   requested URI.
+//!   requested URI. The resolve mode initially returns data only and materializes
+//!   target/tooltip on `documentLink/resolve`.
 //! - `document-link-slow-host` / `document-link-slow-virt` — like
 //!   `document-link`, but sleeps before answering and records request-start
 //!   and downstream `$/cancelRequest` markers under `MOCK_LSP_CANCEL_DIR`.
@@ -195,6 +196,10 @@ fn main() {
                     }),
                     "code-lens-no-resolve" | "code-lens-no-resolve-reserved-data" => json!({
                         "codeLensProvider": { "resolveProvider": false },
+                        "textDocumentSync": 1
+                    }),
+                    "document-link-resolve" => json!({
+                        "documentLinkProvider": { "resolveProvider": true },
                         "textDocumentSync": 1
                     }),
                     "document-link" | "document-link-slow-host" | "document-link-slow-virt" => {
@@ -1369,17 +1374,45 @@ fn main() {
                     .and_then(Value::as_str)
                     .filter(|uri| documents.contains_key(*uri))
                     .map(|uri| {
-                        json!([{
+                        let mut link = json!({
                             "range": {
                                 "start": { "line": 0, "character": 0 },
                                 "end": { "line": 0, "character": 1 }
                             },
-                            "tooltip": format!("mock-link:{uri}"),
-                            "target": uri
-                        }])
+                        });
+                        if mode == "document-link-resolve" {
+                            link["data"] = json!({ "mock": "link-1", "uri": uri });
+                        } else {
+                            link["tooltip"] = json!(format!("mock-link:{uri}"));
+                            link["target"] = json!(uri);
+                        }
+                        json!([link])
                     })
                     .unwrap_or(Value::Null);
                 respond(&mut writer, id, result);
+            }
+            "documentLink/resolve" => {
+                let data = message
+                    .pointer("/params/data")
+                    .cloned()
+                    .unwrap_or(Value::Null);
+                let range = message
+                    .pointer("/params/range")
+                    .cloned()
+                    .unwrap_or(Value::Null);
+                respond(
+                    &mut writer,
+                    id,
+                    json!({
+                        "range": range,
+                        "target": data["uri"],
+                        "tooltip": format!(
+                            "mock resolved:{}",
+                            data["mock"].as_str().unwrap_or("?")
+                        ),
+                        "data": data
+                    }),
+                );
             }
             "textDocument/onTypeFormatting" => {
                 // Answer with the whole-document transformation REGARDLESS of

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -44,7 +44,7 @@
 //!   answers `textDocument/codeLens` with one UNRESOLVED lens (data only) and
 //!   `codeLens/resolve` by materializing a command that echoes the lens data.
 //!   Used by `tests/e2e/e2e_code_lens_resolve.rs` (#355).
-//! - `document-link` / `document-link-resolve` — advertise `documentLinkProvider`; answers
+//! - `document-link` / `document-link-resolve` / `document-link-resolve-replacement` — advertise `documentLinkProvider`; answers
 //!   `textDocument/documentLink` with one link whose tooltip identifies the
 //!   requested URI. The resolve mode initially returns data only and materializes
 //!   target/tooltip on `documentLink/resolve`.
@@ -198,7 +198,9 @@ fn main() {
                         "codeLensProvider": { "resolveProvider": false },
                         "textDocumentSync": 1
                     }),
-                    "document-link-resolve" => json!({
+                    "document-link-resolve"
+                    | "document-link-resolve-replacement"
+                    | "document-link-slow-resolve" => json!({
                         "documentLinkProvider": { "resolveProvider": true },
                         "textDocumentSync": 1
                     }),
@@ -208,6 +210,10 @@ fn main() {
                             "textDocumentSync": 1
                         })
                     }
+                    "document-link-no-resolve-reserved-data" => json!({
+                        "documentLinkProvider": { "resolveProvider": false },
+                        "textDocumentSync": 1
+                    }),
                     "code-action" | "code-action-preferred" | "code-action-reopen-order" => json!({
                         "codeActionProvider": true,
                         "executeCommandProvider": { "commands": ["mock.run"] },
@@ -1380,8 +1386,15 @@ fn main() {
                                 "end": { "line": 0, "character": 1 }
                             },
                         });
-                        if mode == "document-link-resolve" {
+                        if matches!(
+                            mode.as_str(),
+                            "document-link-resolve"
+                                | "document-link-resolve-replacement"
+                                | "document-link-slow-resolve"
+                        ) {
                             link["data"] = json!({ "mock": "link-1", "uri": uri });
+                        } else if mode == "document-link-no-resolve-reserved-data" {
+                            link["data"] = json!({ "kakehashi": { "origin": "forged" } });
                         } else {
                             link["tooltip"] = json!(format!("mock-link:{uri}"));
                             link["target"] = json!(uri);
@@ -1392,7 +1405,21 @@ fn main() {
                 respond(&mut writer, id, result);
             }
             "documentLink/resolve" => {
-                let data = message
+                if mode == "document-link-slow-resolve" {
+                    record_mock_event(&mode, "request", &message);
+                    // Give the bridge writer time to record sent-state, then
+                    // send an editor-visible barrier. The cancellation E2E
+                    // waits for this notification before cancelling, avoiding
+                    // a filesystem-observation race with writer bookkeeping.
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                    notify(
+                        &mut writer,
+                        "window/logMessage",
+                        json!({ "type": 2, "message": "document-link-resolve-started" }),
+                    );
+                    continue;
+                }
+                let mut data = message
                     .pointer("/params/data")
                     .cloned()
                     .unwrap_or(Value::Null);
@@ -1400,6 +1427,7 @@ fn main() {
                     .pointer("/params/range")
                     .cloned()
                     .unwrap_or(Value::Null);
+                data["receivedRange"] = range.clone();
                 respond(
                     &mut writer,
                     id,
@@ -1407,7 +1435,12 @@ fn main() {
                         "range": range,
                         "target": data["uri"],
                         "tooltip": format!(
-                            "mock resolved:{}",
+                            "{} resolved:{}",
+                            if mode == "document-link-resolve-replacement" {
+                                "replacement"
+                            } else {
+                                "mock"
+                            },
                             data["mock"].as_str().unwrap_or("?")
                         ),
                         "data": data

--- a/tests/e2e/e2e_lsp_lua_document_link.rs
+++ b/tests/e2e/e2e_lsp_lua_document_link.rs
@@ -224,6 +224,10 @@ fn assert_virtual_document_link_replacement_fails_soft(change_pool_key: bool) {
             old_envelope["connection_key"],
             replacement_envelope["connection_key"]
         );
+        assert_eq!(
+            old_envelope["connection_generation"], replacement_envelope["connection_generation"],
+            "different keys should demonstrate the equal-generation collision"
+        );
     } else {
         assert_eq!(
             old_envelope["connection_key"],
@@ -369,6 +373,10 @@ fn assert_host_document_link_replacement_fails_soft(change_pool_key: bool) {
             old_envelope["connection_key"],
             replacement_envelope["connection_key"]
         );
+        assert_eq!(
+            old_envelope["connection_generation"], replacement_envelope["connection_generation"],
+            "different keys should demonstrate the equal-generation collision"
+        );
     } else {
         assert_eq!(
             old_envelope["connection_key"],
@@ -458,10 +466,10 @@ fn e2e_host_document_link_reserved_data_cannot_impersonate_routing_envelope() {
     );
     assert_eq!(link["data"]["kakehashi"]["origin"], "mock-document-link");
 
-    let response = client.send_request("documentLink/resolve", link);
+    let response = client.send_request("documentLink/resolve", link.clone());
     assert_eq!(
-        response["result"]["data"]["kakehashi"]["inner"]["kakehashi"]["origin"],
-        "forged"
+        response["result"], link,
+        "a server without resolveProvider must not receive documentLink/resolve"
     );
     shutdown_client(&mut client);
 }

--- a/tests/e2e/e2e_lsp_lua_document_link.rs
+++ b/tests/e2e/e2e_lsp_lua_document_link.rs
@@ -471,6 +471,73 @@ fn e2e_host_document_link_from_closed_incarnation_stays_unresolved() {
 }
 
 #[test]
+fn e2e_virtual_document_link_from_non_resolving_server_keeps_its_data() {
+    let (mut client, _config_dir) =
+        init_mock_document_link_client("document-link-no-resolve-plain-data", "lua", false, None);
+    let uri = "file:///test_virtual_document_link_plain_data.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({ "textDocument": {
+            "uri": uri,
+            "languageId": "markdown",
+            "version": 1,
+            "text": "# Test\n\n```lua\nlocal x = 1\n```\n"
+        }}),
+    );
+    let link = document_links_with_retry(&mut client, uri).remove(0);
+    assert_eq!(
+        link["range"]["start"]["line"], 3,
+        "ranges are translated to host coordinates regardless of the envelope"
+    );
+    assert!(
+        link["data"].get("kakehashi").is_none(),
+        "a producer that cannot resolve must keep its own payload: {link}"
+    );
+    assert_eq!(link["data"]["mock"], "link-1");
+    shutdown_client(&mut client);
+}
+
+#[test]
+fn e2e_virtual_document_link_reserved_data_cannot_impersonate_routing_envelope() {
+    let (mut client, _config_dir) = init_mock_document_link_client(
+        "document-link-no-resolve-reserved-data",
+        "lua",
+        false,
+        None,
+    );
+    let uri = "file:///test_virtual_document_link_reserved_data.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({ "textDocument": {
+            "uri": uri,
+            "languageId": "markdown",
+            "version": 1,
+            "text": "# Test\n\n```lua\nlocal x = 1\n```\n"
+        }}),
+    );
+    let link = document_links_with_retry(&mut client, uri).remove(0);
+    assert_eq!(
+        link["data"]["kakehashi"]["inner"]["kakehashi"]["origin"], "forged",
+        "the foreign payload must be nested, not honored: {link}"
+    );
+    assert_eq!(link["data"]["kakehashi"]["origin"], "mock-document-link");
+    assert!(
+        !link["data"]["kakehashi"]["region_id"]
+            .as_str()
+            .expect("virtual envelopes carry a region id")
+            .is_empty(),
+        "this must be the injection layer, not a host-layer envelope"
+    );
+
+    let response = client.send_request("documentLink/resolve", link.clone());
+    assert_eq!(
+        response["result"], link,
+        "a server without resolveProvider must not receive documentLink/resolve"
+    );
+    shutdown_client(&mut client);
+}
+
+#[test]
 fn e2e_host_document_link_reserved_data_cannot_impersonate_routing_envelope() {
     let (mut client, _config_dir) = init_mock_document_link_client(
         "document-link-no-resolve-reserved-data",

--- a/tests/e2e/e2e_lsp_lua_document_link.rs
+++ b/tests/e2e/e2e_lsp_lua_document_link.rs
@@ -40,6 +40,52 @@ fn document_links_with_retry(client: &mut LspClient, uri: &str) -> Vec<Value> {
     panic!("timed out waiting for a document link");
 }
 
+fn init_mock_document_link_client(
+    mode: &str,
+    language: &str,
+    host: bool,
+    cancel_dir: Option<&std::path::Path>,
+) -> (LspClient, tempfile::TempDir) {
+    let config_dir = tempfile::TempDir::new().expect("config temp dir");
+    let config_path = config_dir.path().join("document_link_resolve.toml");
+    std::fs::write(&config_path, "").expect("write config");
+    let builder = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("UTF-8 config path"));
+    let builder = match cancel_dir {
+        Some(dir) => builder.env("MOCK_LSP_CANCEL_DIR", dir.to_string_lossy()),
+        None => builder,
+    };
+    let mut client = builder.build();
+    let mut initialization_options = json!({ "languageServers": {
+        "mock-document-link": {
+            "cmd": [mock_formatter_bin(), mode],
+            "languages": [language]
+        }
+    }});
+    if host {
+        initialization_options["languages"] = json!({
+            (language): { "bridge": { "_self": { "enabled": true } } }
+        });
+    }
+    let init = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": initialization_options
+        }),
+    );
+    assert_eq!(
+        init["result"]["capabilities"]["documentLinkProvider"]["resolveProvider"],
+        json!(true)
+    );
+    client.send_notification("initialized", json!({}));
+    (client, config_dir)
+}
+
 #[test]
 fn e2e_document_link_resolve_round_trips_to_virtual_origin() {
     let config_dir = tempfile::TempDir::new().expect("config temp dir");
@@ -99,6 +145,11 @@ fn e2e_document_link_resolve_round_trips_to_virtual_origin() {
         resolved["data"]["kakehashi"]["inner"]["uri"]
     );
     assert_eq!(resolved["range"], link["range"]);
+    assert_eq!(
+        resolved["data"]["kakehashi"]["inner"]["receivedRange"]["start"],
+        json!({ "line": 0, "character": 0 }),
+        "the producer must receive its original injection-local range"
+    );
 
     client.send_notification(
         "textDocument/didChange",
@@ -123,6 +174,95 @@ fn e2e_document_link_resolve_round_trips_to_virtual_origin() {
     assert_eq!(stale["data"]["kakehashi"]["origin"], "mock-document-link");
 
     shutdown_client(&mut client);
+}
+
+fn assert_virtual_document_link_replacement_fails_soft(change_pool_key: bool) {
+    let (mut client, _config_dir) =
+        init_mock_document_link_client("document-link-resolve", "lua", false, None);
+    let uri = "file:///test_document_link_replacement.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({ "textDocument": {
+            "uri": uri,
+            "languageId": "markdown",
+            "version": 1,
+            "text": "# Test\n\n```lua\nlocal x = 1\n```\n"
+        }}),
+    );
+    let old_link = document_links_with_retry(&mut client, uri).remove(0);
+
+    let mut server = json!({
+        "cmd": [mock_formatter_bin(), "document-link-resolve-replacement"],
+        "languages": ["lua"]
+    });
+    if change_pool_key {
+        server["preferSharedInstance"] = json!(true);
+    }
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({ "settings": { "languageServers": { "mock-document-link": server } } }),
+    );
+    client.send_notification(
+        "textDocument/didClose",
+        json!({ "textDocument": { "uri": uri } }),
+    );
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({ "textDocument": {
+            "uri": uri,
+            "languageId": "markdown",
+            "version": 1,
+            "text": "# Test\n\n```lua\nlocal x = 1\n```\n"
+        }}),
+    );
+
+    let replacement_link = document_links_with_retry(&mut client, uri).remove(0);
+    let old_envelope = &old_link["data"]["kakehashi"];
+    let replacement_envelope = &replacement_link["data"]["kakehashi"];
+    if change_pool_key {
+        assert_ne!(
+            old_envelope["connection_key"],
+            replacement_envelope["connection_key"]
+        );
+    } else {
+        assert_eq!(
+            old_envelope["connection_key"],
+            replacement_envelope["connection_key"]
+        );
+        assert_ne!(
+            old_envelope["connection_generation"],
+            replacement_envelope["connection_generation"]
+        );
+    }
+
+    let replacement = client.send_request("documentLink/resolve", replacement_link.clone());
+    assert_eq!(
+        replacement["result"]["tooltip"],
+        "replacement resolved:link-1"
+    );
+
+    let mut stale_link = replacement_link;
+    stale_link["data"]["kakehashi"]["connection_key"] = old_envelope["connection_key"].clone();
+    stale_link["data"]["kakehashi"]["connection_generation"] =
+        old_envelope["connection_generation"].clone();
+    stale_link["data"]["kakehashi"]["inner"] = old_envelope["inner"].clone();
+    let stale_data = stale_link["data"].clone();
+    let stale = client.send_request("documentLink/resolve", stale_link);
+    assert!(stale.get("error").is_none(), "unexpected response: {stale}");
+    assert!(stale["result"].get("target").is_none() || stale["result"]["target"].is_null());
+    assert_eq!(stale["result"]["data"], stale_data);
+
+    shutdown_client(&mut client);
+}
+
+#[test]
+fn e2e_virtual_document_link_from_same_key_replacement_stays_unresolved() {
+    assert_virtual_document_link_replacement_fails_soft(false);
+}
+
+#[test]
+fn e2e_virtual_document_link_from_different_key_replacement_stays_unresolved() {
+    assert_virtual_document_link_replacement_fails_soft(true);
 }
 
 #[test]
@@ -187,6 +327,204 @@ fn e2e_document_link_resolve_round_trips_to_host_origin() {
     assert_eq!(resolved["range"], link["range"]);
     assert_eq!(resolved["data"]["kakehashi"]["host_layer"], true);
 
+    shutdown_client(&mut client);
+}
+
+fn assert_host_document_link_replacement_fails_soft(change_pool_key: bool) {
+    let (mut client, _config_dir) =
+        init_mock_document_link_client("document-link-resolve", "markdown", true, None);
+    let uri = "file:///test_host_document_link_replacement.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({ "textDocument": {
+            "uri": uri,
+            "languageId": "markdown",
+            "version": 1,
+            "text": "# Host link\n"
+        }}),
+    );
+    let old_link = document_links_with_retry(&mut client, uri).remove(0);
+
+    let mut server = json!({
+        "cmd": [mock_formatter_bin(), "document-link-resolve-replacement"],
+        "languages": ["markdown"]
+    });
+    if change_pool_key {
+        server["preferSharedInstance"] = json!(true);
+    }
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({ "settings": {
+            "languageServers": { "mock-document-link": server },
+            "languages": {
+                "markdown": { "bridge": { "_self": { "enabled": true } } }
+            }
+        }}),
+    );
+    let replacement_link = document_links_with_retry(&mut client, uri).remove(0);
+    let old_envelope = &old_link["data"]["kakehashi"];
+    let replacement_envelope = &replacement_link["data"]["kakehashi"];
+    if change_pool_key {
+        assert_ne!(
+            old_envelope["connection_key"],
+            replacement_envelope["connection_key"]
+        );
+    } else {
+        assert_eq!(
+            old_envelope["connection_key"],
+            replacement_envelope["connection_key"]
+        );
+        assert_ne!(
+            old_envelope["connection_generation"],
+            replacement_envelope["connection_generation"]
+        );
+    }
+    let replacement = client.send_request("documentLink/resolve", replacement_link);
+    assert_eq!(
+        replacement["result"]["tooltip"],
+        "replacement resolved:link-1"
+    );
+
+    let old_data = old_link["data"].clone();
+    let stale = client.send_request("documentLink/resolve", old_link);
+    assert!(stale["result"].get("target").is_none() || stale["result"]["target"].is_null());
+    assert_eq!(stale["result"]["data"], old_data);
+    shutdown_client(&mut client);
+}
+
+#[test]
+fn e2e_host_document_link_from_same_key_replacement_stays_unresolved() {
+    assert_host_document_link_replacement_fails_soft(false);
+}
+
+#[test]
+fn e2e_host_document_link_from_different_key_replacement_stays_unresolved() {
+    assert_host_document_link_replacement_fails_soft(true);
+}
+
+#[test]
+fn e2e_host_document_link_from_closed_incarnation_stays_unresolved() {
+    let (mut client, _config_dir) =
+        init_mock_document_link_client("document-link-resolve", "markdown", true, None);
+    let uri = "file:///test_host_document_link_reopen.md";
+    let open = |client: &mut LspClient| {
+        client.send_notification(
+            "textDocument/didOpen",
+            json!({ "textDocument": {
+                "uri": uri,
+                "languageId": "markdown",
+                "version": 1,
+                "text": "# Host link\n"
+            }}),
+        );
+    };
+    open(&mut client);
+    let old_link = document_links_with_retry(&mut client, uri).remove(0);
+    client.send_notification(
+        "textDocument/didClose",
+        json!({ "textDocument": { "uri": uri } }),
+    );
+    open(&mut client);
+    let _replacement = document_links_with_retry(&mut client, uri);
+
+    let stale = client.send_request("documentLink/resolve", old_link);
+    assert!(stale["result"].get("target").is_none() || stale["result"]["target"].is_null());
+    assert_eq!(stale["result"]["data"]["kakehashi"]["host_layer"], true);
+    shutdown_client(&mut client);
+}
+
+#[test]
+fn e2e_host_document_link_reserved_data_cannot_impersonate_routing_envelope() {
+    let (mut client, _config_dir) = init_mock_document_link_client(
+        "document-link-no-resolve-reserved-data",
+        "markdown",
+        true,
+        None,
+    );
+    let uri = "file:///test_host_document_link_reserved_data.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({ "textDocument": {
+            "uri": uri,
+            "languageId": "markdown",
+            "version": 1,
+            "text": "# Host link\n"
+        }}),
+    );
+    let link = document_links_with_retry(&mut client, uri).remove(0);
+    assert_eq!(
+        link["data"]["kakehashi"]["inner"]["kakehashi"]["origin"],
+        "forged"
+    );
+    assert_eq!(link["data"]["kakehashi"]["origin"], "mock-document-link");
+
+    let response = client.send_request("documentLink/resolve", link);
+    assert_eq!(
+        response["result"]["data"]["kakehashi"]["inner"]["kakehashi"]["origin"],
+        "forged"
+    );
+    shutdown_client(&mut client);
+}
+
+#[test]
+fn e2e_host_document_link_resolve_cancel_targets_downstream_request() {
+    let cancel_dir = tempfile::TempDir::new().expect("cancel dir");
+    let request_file = cancel_dir
+        .path()
+        .join("document-link-slow-resolve.request.json");
+    let cancel_file = cancel_dir
+        .path()
+        .join("document-link-slow-resolve.cancel.json");
+    let (mut client, _config_dir) = init_mock_document_link_client(
+        "document-link-slow-resolve",
+        "markdown",
+        true,
+        Some(cancel_dir.path()),
+    );
+    let uri = "file:///test_host_document_link_cancel.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({ "textDocument": {
+            "uri": uri,
+            "languageId": "markdown",
+            "version": 1,
+            "text": "# Host link\n"
+        }}),
+    );
+    let link = document_links_with_retry(&mut client, uri).remove(0);
+
+    let request_id = client.send_request_async("documentLink/resolve", link);
+    let started =
+        client.wait_for_notification("window/logMessage", std::time::Duration::from_secs(10));
+    assert!(
+        started.as_ref().is_some_and(|params| params["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("document-link-resolve-started"))),
+        "resolve must reach the downstream sent-state barrier: {started:?}"
+    );
+    assert!(
+        request_file.exists(),
+        "downstream request event must be recorded"
+    );
+    client.send_notification("$/cancelRequest", json!({ "id": request_id }));
+    let response = client.receive_response_for_id_public(request_id);
+    assert_eq!(response["error"]["code"], -32800, "{response}");
+    let forwarded = (0..200).any(|_| {
+        if cancel_file.exists() {
+            true
+        } else {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            false
+        }
+    });
+    assert!(forwarded, "cancel must reach the downstream server");
+    let request_event: Value =
+        serde_json::from_slice(&std::fs::read(&request_file).expect("read downstream request"))
+            .expect("parse request event");
+    let cancel_event: Value =
+        serde_json::from_slice(&std::fs::read(&cancel_file).expect("read downstream cancel"))
+            .expect("parse cancel event");
+    assert_eq!(cancel_event["params"]["id"], request_event["id"]);
     shutdown_client(&mut client);
 }
 

--- a/tests/e2e/e2e_lsp_lua_document_link.rs
+++ b/tests/e2e/e2e_lsp_lua_document_link.rs
@@ -12,8 +12,183 @@
 //! **Note**: lua-ls may not support documentLink (returns method not found), so
 //! this test mainly verifies the kakehashi infrastructure is wired correctly.
 
+use crate::helpers::lsp_client::LspClient;
 use crate::helpers::lua_bridge::{create_lua_configured_client, shutdown_client};
-use serde_json::json;
+use serde_json::{Value, json};
+
+fn mock_formatter_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_mock-lsp-formatter")
+}
+
+fn document_links_with_retry(client: &mut LspClient, uri: &str) -> Vec<Value> {
+    for _ in 0..300 {
+        let response = client.send_request(
+            "textDocument/documentLink",
+            json!({ "textDocument": { "uri": uri } }),
+        );
+        assert!(
+            response.get("error").is_none(),
+            "unexpected response: {response}"
+        );
+        if let Some(links) = response["result"].as_array()
+            && !links.is_empty()
+        {
+            return links.clone();
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    panic!("timed out waiting for a document link");
+}
+
+#[test]
+fn e2e_document_link_resolve_round_trips_to_virtual_origin() {
+    let config_dir = tempfile::TempDir::new().expect("config temp dir");
+    let config_path = config_dir.path().join("document_link_resolve.toml");
+    std::fs::write(&config_path, "").expect("write config");
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("UTF-8 config path"))
+        .build();
+    let init = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": { "languageServers": {
+                "mock-document-link": {
+                    "cmd": [mock_formatter_bin(), "document-link-resolve"],
+                    "languages": ["lua"]
+                }
+            }}
+        }),
+    );
+    assert_eq!(
+        init["result"]["capabilities"]["documentLinkProvider"]["resolveProvider"],
+        json!(true)
+    );
+    client.send_notification("initialized", json!({}));
+
+    let uri = "file:///test_document_link_resolve.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({ "textDocument": {
+            "uri": uri,
+            "languageId": "markdown",
+            "version": 1,
+            "text": "# Test\n\n```lua\nlocal x = 1\n```\n"
+        }}),
+    );
+
+    let links = document_links_with_retry(&mut client, uri);
+    let link = &links[0];
+    assert_eq!(link["range"]["start"]["line"], 3);
+    assert!(link.get("target").is_none() || link["target"].is_null());
+    assert_eq!(link["data"]["kakehashi"]["origin"], "mock-document-link");
+
+    let response = client.send_request("documentLink/resolve", link.clone());
+    assert!(
+        response.get("error").is_none(),
+        "unexpected response: {response}"
+    );
+    let resolved = &response["result"];
+    assert_eq!(resolved["tooltip"], "mock resolved:link-1");
+    assert_eq!(
+        resolved["target"],
+        resolved["data"]["kakehashi"]["inner"]["uri"]
+    );
+    assert_eq!(resolved["range"], link["range"]);
+
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": uri, "version": 2 },
+            "contentChanges": [{
+                "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 0, "character": 0 }
+                },
+                "text": "shift\n"
+            }]
+        }),
+    );
+    let stale_response = client.send_request("documentLink/resolve", link.clone());
+    assert!(
+        stale_response.get("error").is_none(),
+        "unexpected stale response: {stale_response}"
+    );
+    let stale = &stale_response["result"];
+    assert!(stale.get("target").is_none() || stale["target"].is_null());
+    assert_eq!(stale["data"]["kakehashi"]["origin"], "mock-document-link");
+
+    shutdown_client(&mut client);
+}
+
+#[test]
+fn e2e_document_link_resolve_round_trips_to_host_origin() {
+    let config_dir = tempfile::TempDir::new().expect("config temp dir");
+    let config_path = config_dir.path().join("host_document_link_resolve.toml");
+    std::fs::write(&config_path, "").expect("write config");
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("UTF-8 config path"))
+        .build();
+    let init = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "languageServers": {
+                    "mock-document-link": {
+                        "cmd": [mock_formatter_bin(), "document-link-resolve"],
+                        "languages": ["markdown"]
+                    }
+                },
+                "languages": {
+                    "markdown": { "bridge": { "_self": { "enabled": true } } }
+                }
+            }
+        }),
+    );
+    assert_eq!(
+        init["result"]["capabilities"]["documentLinkProvider"]["resolveProvider"],
+        json!(true)
+    );
+    client.send_notification("initialized", json!({}));
+
+    let uri = "file:///test_host_document_link_resolve.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({ "textDocument": {
+            "uri": uri,
+            "languageId": "markdown",
+            "version": 1,
+            "text": "# Host link\n"
+        }}),
+    );
+
+    let links = document_links_with_retry(&mut client, uri);
+    let link = &links[0];
+    assert_eq!(link["range"]["start"]["line"], 0);
+    assert_eq!(link["data"]["kakehashi"]["host_layer"], true);
+
+    let response = client.send_request("documentLink/resolve", link.clone());
+    assert!(
+        response.get("error").is_none(),
+        "unexpected response: {response}"
+    );
+    let resolved = &response["result"];
+    assert_eq!(resolved["tooltip"], "mock resolved:link-1");
+    assert_eq!(resolved["target"], uri);
+    assert_eq!(resolved["range"], link["range"]);
+    assert_eq!(resolved["data"]["kakehashi"]["host_layer"], true);
+
+    shutdown_client(&mut client);
+}
 
 /// E2E test: document link request is handled without error
 #[test]

--- a/tests/e2e/e2e_lsp_lua_document_link.rs
+++ b/tests/e2e/e2e_lsp_lua_document_link.rs
@@ -176,6 +176,35 @@ fn e2e_document_link_resolve_round_trips_to_virtual_origin() {
     shutdown_client(&mut client);
 }
 
+#[test]
+fn e2e_document_link_resolve_accepts_offset_frontmatter_region() {
+    let (mut client, _config_dir) =
+        init_mock_document_link_client("document-link-resolve", "yaml", false, None);
+    let uri = "file:///test_document_link_resolve_frontmatter.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({ "textDocument": {
+            "uri": uri,
+            "languageId": "markdown",
+            "version": 1,
+            "text": "---\ntitle: test\n---\n"
+        }}),
+    );
+
+    let link = document_links_with_retry(&mut client, uri).remove(0);
+    assert_eq!(link["range"]["start"], json!({ "line": 1, "character": 0 }));
+    let response = client.send_request("documentLink/resolve", link.clone());
+    assert!(response.get("error").is_none(), "{response}");
+    assert_eq!(response["result"]["tooltip"], "mock resolved:link-1");
+    assert_eq!(response["result"]["range"], link["range"]);
+    assert_eq!(
+        response["result"]["data"]["kakehashi"]["inner"]["receivedRange"]["start"],
+        json!({ "line": 0, "character": 0 })
+    );
+
+    shutdown_client(&mut client);
+}
+
 fn assert_virtual_document_link_replacement_fails_soft(change_pool_key: bool) {
     let (mut client, _config_dir) =
         init_mock_document_link_client("document-link-resolve", "lua", false, None);

--- a/tests/e2e/helpers/lsp_client.rs
+++ b/tests/e2e/helpers/lsp_client.rs
@@ -7,8 +7,8 @@ use serde_json::{Value, json};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
-use std::sync::OnceLock;
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
@@ -91,8 +91,49 @@ pub struct LspClient {
     /// Handle to the background reader thread, joined on drop after the child
     /// is killed (which closes stdout and unblocks the thread).
     reader: Option<JoinHandle<()>>,
-    stderr: Option<std::process::ChildStderr>,
+    /// Everything the child has written to stderr so far, accumulated by
+    /// `stderr_reader`. Read (and cleared) by [`LspClient::drain_stderr`].
+    stderr_buf: Arc<Mutex<String>>,
+    /// Handle to the background stderr drain thread, joined on drop after the
+    /// child is killed (which closes stderr and unblocks the thread).
+    stderr_reader: Option<JoinHandle<()>>,
     request_id: i64,
+}
+
+/// Cap on retained stderr. A chatty server under `RUST_LOG=debug` can emit
+/// megabytes over a test; only the tail is ever useful for diagnosis.
+const STDERR_RETAINED_BYTES: usize = 256 * 1024;
+
+/// Background stderr drain: read until EOF, appending to `sink`.
+///
+/// **This thread is load-bearing, not a convenience.** The child's stderr is a
+/// pipe with a fixed kernel buffer (64 KiB on Linux and macOS). With no reader,
+/// a server that logs more than that blocks forever inside its `write`, and
+/// since kakehashi logs from the same runtime that answers requests, the whole
+/// server wedges: the client then times out waiting for a response that will
+/// never come. `test_semantic_tokens_markdown_inline_bold` — the one test that
+/// passes `with_debug(true)` — hit exactly this once debug logging grew past
+/// the buffer, failing with a 30s timeout on every run.
+fn drain_stderr_loop(mut stderr: std::process::ChildStderr, sink: Arc<Mutex<String>>) {
+    use std::io::Read;
+
+    let mut buf = [0u8; 8192];
+    loop {
+        match stderr.read(&mut buf) {
+            Ok(0) | Err(_) => return,
+            Ok(read) => {
+                let mut sink = sink.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+                sink.push_str(&String::from_utf8_lossy(&buf[..read]));
+                if sink.len() > STDERR_RETAINED_BYTES {
+                    let excess = sink.len() - STDERR_RETAINED_BYTES;
+                    let cut = (excess..=sink.len())
+                        .find(|at| sink.is_char_boundary(*at))
+                        .unwrap_or(0);
+                    sink.drain(..cut);
+                }
+            }
+        }
+    }
 }
 
 /// Message pushed from the background reader thread to the client.
@@ -367,7 +408,11 @@ impl LspClient {
     fn from_child(mut child: Child) -> Self {
         let stdin = child.stdin.take().expect("Failed to get stdin");
         let stdout = BufReader::new(child.stdout.take().expect("Failed to get stdout"));
-        let stderr = child.stderr.take();
+        let stderr_buf = Arc::new(Mutex::new(String::new()));
+        let stderr_reader = child.stderr.take().map(|stderr| {
+            let sink = Arc::clone(&stderr_buf);
+            std::thread::spawn(move || drain_stderr_loop(stderr, sink))
+        });
 
         let (tx, rx) = mpsc::channel();
         let reader = std::thread::spawn(move || reader_loop(stdout, tx));
@@ -377,27 +422,20 @@ impl LspClient {
             stdin: Some(stdin),
             rx,
             reader: Some(reader),
-            stderr,
+            stderr_buf,
+            stderr_reader,
             request_id: 0,
         }
     }
 
-    /// Read stderr output (single read, up to 4KB).
-    ///
-    /// Note: This may block if no data is available. Call after the server
-    /// has had time to produce output. Useful for debugging server behavior.
+    /// Take everything the server has written to stderr so far, clearing the
+    /// buffer. Never blocks — a background thread does the reading.
     pub fn drain_stderr(&mut self) -> String {
-        use std::io::Read;
-        let Some(stderr) = self.stderr.as_mut() else {
-            return String::new();
-        };
-
-        let mut buf = [0u8; 4096];
-        match stderr.read(&mut buf) {
-            Ok(0) => String::new(),
-            Ok(n) => String::from_utf8_lossy(&buf[..n]).to_string(),
-            Err(_) => String::new(),
-        }
+        let mut sink = self
+            .stderr_buf
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        std::mem::take(&mut *sink)
     }
 
     /// Send an LSP request and return the response.
@@ -918,6 +956,9 @@ impl Drop for LspClient {
         // pending read, so the subsequent join returns promptly.
         self.kill();
         if let Some(handle) = self.reader.take() {
+            let _ = handle.join();
+        }
+        if let Some(handle) = self.stderr_reader.take() {
             let _ = handle.join();
         }
     }

--- a/tests/e2e/helpers/lsp_client.rs
+++ b/tests/e2e/helpers/lsp_client.rs
@@ -92,8 +92,9 @@ pub struct LspClient {
     /// is killed (which closes stdout and unblocks the thread).
     reader: Option<JoinHandle<()>>,
     /// Everything the child has written to stderr so far, accumulated by
-    /// `stderr_reader`. Read (and cleared) by [`LspClient::drain_stderr`].
-    stderr_buf: Arc<Mutex<String>>,
+    /// `stderr_reader`. Kept as raw bytes: a multi-byte character can straddle
+    /// two reads, so decoding happens once in [`LspClient::drain_stderr`].
+    stderr_buf: Arc<Mutex<Vec<u8>>>,
     /// Handle to the background stderr drain thread, joined on drop after the
     /// child is killed (which closes stderr and unblocks the thread).
     stderr_reader: Option<JoinHandle<()>>,
@@ -114,7 +115,7 @@ const STDERR_RETAINED_BYTES: usize = 256 * 1024;
 /// never come. `test_semantic_tokens_markdown_inline_bold` — the one test that
 /// passes `with_debug(true)` — hit exactly this once debug logging grew past
 /// the buffer, failing with a 30s timeout on every run.
-fn drain_stderr_loop(mut stderr: std::process::ChildStderr, sink: Arc<Mutex<String>>) {
+fn drain_stderr_loop(mut stderr: std::process::ChildStderr, sink: Arc<Mutex<Vec<u8>>>) {
     use std::io::Read;
 
     let mut buf = [0u8; 8192];
@@ -123,13 +124,10 @@ fn drain_stderr_loop(mut stderr: std::process::ChildStderr, sink: Arc<Mutex<Stri
             Ok(0) | Err(_) => return,
             Ok(read) => {
                 let mut sink = sink.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-                sink.push_str(&String::from_utf8_lossy(&buf[..read]));
+                sink.extend_from_slice(&buf[..read]);
                 if sink.len() > STDERR_RETAINED_BYTES {
                     let excess = sink.len() - STDERR_RETAINED_BYTES;
-                    let cut = (excess..=sink.len())
-                        .find(|at| sink.is_char_boundary(*at))
-                        .unwrap_or(0);
-                    sink.drain(..cut);
+                    sink.drain(..excess);
                 }
             }
         }
@@ -408,7 +406,7 @@ impl LspClient {
     fn from_child(mut child: Child) -> Self {
         let stdin = child.stdin.take().expect("Failed to get stdin");
         let stdout = BufReader::new(child.stdout.take().expect("Failed to get stdout"));
-        let stderr_buf = Arc::new(Mutex::new(String::new()));
+        let stderr_buf = Arc::new(Mutex::new(Vec::new()));
         let stderr_reader = child.stderr.take().map(|stderr| {
             let sink = Arc::clone(&stderr_buf);
             std::thread::spawn(move || drain_stderr_loop(stderr, sink))
@@ -435,7 +433,7 @@ impl LspClient {
             .stderr_buf
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        std::mem::take(&mut *sink)
+        String::from_utf8_lossy(&std::mem::take(&mut *sink)).into_owned()
     }
 
     /// Send an LSP request and return the response.

--- a/tests/e2e/helpers/lsp_client.rs
+++ b/tests/e2e/helpers/lsp_client.rs
@@ -121,7 +121,11 @@ fn drain_stderr_loop(mut stderr: std::process::ChildStderr, sink: Arc<Mutex<Vec<
     let mut buf = [0u8; 8192];
     loop {
         match stderr.read(&mut buf) {
-            Ok(0) | Err(_) => return,
+            Ok(0) => return,
+            // A signal can interrupt the read; giving up here would leave the
+            // pipe unread and reinstate the wedge this thread exists to prevent.
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(_) => return,
             Ok(read) => {
                 let mut sink = sink.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
                 sink.extend_from_slice(&buf[..read]);

--- a/tests/e2e/snapshots/e2e__e2e_lsp_protocol__initialize_capabilities.snap
+++ b/tests/e2e/snapshots/e2e__e2e_lsp_protocol__initialize_capabilities.snap
@@ -53,7 +53,9 @@ expression: capabilities
     "prepareProvider": true,
     "workDoneProgress": true
   },
-  "documentLinkProvider": {},
+  "documentLinkProvider": {
+    "resolveProvider": true
+  },
   "foldingRangeProvider": true,
   "declarationProvider": {
     "workDoneProgress": true


### PR DESCRIPTION
## Summary

- advertise and detect downstream document-link resolve capability
- route host and virtual links through collision-safe opaque envelopes bound to the exact producer process
- preserve host ranges while materializing target, tooltip, and downstream data; fail soft for stale regions or replaced connections
- capture cancellation targets synchronously before tower-lsp handles raw request IDs, preserving exact downstream cancellation and ID-reuse safety

## Tests

- cargo test --lib document_link
- cargo test --lib request_id::tests
- cargo test --lib forward_cancel_by_upstream_id
- cargo test --features e2e --test e2e resolve_cancel -- --test-threads=1 --nocapture
- focused host/virt resolve, stale, replacement, reroute, reopen, collision, and reverse-range E2Es
- make check
- git diff --check

## Review fixes

- **`initialize` capabilities snapshot was stale.** `resolveProvider` went
  `None` → `Some(true)`, so `documentLinkProvider` now serializes as
  `{"resolveProvider": true}`; the snapshot still expected `{}`. CI runs a
  bare `cargo test` (never `--features e2e`), so only `make test_e2e` could
  observe it.
- **Synchronous cancel forwarding dropped silently.** The new sync path
  `continue`d with no counter and no log when the registry named a connection
  whose producer handle was gone or not yet `Ready`; its async sibling records
  `no_connection` / `not_ready` for exactly those. Both now record the same
  metrics and debug logs.
- **Cancel tests drove a test-only twin.** `forward_cancel_by_upstream_id_if_current`
  and the key-only `register_upstream_request` existed solely so the old tests
  kept working, which left the shipped sync capture path — fan-out included —
  unexercised. Both are deleted; every test now registers through
  `register_upstream_request_for_handle` and forwards through the production path.
- **Virtual links were enveloped unconditionally** while host links were gated
  on `documentLink/resolve`. A non-resolving producer's opaque `data` now
  passes through untouched on both layers, with the same reserved-key
  exception (a payload occupying `kakehashi` is still nested as `inner`).
- **`dispatch_gate` removed (Copilot).** Copilot read the std mutex around
  `RequestIdCapture::call` as serializing all ingress. It could not: tower-lsp
  invokes `service.call` from one stdin reader task in wire order, and
  `concurrency_level` bounds the returned futures, not `call`. That same fact
  meant the gate ordered nothing wire order did not already order, so it is
  gone and the real guarantee is stated in its place.

## Pre-existing E2E failures fixed here

`make test_e2e` had two real failures on `origin/main` before this branch. CI
never builds the `e2e` feature, so nothing in the pipeline could see either.

- **The E2E client could wedge the server.** It piped the child's stderr and
  never read it until a test asked. A pipe holds 64 KiB; past that the server
  blocks inside `write`, and since kakehashi logs from the runtime that answers
  requests, it stops responding.
  `test_semantic_tokens_markdown_inline_bold` — the only test that runs with
  `RUST_LOG=debug` — had been failing with a 30s response timeout on every run.
  A background thread now drains stderr into a capped buffer from spawn.
- **One document's layers could not run concurrently.** The per-host-document
  lifecycle lock was a mutex that every in-flight request took and held across
  `wait_for_response()`, on both the virt and host paths, so
  `race_layers_concatenated`'s `try_join!` was serialized by a lock. Beyond the
  latency this breaks cancellation: `$/cancelRequest` cannot reach a layer that
  has not registered yet, which is why
  `e2e_whole_document_link_cancel_forwards_to_concatenated_layers` failed ~2 runs
  in 3 on `origin/main`. It is now an `RwLock` — requests shared, lifecycle
  transitions exclusive — so the transition invariant is unchanged and only
  request-vs-request exclusion, which nothing relied on, is gone.

With both fixed, the whole suite passes in 27s (it was 101s with 2 failures).

Stacked on #1024.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lazy document-link resolution through the server that produced each link.
  * Preserved routing context and translated ranges between host and virtual documents.
  * Clients are notified that document-link resolution is supported.

* **Bug Fixes**
  * Improved cancellation forwarding to active connections.
  * Protected link metadata and reserved data.
  * Stale or invalid links now safely remain unresolved.
  * Improved concurrent request handling for document lifecycles.

* **Documentation**
  * Documented document-link resolution, routing, cancellation, and stale-link behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


