### PR TITLE
feat(lsp): bridge call hierarchy preparation

### DIFF
--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -10,6 +10,7 @@ pub(crate) struct DocumentSnapshot {
     text: Arc<str>,
     tree: Tree,
     incarnation: u64,
+    content_version: u64,
 }
 
 impl DocumentSnapshot {
@@ -32,6 +33,10 @@ impl DocumentSnapshot {
 
     pub(crate) fn incarnation(&self) -> u64 {
         self.incarnation
+    }
+
+    pub(crate) fn content_version(&self) -> u64 {
+        self.content_version
     }
 }
 
@@ -330,6 +335,7 @@ impl Document {
             tree: snapshot.tree.clone()?,
             text: Arc::clone(&snapshot.text),
             incarnation: self.incarnation,
+            content_version: self.content_version,
         })
     }
 

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -90,11 +90,12 @@ pub(crate) use protocol::workspace_edit_within_region;
 pub(crate) use text_document::completion_item::CompletionResolveDocument;
 pub(crate) use text_document::host::{HostDocument, HostTextReader, normalize_host_goto_result};
 pub(crate) use text_document::{
-    CodeActionEnvelope, EnvelopeOffset, InlayHintDocumentRevision, InlayHintEnvelope,
-    KakehashiEnvelope, UpstreamCodeActionCaps, bridge_code_actions, bridge_host_completion_items,
-    envelope_host_code_lenses, envelope_host_document_links, envelope_host_inlay_hints,
-    extract_code_action_envelope, extract_code_lens_envelope, extract_document_link_envelope,
-    extract_envelope, extract_inlay_hint_envelope, parse_code_actions_leniently,
+    CallHierarchyDocumentRevision, CodeActionEnvelope, EnvelopeOffset, InlayHintDocumentRevision,
+    InlayHintEnvelope, KakehashiEnvelope, UpstreamCodeActionCaps, bridge_code_actions,
+    bridge_host_completion_items, envelope_host_call_hierarchy_items, envelope_host_code_lenses,
+    envelope_host_document_links, envelope_host_inlay_hints, extract_code_action_envelope,
+    extract_code_lens_envelope, extract_document_link_envelope, extract_envelope,
+    extract_inlay_hint_envelope, parse_code_actions_leniently,
 };
 pub(crate) use text_document::{OpenExpectation, OpenOutcome};
 pub(crate) use workspace::WorkspaceFolderSet;

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -791,6 +791,13 @@ impl ConnectionHandle {
                     Some(OneOf::Left(true) | OneOf::Right(_))
                 )
             }
+            "textDocument/prepareCallHierarchy" => matches!(
+                caps.call_hierarchy_provider,
+                Some(
+                    tower_lsp_server::ls_types::CallHierarchyServerCapability::Simple(true)
+                        | tower_lsp_server::ls_types::CallHierarchyServerCapability::Options(_)
+                )
+            ),
             "inlayHint/resolve" => match caps.inlay_hint_provider.as_ref() {
                 Some(OneOf::Right(
                     tower_lsp_server::ls_types::InlayHintServerCapabilities::Options(options),
@@ -2254,12 +2261,12 @@ mod tests {
     #[tokio::test]
     async fn has_capability_returns_true_for_enabled_providers() {
         use tower_lsp_server::ls_types::{
-            ColorProviderCapability, ColorProviderOptions, CompletionOptions,
-            DeclarationCapability, DeclarationOptions, DeclarationRegistrationOptions,
-            DocumentLinkOptions, HoverProviderCapability, ImplementationProviderCapability, OneOf,
-            SignatureHelpOptions, StaticTextDocumentColorProviderOptions,
-            TextDocumentRegistrationOptions, TextDocumentSyncCapability, TextDocumentSyncOptions,
-            TypeDefinitionProviderCapability,
+            CallHierarchyServerCapability, ColorProviderCapability, ColorProviderOptions,
+            CompletionOptions, DeclarationCapability, DeclarationOptions,
+            DeclarationRegistrationOptions, DocumentLinkOptions, HoverProviderCapability,
+            ImplementationProviderCapability, OneOf, SignatureHelpOptions,
+            StaticTextDocumentColorProviderOptions, TextDocumentRegistrationOptions,
+            TextDocumentSyncCapability, TextDocumentSyncOptions, TypeDefinitionProviderCapability,
         };
 
         type CapCase = (&'static str, Box<dyn Fn(&mut ServerCapabilities)>);
@@ -2360,6 +2367,12 @@ mod tests {
                 "textDocument/inlayHint",
                 Box::new(|c| {
                     c.inlay_hint_provider = Some(OneOf::Left(true));
+                }),
+            ),
+            (
+                "textDocument/prepareCallHierarchy",
+                Box::new(|c| {
+                    c.call_hierarchy_provider = Some(CallHierarchyServerCapability::Simple(true));
                 }),
             ),
             (
@@ -2491,8 +2504,9 @@ mod tests {
     #[tokio::test]
     async fn has_capability_returns_false_for_explicitly_disabled() {
         use tower_lsp_server::ls_types::{
-            ColorProviderCapability, DeclarationCapability, HoverProviderCapability,
-            ImplementationProviderCapability, OneOf, TypeDefinitionProviderCapability,
+            CallHierarchyServerCapability, ColorProviderCapability, DeclarationCapability,
+            HoverProviderCapability, ImplementationProviderCapability, OneOf,
+            TypeDefinitionProviderCapability,
         };
 
         type CapCase = (&'static str, Box<dyn Fn(&mut ServerCapabilities)>);
@@ -2573,6 +2587,12 @@ mod tests {
                 }),
             ),
             (
+                "textDocument/prepareCallHierarchy",
+                Box::new(|c| {
+                    c.call_hierarchy_provider = Some(CallHierarchyServerCapability::Simple(false));
+                }),
+            ),
+            (
                 "textDocument/documentSymbol",
                 Box::new(|c| {
                     c.document_symbol_provider = Some(OneOf::Left(false));
@@ -2620,6 +2640,7 @@ mod tests {
             "textDocument/prepareRename",
             "textDocument/moniker",
             "textDocument/inlayHint",
+            "textDocument/prepareCallHierarchy",
             "textDocument/documentColor",
             "textDocument/colorPresentation",
             "textDocument/codeAction",

--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -128,6 +128,7 @@ impl LanguageServerPool {
             offset,
             virtual_content,
             upstream_request_id,
+            None,
             build_request,
             transform_response,
             None,
@@ -152,6 +153,7 @@ impl LanguageServerPool {
         offset: &RegionOffset,
         virtual_content: &str,
         upstream_request_id: Option<UpstreamId>,
+        expected_incarnation: Option<u64>,
         build_request: impl FnOnce(&VirtualDocumentUri, RequestId) -> JsonRpcRequest<P>,
         transform_response: impl FnOnce(serde_json::Value, &BridgeResponseContext<'_>) -> T,
         downstream_id_probe: Option<&std::sync::OnceLock<RequestId>>,
@@ -168,7 +170,13 @@ impl LanguageServerPool {
         // Build virtual document URI
         let virtual_uri = VirtualDocumentUri::new(&host_uri_lsp, injection_language, region_id);
 
-        let host_lifecycle = self.request_host_lifecycle(host_uri).await?;
+        let host_lifecycle = match expected_incarnation {
+            Some(expected) => {
+                self.request_host_lifecycle_for_incarnation(host_uri, expected)
+                    .await?
+            }
+            None => self.request_host_lifecycle(host_uri).await?,
+        };
         let routing_uri = url::Url::parse(&virtual_uri.to_uri_string())
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
         if self
@@ -338,6 +346,79 @@ impl LanguageServerPool {
         build_request: impl FnOnce(&VirtualDocumentUri, RequestId) -> JsonRpcRequest<P>,
         transform_response: impl FnOnce(serde_json::Value, &BridgeResponseContext<'_>) -> T,
     ) -> io::Result<T> {
+        self.execute_position_bridge_request_with_handle_inner(
+            handle,
+            host_uri,
+            injection_language,
+            region_id,
+            offset,
+            virtual_content,
+            upstream_request_id,
+            None,
+            host_position,
+            region_end,
+            method,
+            build_request,
+            transform_response,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn execute_position_bridge_request_with_handle_for_incarnation<
+        T,
+        P: serde::Serialize,
+    >(
+        &self,
+        handle: Arc<ConnectionHandle>,
+        host_uri: &Url,
+        injection_language: &str,
+        region_id: &str,
+        offset: &RegionOffset,
+        virtual_content: &str,
+        upstream_request_id: Option<UpstreamId>,
+        expected_incarnation: u64,
+        host_position: Position,
+        region_end: Position,
+        method: &'static str,
+        build_request: impl FnOnce(&VirtualDocumentUri, RequestId) -> JsonRpcRequest<P>,
+        transform_response: impl FnOnce(serde_json::Value, &BridgeResponseContext<'_>) -> T,
+    ) -> io::Result<T> {
+        self.execute_position_bridge_request_with_handle_inner(
+            handle,
+            host_uri,
+            injection_language,
+            region_id,
+            offset,
+            virtual_content,
+            upstream_request_id,
+            Some(expected_incarnation),
+            host_position,
+            region_end,
+            method,
+            build_request,
+            transform_response,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn execute_position_bridge_request_with_handle_inner<T, P: serde::Serialize>(
+        &self,
+        handle: Arc<ConnectionHandle>,
+        host_uri: &Url,
+        injection_language: &str,
+        region_id: &str,
+        offset: &RegionOffset,
+        virtual_content: &str,
+        upstream_request_id: Option<UpstreamId>,
+        expected_incarnation: Option<u64>,
+        host_position: Position,
+        region_end: Position,
+        method: &'static str,
+        build_request: impl FnOnce(&VirtualDocumentUri, RequestId) -> JsonRpcRequest<P>,
+        transform_response: impl FnOnce(serde_json::Value, &BridgeResponseContext<'_>) -> T,
+    ) -> io::Result<T> {
         // `region_end` is `region_host_end(virtual_content, offset)`, derived
         // once per request by the fan-out (deriving it is O(virtual_content))
         // and shared by every arm. The bound is SNAPSHOT-scoped, not
@@ -410,6 +491,7 @@ impl LanguageServerPool {
             offset,
             virtual_content,
             upstream_request_id,
+            expected_incarnation,
             build_request,
             transform_response,
             None,
@@ -447,6 +529,7 @@ mod tests {
                 &RegionOffset::new(0, 0),
                 "print('hello')",
                 Some(upstream_id),
+                None,
                 |_, request_id| {
                     JsonRpcRequest::new(
                         request_id.as_i64(),

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -67,6 +67,9 @@ fn build_baseline_capabilities(advertise_configuration: bool) -> ClientCapabilit
             dynamic_registration: Some(false),
             tooltip_support: Some(true),
         }),
+        call_hierarchy: Some(DynamicRegistrationClientCapabilities {
+            dynamic_registration: Some(false),
+        }),
         inlay_hint: Some(InlayHintClientCapabilities {
             dynamic_registration: Some(false),
             ..Default::default()
@@ -487,6 +490,18 @@ mod tests {
 
         assert_eq!(synchronization.dynamic_registration, Some(false));
         assert_eq!(synchronization.did_save, Some(true));
+    }
+
+    #[test]
+    fn bridge_advertises_static_call_hierarchy_support() {
+        let capabilities = build_bridge_client_capabilities(None, true);
+        let call_hierarchy = capabilities
+            .text_document
+            .as_ref()
+            .and_then(|text_document| text_document.call_hierarchy.as_ref())
+            .expect("the bridge must advertise call-hierarchy support downstream");
+
+        assert_eq!(call_hierarchy.dynamic_registration, Some(false));
     }
 
     #[test]

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
@@ -143,6 +143,9 @@ expression: merged
     "colorProvider": {
       "dynamicRegistration": false
     },
+    "callHierarchy": {
+      "dynamicRegistration": false
+    },
     "moniker": {
       "dynamicRegistration": false
     },

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
@@ -88,6 +88,9 @@ expression: capabilities
     "colorProvider": {
       "dynamicRegistration": false
     },
+    "callHierarchy": {
+      "dynamicRegistration": false
+    },
     "moniker": {
       "dynamicRegistration": false
     },

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
@@ -95,6 +95,9 @@ expression: request
         "colorProvider": {
           "dynamicRegistration": false
         },
+        "callHierarchy": {
+          "dynamicRegistration": false
+        },
         "moniker": {
           "dynamicRegistration": false
         },

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
@@ -106,6 +106,9 @@ expression: request
         "colorProvider": {
           "dynamicRegistration": false
         },
+        "callHierarchy": {
+          "dynamicRegistration": false
+        },
         "moniker": {
           "dynamicRegistration": false
         },

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
@@ -95,6 +95,9 @@ expression: request
         "colorProvider": {
           "dynamicRegistration": false
         },
+        "callHierarchy": {
+          "dynamicRegistration": false
+        },
         "moniker": {
           "dynamicRegistration": false
         },

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
@@ -104,6 +104,9 @@ expression: request
         "colorProvider": {
           "dynamicRegistration": false
         },
+        "callHierarchy": {
+          "dynamicRegistration": false
+        },
         "moniker": {
           "dynamicRegistration": false
         },

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -5,8 +5,12 @@
 //!
 //! The structure mirrors `lsp_impl/text_document/` for consistency.
 
+mod call_hierarchy;
 mod code_action;
 mod code_lens;
+pub(crate) use call_hierarchy::{
+    CallHierarchyDocumentRevision, envelope_host_call_hierarchy_items,
+};
 mod color_presentation;
 
 pub(crate) use code_action::{

--- a/src/lsp/bridge/text_document/call_hierarchy.rs
+++ b/src/lsp/bridge/text_document/call_hierarchy.rs
@@ -113,11 +113,11 @@ impl LanguageServerPool {
         region_id: &str,
         offset: RegionOffset,
         virtual_content: &str,
+        incarnation: u64,
         content_version: u64,
         upstream_request_id: Option<UpstreamId>,
         work_done_token: Option<NumberOrString>,
     ) -> io::Result<Option<Vec<CallHierarchyItem>>> {
-        let incarnation = self.current_host_incarnation(host_uri);
         let handle = self
             .get_or_create_virtual_connection(
                 server_name,
@@ -132,7 +132,7 @@ impl LanguageServerPool {
         }
         let connection_key = handle.key().clone();
         let connection_generation = self.document_connection_generation(&connection_key);
-        self.execute_position_bridge_request_with_handle(
+        self.execute_position_bridge_request_with_handle_for_incarnation(
             handle,
             host_uri,
             injection_language,
@@ -140,6 +140,7 @@ impl LanguageServerPool {
             &offset,
             virtual_content,
             upstream_request_id,
+            incarnation,
             host_position,
             region_end,
             "textDocument/prepareCallHierarchy",
@@ -164,7 +165,7 @@ impl LanguageServerPool {
                         region_id,
                         injection_language,
                         revision: CallHierarchyDocumentRevision {
-                            incarnation,
+                            incarnation: Some(incarnation),
                             content_version,
                         },
                         connection_generation,
@@ -254,7 +255,7 @@ mod tests {
     fn prepare_request_uses_virtual_position_and_progress_token() {
         let request = build_call_hierarchy_prepare_request(
             &VirtualDocumentUri::new(&test_host_uri(), "lua", "region"),
-            Position::new(5, 4),
+            Position::new(3, 4),
             &RegionOffset::new(3, 2),
             RequestId::new(7),
             Some(NumberOrString::String("progress".into())),
@@ -267,7 +268,7 @@ mod tests {
         );
         assert_eq!(
             value["params"]["position"],
-            json!({ "line": 2, "character": 4 })
+            json!({ "line": 0, "character": 2 })
         );
         assert_eq!(value["params"]["workDoneToken"], "progress");
     }

--- a/src/lsp/bridge/text_document/call_hierarchy.rs
+++ b/src/lsp/bridge/text_document/call_hierarchy.rs
@@ -1,0 +1,367 @@
+//! Call-hierarchy preparation for host and virtual bridge layers.
+
+use std::io;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tower_lsp_server::ls_types::{
+    CallHierarchyItem, CallHierarchyPrepareParams, NumberOrString, Position,
+    TextDocumentIdentifier, TextDocumentPositionParams, Uri, WorkDoneProgressParams,
+};
+use url::Url;
+
+use crate::config::settings::BridgeServerConfig;
+
+use super::super::pool::{ConnectionKey, LanguageServerPool, UpstreamId};
+use super::super::protocol::{
+    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, response_has_jsonrpc_error,
+    translate_host_position_to_virtual, translate_virtual_range_to_host, virtual_uri_to_lsp_uri,
+};
+use super::completion::EnvelopeOffset;
+
+const ENVELOPE_KEY: &str = "kakehashi";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct CallHierarchyEnvelope {
+    pub(crate) origin: String,
+    pub(crate) host_uri: String,
+    pub(crate) region_id: String,
+    pub(crate) injection_language: String,
+    pub(crate) incarnation: Option<u64>,
+    pub(crate) content_version: u64,
+    pub(crate) connection_generation: u64,
+    pub(crate) connection_key: ConnectionKey,
+    pub(crate) offset: EnvelopeOffset,
+    pub(crate) inner: Option<Value>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub(crate) host_layer: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+pub(crate) struct CallHierarchyDocumentRevision {
+    pub(crate) incarnation: Option<u64>,
+    pub(crate) content_version: u64,
+}
+
+struct CallHierarchyEnvelopeContext<'a> {
+    server_name: &'a str,
+    host_uri: &'a str,
+    region_id: &'a str,
+    injection_language: &'a str,
+    revision: CallHierarchyDocumentRevision,
+    connection_generation: u64,
+    connection_key: &'a ConnectionKey,
+    offset: &'a RegionOffset,
+    host_layer: bool,
+}
+
+fn envelope_item_data(item: &mut CallHierarchyItem, ctx: &CallHierarchyEnvelopeContext<'_>) {
+    let inner = item.data.take();
+    item.data = Some(serde_json::json!({ ENVELOPE_KEY: CallHierarchyEnvelope {
+        origin: ctx.server_name.to_string(),
+        host_uri: ctx.host_uri.to_string(),
+        region_id: ctx.region_id.to_string(),
+        injection_language: ctx.injection_language.to_string(),
+        incarnation: ctx.revision.incarnation,
+        content_version: ctx.revision.content_version,
+        connection_generation: ctx.connection_generation,
+        connection_key: ctx.connection_key.clone(),
+        offset: EnvelopeOffset::from(ctx.offset),
+        inner,
+        host_layer: ctx.host_layer,
+    }}));
+}
+
+pub(crate) fn envelope_host_call_hierarchy_items(
+    items: &mut [CallHierarchyItem],
+    server_name: &str,
+    host_uri: &str,
+    revision: CallHierarchyDocumentRevision,
+    connection_generation: u64,
+    connection_key: &ConnectionKey,
+) {
+    let offset = RegionOffset::new(0, 0);
+    let ctx = CallHierarchyEnvelopeContext {
+        server_name,
+        host_uri,
+        region_id: "",
+        injection_language: "",
+        revision,
+        connection_generation,
+        connection_key,
+        offset: &offset,
+        host_layer: true,
+    };
+    for item in items {
+        envelope_item_data(item, &ctx);
+    }
+}
+
+impl LanguageServerPool {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn send_call_hierarchy_prepare_request(
+        &self,
+        server_name: &str,
+        server_config: &BridgeServerConfig,
+        host_uri: &Url,
+        host_position: Position,
+        region_end: Position,
+        injection_language: &str,
+        region_id: &str,
+        offset: RegionOffset,
+        virtual_content: &str,
+        content_version: u64,
+        upstream_request_id: Option<UpstreamId>,
+        work_done_token: Option<NumberOrString>,
+    ) -> io::Result<Option<Vec<CallHierarchyItem>>> {
+        let incarnation = self.current_host_incarnation(host_uri);
+        let handle = self
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
+            .await?;
+        if !handle.has_capability("textDocument/prepareCallHierarchy") {
+            return Ok(None);
+        }
+        let connection_key = handle.key().clone();
+        let connection_generation = self.document_connection_generation(&connection_key);
+        self.execute_position_bridge_request_with_handle(
+            handle,
+            host_uri,
+            injection_language,
+            region_id,
+            &offset,
+            virtual_content,
+            upstream_request_id,
+            host_position,
+            region_end,
+            "textDocument/prepareCallHierarchy",
+            |virtual_uri, request_id| {
+                build_call_hierarchy_prepare_request(
+                    virtual_uri,
+                    host_position,
+                    &offset,
+                    request_id,
+                    work_done_token,
+                )
+            },
+            |response, ctx| {
+                transform_call_hierarchy_prepare_response_to_host(
+                    response,
+                    &ctx.virtual_uri_string,
+                    ctx.host_uri_lsp,
+                    ctx.offset,
+                    &CallHierarchyEnvelopeContext {
+                        server_name,
+                        host_uri: host_uri.as_str(),
+                        region_id,
+                        injection_language,
+                        revision: CallHierarchyDocumentRevision {
+                            incarnation,
+                            content_version,
+                        },
+                        connection_generation,
+                        connection_key: &connection_key,
+                        offset: ctx.offset,
+                        host_layer: false,
+                    },
+                )
+            },
+        )
+        .await?
+    }
+}
+
+fn build_call_hierarchy_prepare_request(
+    virtual_uri: &VirtualDocumentUri,
+    mut host_position: Position,
+    offset: &RegionOffset,
+    request_id: RequestId,
+    work_done_token: Option<NumberOrString>,
+) -> JsonRpcRequest<CallHierarchyPrepareParams> {
+    translate_host_position_to_virtual(&mut host_position, offset);
+    JsonRpcRequest::new(
+        request_id.as_i64(),
+        "textDocument/prepareCallHierarchy",
+        CallHierarchyPrepareParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: virtual_uri_to_lsp_uri(virtual_uri),
+                },
+                position: host_position,
+            },
+            work_done_progress_params: WorkDoneProgressParams { work_done_token },
+        },
+    )
+}
+
+fn transform_call_hierarchy_prepare_response_to_host(
+    mut response: Value,
+    request_virtual_uri: &str,
+    host_uri: &Uri,
+    offset: &RegionOffset,
+    envelope_ctx: &CallHierarchyEnvelopeContext<'_>,
+) -> io::Result<Option<Vec<CallHierarchyItem>>> {
+    if response_has_jsonrpc_error(&response, "textDocument/prepareCallHierarchy") {
+        return Ok(None);
+    }
+    let Some(result) = response.get_mut("result").map(Value::take) else {
+        return Err(io::Error::other(
+            "textDocument/prepareCallHierarchy response carries neither result nor error (protocol violation)",
+        ));
+    };
+    if result.is_null() {
+        return Ok(None);
+    }
+    let items: Vec<CallHierarchyItem> = serde_json::from_value(result).map_err(|error| {
+        io::Error::other(format!(
+            "malformed textDocument/prepareCallHierarchy result from downstream server: {error}"
+        ))
+    })?;
+    let items = items
+        .into_iter()
+        .filter_map(|mut item| {
+            let uri = item.uri.as_str();
+            if VirtualDocumentUri::is_virtual_uri(uri) {
+                if uri != request_virtual_uri {
+                    return None;
+                }
+                item.uri = host_uri.clone();
+                translate_virtual_range_to_host(&mut item.range, offset);
+                translate_virtual_range_to_host(&mut item.selection_range, offset);
+            }
+            envelope_item_data(&mut item, envelope_ctx);
+            Some(item)
+        })
+        .collect();
+    Ok(Some(items))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_helpers::*;
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn prepare_request_uses_virtual_position_and_progress_token() {
+        let request = build_call_hierarchy_prepare_request(
+            &VirtualDocumentUri::new(&test_host_uri(), "lua", "region"),
+            Position::new(5, 4),
+            &RegionOffset::new(3, 2),
+            RequestId::new(7),
+            Some(NumberOrString::String("progress".into())),
+        );
+        let value = serde_json::to_value(request).unwrap();
+        assert!(
+            value["params"]["textDocument"]["uri"]
+                .as_str()
+                .is_some_and(|uri| uri.contains("kakehashi-virtual-uri-region.lua"))
+        );
+        assert_eq!(
+            value["params"]["position"],
+            json!({ "line": 2, "character": 4 })
+        );
+        assert_eq!(value["params"]["workDoneToken"], "progress");
+    }
+
+    #[test]
+    fn prepare_response_translates_and_envelopes_same_virtual_item() {
+        let host_uri: Uri = "file:///test.md".parse().unwrap();
+        let key = ConnectionKey::shared("lua-ls");
+        let offset = RegionOffset::new(3, 2);
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region");
+        let response = json!({ "jsonrpc": "2.0", "id": 7, "result": [{
+            "name": "f",
+            "kind": 12,
+            "uri": virtual_uri.to_uri_string(),
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 1, "character": 1 }
+            },
+            "selectionRange": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 1 }
+            },
+            "data": { "token": 9 }
+        }]});
+        let items = transform_call_hierarchy_prepare_response_to_host(
+            response,
+            &virtual_uri.to_uri_string(),
+            &host_uri,
+            &offset,
+            &CallHierarchyEnvelopeContext {
+                server_name: "lua-ls",
+                host_uri: host_uri.as_str(),
+                region_id: "region",
+                injection_language: "lua",
+                revision: CallHierarchyDocumentRevision {
+                    incarnation: Some(2),
+                    content_version: 3,
+                },
+                connection_generation: 4,
+                connection_key: &key,
+                offset: &offset,
+                host_layer: false,
+            },
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(items[0].uri, host_uri);
+        assert_eq!(items[0].range.start, Position::new(3, 2));
+        assert_eq!(items[0].range.end, Position::new(4, 1));
+        assert_eq!(items[0].selection_range.start, Position::new(3, 2));
+        assert_eq!(
+            items[0].data.as_ref().unwrap()["kakehashi"]["inner"],
+            json!({ "token": 9 })
+        );
+        assert_eq!(
+            items[0].data.as_ref().unwrap()["kakehashi"]["content_version"],
+            3
+        );
+    }
+
+    #[test]
+    fn prepare_response_filters_cross_region_virtual_item() {
+        let host_uri: Uri = "file:///test.md".parse().unwrap();
+        let key = ConnectionKey::shared("lua-ls");
+        let offset = RegionOffset::new(3, 0);
+        let request_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-a");
+        let other_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-b");
+        let response = json!({ "jsonrpc": "2.0", "id": 7, "result": [{
+            "name": "f", "kind": 12, "uri": other_uri.to_uri_string(),
+            "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 1 } },
+            "selectionRange": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 1 } }
+        }]});
+        let items = transform_call_hierarchy_prepare_response_to_host(
+            response,
+            &request_uri.to_uri_string(),
+            &host_uri,
+            &offset,
+            &CallHierarchyEnvelopeContext {
+                server_name: "lua-ls",
+                host_uri: host_uri.as_str(),
+                region_id: "region-a",
+                injection_language: "lua",
+                revision: CallHierarchyDocumentRevision {
+                    incarnation: Some(1),
+                    content_version: 1,
+                },
+                connection_generation: 1,
+                connection_key: &key,
+                offset: &offset,
+                host_layer: false,
+            },
+        )
+        .unwrap()
+        .unwrap();
+        assert!(items.is_empty());
+    }
+}

--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -94,6 +94,7 @@ impl LanguageServerPool {
             &offset,
             virtual_content,
             upstream_request_id,
+            None,
             |virtual_uri, request_id| {
                 build_formatting_request(virtual_uri, options, request_id, client_progress_token)
             },

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -472,8 +472,56 @@ impl LanguageServerPool {
         server_config: &BridgeServerConfig,
         doc: &HostDocument<'_>,
         method: &'static str,
+        params: serde_json::Value,
+        upstream_request_id: Option<UpstreamId>,
+    ) -> io::Result<Option<HostRawResponse>> {
+        self.send_host_raw_request_inner(
+            server_name,
+            server_config,
+            doc,
+            method,
+            params,
+            upstream_request_id,
+            None,
+        )
+        .await
+    }
+
+    /// Variant of [`Self::send_host_raw_request`] that rejects a request if
+    /// the host document was closed and reopened after its source snapshot.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn send_host_raw_request_for_incarnation(
+        &self,
+        server_name: &str,
+        server_config: &BridgeServerConfig,
+        doc: &HostDocument<'_>,
+        method: &'static str,
+        params: serde_json::Value,
+        upstream_request_id: Option<UpstreamId>,
+        expected_incarnation: u64,
+    ) -> io::Result<Option<HostRawResponse>> {
+        self.send_host_raw_request_inner(
+            server_name,
+            server_config,
+            doc,
+            method,
+            params,
+            upstream_request_id,
+            Some(expected_incarnation),
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn send_host_raw_request_inner(
+        &self,
+        server_name: &str,
+        server_config: &BridgeServerConfig,
+        doc: &HostDocument<'_>,
+        method: &'static str,
         mut params: serde_json::Value,
         upstream_request_id: Option<UpstreamId>,
+        expected_incarnation: Option<u64>,
     ) -> io::Result<Option<HostRawResponse>> {
         strip_progress_tokens(&mut params);
         let handle = self
@@ -493,6 +541,7 @@ impl LanguageServerPool {
                 handle,
                 doc,
                 upstream_request_id,
+                expected_incarnation,
                 |request_id| JsonRpcRequest::new(request_id.as_i64(), method, params),
                 move |response, incarnation, connection_generation| {
                     (
@@ -542,6 +591,7 @@ impl LanguageServerPool {
             handle,
             doc,
             upstream_request_id,
+            None,
             |request_id| JsonRpcRequest::new(request_id.as_i64(), method, params),
             // The parser promotes error responses, missing results, and
             // malformed payloads to `Err` (request failure) — mirrors
@@ -623,6 +673,7 @@ impl LanguageServerPool {
                 handle,
                 doc,
                 upstream_request_id,
+                None,
                 |request_id| JsonRpcRequest::new(request_id.as_i64(), method, params),
                 move |response, _incarnation, _connection_generation| {
                     if response_has_jsonrpc_error(&response, method) {
@@ -660,15 +711,20 @@ impl LanguageServerPool {
         handle: Arc<ConnectionHandle>,
         doc: &HostDocument<'_>,
         upstream_request_id: Option<UpstreamId>,
+        expected_incarnation: Option<u64>,
         build_request: impl FnOnce(RequestId) -> JsonRpcRequest<P>,
         transform_response: impl FnOnce(serde_json::Value, u64, u64) -> T,
     ) -> io::Result<T> {
         // Route per-connection state by this handle's pool key (#382).
         let connection_key = handle.key();
         self.wait_for_host_routing(doc.uri).await;
-        let host_lifecycle = match doc.revision {
-            Some(revision) => {
-                self.request_host_lifecycle_for_incarnation(doc.uri, revision.incarnation)
+        // An explicitly requested incarnation wins over the one the text was
+        // read at: a caller that names it is fencing a specific lifetime.
+        let expected_incarnation =
+            expected_incarnation.or(doc.revision.map(|revision| revision.incarnation));
+        let host_lifecycle = match expected_incarnation {
+            Some(expected) => {
+                self.request_host_lifecycle_for_incarnation(doc.uri, expected)
                     .await?
             }
             None => self.request_host_lifecycle(doc.uri).await?,

--- a/src/lsp/bridge/text_document/range_formatting.rs
+++ b/src/lsp/bridge/text_document/range_formatting.rs
@@ -87,6 +87,7 @@ impl LanguageServerPool {
             &offset,
             virtual_content,
             upstream_request_id,
+            None,
             move |virtual_uri, request_id| {
                 build_range_formatting_request(
                     virtual_uri,

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -357,6 +357,7 @@ fn classify(req: &Request) -> Option<Role> {
         | "textDocument/inlayHint"
         | "textDocument/documentColor"
         | "textDocument/colorPresentation"
+        | "textDocument/prepareCallHierarchy"
         | "textDocument/diagnostic"
         | "kakehashi/captures/full"
         | "kakehashi/captures/full/delta"

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -21,21 +21,22 @@ use tower_lsp_server::ls_types::request::{
     GotoImplementationResponse, GotoTypeDefinitionParams, GotoTypeDefinitionResponse,
 };
 use tower_lsp_server::ls_types::{
-    CodeAction, CodeActionParams, CodeActionResponse, CodeLens, CodeLensParams, CompletionItem,
-    CompletionParams, CompletionResponse, DidChangeConfigurationParams,
-    DidChangeTextDocumentParams, DidChangeWorkspaceFoldersParams, DidCloseTextDocumentParams,
-    DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentDiagnosticParams,
-    DocumentDiagnosticReportResult, DocumentFormattingParams, DocumentHighlight,
-    DocumentHighlightParams, DocumentLink, DocumentLinkParams, DocumentOnTypeFormattingParams,
-    DocumentRangeFormattingParams, DocumentSymbolParams, DocumentSymbolResponse,
-    ExecuteCommandParams, FoldingRange, FoldingRangeParams, GotoDefinitionParams,
-    GotoDefinitionResponse, Hover, HoverParams, InitializeParams, InitializeResult,
-    InitializedParams, InlayHint, InlayHintParams, LinkedEditingRangeParams, LinkedEditingRanges,
-    Location, Moniker, MonikerParams, PrepareRenameResponse, ReferenceParams, RenameParams,
-    SelectionRange, SelectionRangeParams, SemanticTokensDeltaParams, SemanticTokensFullDeltaResult,
-    SemanticTokensParams, SemanticTokensRangeParams, SemanticTokensRangeResult,
-    SemanticTokensResult, SignatureHelp, SignatureHelpParams, TextDocumentPositionParams, TextEdit,
-    Uri, WillSaveTextDocumentParams, WorkspaceEdit,
+    CallHierarchyItem, CallHierarchyPrepareParams, CodeAction, CodeActionParams,
+    CodeActionResponse, CodeLens, CodeLensParams, CompletionItem, CompletionParams,
+    CompletionResponse, DidChangeConfigurationParams, DidChangeTextDocumentParams,
+    DidChangeWorkspaceFoldersParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+    DidSaveTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReportResult,
+    DocumentFormattingParams, DocumentHighlight, DocumentHighlightParams, DocumentLink,
+    DocumentLinkParams, DocumentOnTypeFormattingParams, DocumentRangeFormattingParams,
+    DocumentSymbolParams, DocumentSymbolResponse, ExecuteCommandParams, FoldingRange,
+    FoldingRangeParams, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams,
+    InitializeParams, InitializeResult, InitializedParams, InlayHint, InlayHintParams,
+    LinkedEditingRangeParams, LinkedEditingRanges, Location, Moniker, MonikerParams,
+    PrepareRenameResponse, ReferenceParams, RenameParams, SelectionRange, SelectionRangeParams,
+    SemanticTokensDeltaParams, SemanticTokensFullDeltaResult, SemanticTokensParams,
+    SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult, SignatureHelp,
+    SignatureHelpParams, TextDocumentPositionParams, TextEdit, Uri, WillSaveTextDocumentParams,
+    WorkspaceEdit,
 };
 use tower_lsp_server::ls_types::{
     ColorInformation, ColorPresentation, ColorPresentationParams, DocumentColorParams,
@@ -953,6 +954,13 @@ impl LanguageServer for Kakehashi {
 
     async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {
         self.references_impl(params).await
+    }
+
+    async fn prepare_call_hierarchy(
+        &self,
+        params: CallHierarchyPrepareParams,
+    ) -> Result<Option<Vec<CallHierarchyItem>>> {
+        self.prepare_call_hierarchy_impl(params).await
     }
 
     async fn document_highlight(

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -244,6 +244,10 @@ pub(crate) struct PositionRequestContext {
     pub(crate) document: DocumentRequestContext,
     /// The cursor position within the document.
     pub(crate) position: Position,
+    /// Open-document lifetime of the snapshot that produced the region.
+    pub(crate) incarnation: u64,
+    /// Input revision of the snapshot that produced the region.
+    pub(crate) content_version: u64,
 }
 
 /// Document context plus a range.
@@ -265,6 +269,8 @@ struct PreambleResult {
     /// End-of-content derived for the bounds precheck, carried so no later
     /// stage re-derives it.
     region_end: Position,
+    incarnation: u64,
+    content_version: u64,
 }
 
 fn resolve_bridge_language_config_from_settings(
@@ -991,6 +997,8 @@ impl Kakehashi {
                 language_name,
                 upstream_request_id,
                 region_end,
+                incarnation: snapshot.incarnation(),
+                content_version: snapshot.content_version(),
             },
             position,
             range_end,
@@ -1604,11 +1612,18 @@ impl Kakehashi {
         self.ensure_fresh_tree_for_bridge(lsp_uri).await;
         let (preamble, position, _) =
             self.resolve_bridge_preamble(lsp_uri, position, None, method_name)?;
+        let incarnation = preamble.incarnation;
+        let content_version = preamble.content_version;
         let document = self
             .preamble_to_document_context(preamble, method_name)
             .await?;
 
-        Some(PositionRequestContext { document, position })
+        Some(PositionRequestContext {
+            document,
+            position,
+            incarnation,
+            content_version,
+        })
     }
 
     /// Wait for / on-demand the document's tree before a sync bridge-preamble
@@ -1746,6 +1761,8 @@ impl Kakehashi {
                 resolved,
                 language_name: language_name.clone(),
                 upstream_request_id: upstream_request_id.clone(),
+                incarnation: snapshot.incarnation(),
+                content_version: snapshot.content_version(),
             };
             // A region that resolves to no bridge config contributes nothing.
             let Some(document) = self

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -615,11 +615,11 @@ impl DiagnosticSnapshotPreparer {
                 narrower_than_editor_pull = true;
             }
             Some(HostRequestContext {
-                incarnation: 1,
-                content_version: 0,
                 uri: uri.clone(),
                 language_id: language_name.clone(),
                 text: snapshot.text_arc(),
+                incarnation: snapshot.incarnation(),
+                content_version: snapshot.content_version(),
                 configs,
                 priorities: agg.priorities,
                 strategy: agg.strategy,

--- a/src/lsp/lsp_impl/text_document.rs
+++ b/src/lsp/lsp_impl/text_document.rs
@@ -1,5 +1,6 @@
 //! Text document related LSP methods.
 
+mod call_hierarchy;
 mod code_action;
 mod code_lens;
 mod color_presentation;

--- a/src/lsp/lsp_impl/text_document/call_hierarchy.rs
+++ b/src/lsp/lsp_impl/text_document/call_hierarchy.rs
@@ -1,0 +1,189 @@
+//! Call-hierarchy preparation across virtual and host bridge layers.
+
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::ls_types::{
+    CallHierarchyItem, CallHierarchyPrepareParams, NumberOrString, Position, Uri,
+};
+
+use super::super::Kakehashi;
+use crate::lsp::aggregation::server::{
+    HostFanOutTask, dispatch_host_preferred, dispatch_preferred,
+};
+use crate::lsp::bridge::{
+    CallHierarchyDocumentRevision, HostDocument, envelope_host_call_hierarchy_items,
+};
+use crate::lsp::lsp_impl::bridge_context::parse_host_verbatim;
+
+const METHOD: &str = "textDocument/prepareCallHierarchy";
+
+impl Kakehashi {
+    pub(crate) async fn prepare_call_hierarchy_impl(
+        &self,
+        params: CallHierarchyPrepareParams,
+    ) -> Result<Option<Vec<CallHierarchyItem>>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
+        let lsp_uri = params.text_document_position_params.text_document.uri;
+        let position = params.text_document_position_params.position;
+        let work_done_token = params.work_done_progress_params.work_done_token;
+        let Some(content_version) = url::Url::parse(lsp_uri.as_str())
+            .ok()
+            .and_then(|uri| self.documents.get(&uri).map(|doc| doc.content_version()))
+        else {
+            return Ok(None);
+        };
+
+        let virt = self.call_hierarchy_prepare_virt_layer(
+            &lsp_uri,
+            position,
+            work_done_token,
+            content_version,
+        );
+        let host = self.call_hierarchy_prepare_host_layer(&lsp_uri, raw_params, content_version);
+        self.walk_layer_futures(
+            &lsp_uri,
+            METHOD,
+            METHOD,
+            virt,
+            host,
+            std::future::ready(Ok(None)),
+            |items: &Vec<CallHierarchyItem>| !items.is_empty(),
+        )
+        .await
+    }
+
+    async fn call_hierarchy_prepare_host_layer(
+        &self,
+        lsp_uri: &Uri,
+        raw_params: serde_json::Value,
+        content_version: u64,
+    ) -> Result<Option<Vec<CallHierarchyItem>>> {
+        let Some(ctx) = self.resolve_host_bridge_context(lsp_uri, METHOD) else {
+            return Ok(None);
+        };
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(ctx.upstream_request_id.as_ref());
+        let pool = self.bridge.pool_arc();
+        let fan_in = dispatch_host_preferred(
+            &ctx,
+            pool,
+            move |t: HostFanOutTask| {
+                let params = raw_params.clone();
+                async move {
+                    let raw = t
+                        .pool
+                        .send_host_raw_request(
+                            &t.server_name,
+                            &t.server_config,
+                            &HostDocument {
+                                uri: &t.uri,
+                                language_id: &t.language_id,
+                                text: &t.text,
+                                revision: Some(t.revision),
+                            },
+                            METHOD,
+                            params,
+                            t.upstream_id,
+                        )
+                        .await?;
+                    let Some(raw) = raw else {
+                        return Ok(None);
+                    };
+                    let Some(items) = parse_host_verbatim::<Vec<CallHierarchyItem>>(raw.value)
+                    else {
+                        return Ok(None);
+                    };
+                    Ok(Some(HostCallHierarchyItems {
+                        items,
+                        server_name: t.server_name,
+                        host_uri: t.uri.to_string(),
+                        revision: CallHierarchyDocumentRevision {
+                            incarnation: Some(raw.incarnation),
+                            content_version,
+                        },
+                        connection_generation: raw.connection_generation,
+                        connection_key: raw.handle.key().clone(),
+                    }))
+                }
+            },
+            |opt| matches!(opt, Some(v) if !v.items.is_empty()),
+            cancel_rx,
+        )
+        .await;
+        self.host_layer_result(fan_in, &ctx, METHOD, |won| {
+            won.map(HostCallHierarchyItems::into_enveloped_items)
+        })
+        .await
+    }
+
+    async fn call_hierarchy_prepare_virt_layer(
+        &self,
+        lsp_uri: &Uri,
+        position: Position,
+        work_done_token: Option<NumberOrString>,
+        content_version: u64,
+    ) -> Result<Option<Vec<CallHierarchyItem>>> {
+        let Some(ctx) = self
+            .resolve_bridge_contexts(lsp_uri, position, METHOD)
+            .await
+        else {
+            return Ok(None);
+        };
+        let (cancel_rx, _cancel_guard) =
+            self.subscribe_cancel(ctx.document.upstream_request_id.as_ref());
+        let pool = self.bridge.pool_arc();
+        let position = ctx.position;
+        let result = dispatch_preferred(
+            &ctx.document,
+            pool,
+            |t| {
+                let work_done_token = work_done_token.clone();
+                async move {
+                    t.pool
+                        .send_call_hierarchy_prepare_request(
+                            &t.server_name,
+                            &t.server_config,
+                            &t.uri,
+                            position,
+                            t.region_end(),
+                            &t.injection_language,
+                            &t.region_id,
+                            t.offset,
+                            &t.virtual_content,
+                            content_version,
+                            t.upstream_id,
+                            work_done_token,
+                        )
+                        .await
+                }
+            },
+            |opt| matches!(opt, Some(v) if !v.is_empty()),
+            cancel_rx,
+        )
+        .await;
+        result
+            .handle(&self.notifier(), "prepare call hierarchy", None, Ok)
+            .await
+    }
+}
+
+struct HostCallHierarchyItems {
+    items: Vec<CallHierarchyItem>,
+    server_name: String,
+    host_uri: String,
+    revision: CallHierarchyDocumentRevision,
+    connection_generation: u64,
+    connection_key: crate::lsp::bridge::ConnectionKey,
+}
+
+impl HostCallHierarchyItems {
+    fn into_enveloped_items(mut self) -> Vec<CallHierarchyItem> {
+        envelope_host_call_hierarchy_items(
+            &mut self.items,
+            &self.server_name,
+            &self.host_uri,
+            self.revision,
+            self.connection_generation,
+            &self.connection_key,
+        );
+        self.items
+    }
+}

--- a/src/lsp/lsp_impl/text_document/call_hierarchy.rs
+++ b/src/lsp/lsp_impl/text_document/call_hierarchy.rs
@@ -25,20 +25,8 @@ impl Kakehashi {
         let lsp_uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
         let work_done_token = params.work_done_progress_params.work_done_token;
-        let Some(content_version) = url::Url::parse(lsp_uri.as_str())
-            .ok()
-            .and_then(|uri| self.documents.get(&uri).map(|doc| doc.content_version()))
-        else {
-            return Ok(None);
-        };
-
-        let virt = self.call_hierarchy_prepare_virt_layer(
-            &lsp_uri,
-            position,
-            work_done_token,
-            content_version,
-        );
-        let host = self.call_hierarchy_prepare_host_layer(&lsp_uri, raw_params, content_version);
+        let virt = self.call_hierarchy_prepare_virt_layer(&lsp_uri, position, work_done_token);
+        let host = self.call_hierarchy_prepare_host_layer(&lsp_uri, raw_params);
         self.walk_layer_futures(
             &lsp_uri,
             METHOD,
@@ -55,11 +43,12 @@ impl Kakehashi {
         &self,
         lsp_uri: &Uri,
         raw_params: serde_json::Value,
-        content_version: u64,
     ) -> Result<Option<Vec<CallHierarchyItem>>> {
         let Some(ctx) = self.resolve_host_bridge_context(lsp_uri, METHOD) else {
             return Ok(None);
         };
+        let incarnation = ctx.incarnation;
+        let content_version = ctx.content_version;
         let (cancel_rx, _cancel_guard) = self.subscribe_cancel(ctx.upstream_request_id.as_ref());
         let pool = self.bridge.pool_arc();
         let fan_in = dispatch_host_preferred(
@@ -70,7 +59,7 @@ impl Kakehashi {
                 async move {
                     let raw = t
                         .pool
-                        .send_host_raw_request(
+                        .send_host_raw_request_for_incarnation(
                             &t.server_name,
                             &t.server_config,
                             &HostDocument {
@@ -82,6 +71,7 @@ impl Kakehashi {
                             METHOD,
                             params,
                             t.upstream_id,
+                            incarnation,
                         )
                         .await?;
                     let Some(raw) = raw else {
@@ -119,7 +109,6 @@ impl Kakehashi {
         lsp_uri: &Uri,
         position: Position,
         work_done_token: Option<NumberOrString>,
-        content_version: u64,
     ) -> Result<Option<Vec<CallHierarchyItem>>> {
         let Some(ctx) = self
             .resolve_bridge_contexts(lsp_uri, position, METHOD)
@@ -131,6 +120,8 @@ impl Kakehashi {
             self.subscribe_cancel(ctx.document.upstream_request_id.as_ref());
         let pool = self.bridge.pool_arc();
         let position = ctx.position;
+        let incarnation = ctx.incarnation;
+        let content_version = ctx.content_version;
         let result = dispatch_preferred(
             &ctx.document,
             pool,
@@ -148,6 +139,7 @@ impl Kakehashi {
                             &t.region_id,
                             t.offset,
                             &t.virtual_content,
+                            incarnation,
                             content_version,
                             t.upstream_id,
                             work_done_token,

--- a/src/lsp/lsp_impl/text_document/call_hierarchy.rs
+++ b/src/lsp/lsp_impl/text_document/call_hierarchy.rs
@@ -110,12 +110,13 @@ impl Kakehashi {
         position: Position,
         work_done_token: Option<NumberOrString>,
     ) -> Result<Option<Vec<CallHierarchyItem>>> {
-        let Some(ctx) = self
+        let Some(mut ctx) = self
             .resolve_bridge_contexts(lsp_uri, position, METHOD)
             .await
         else {
             return Ok(None);
         };
+        ctx.document.client_progress_token = work_done_token;
         let (cancel_rx, _cancel_guard) =
             self.subscribe_cancel(ctx.document.upstream_request_id.as_ref());
         let pool = self.bridge.pool_arc();
@@ -125,27 +126,24 @@ impl Kakehashi {
         let result = dispatch_preferred(
             &ctx.document,
             pool,
-            |t| {
-                let work_done_token = work_done_token.clone();
-                async move {
-                    t.pool
-                        .send_call_hierarchy_prepare_request(
-                            &t.server_name,
-                            &t.server_config,
-                            &t.uri,
-                            position,
-                            t.region_end(),
-                            &t.injection_language,
-                            &t.region_id,
-                            t.offset,
-                            &t.virtual_content,
-                            incarnation,
-                            content_version,
-                            t.upstream_id,
-                            work_done_token,
-                        )
-                        .await
-                }
+            |t| async move {
+                t.pool
+                    .send_call_hierarchy_prepare_request(
+                        &t.server_name,
+                        &t.server_config,
+                        &t.uri,
+                        position,
+                        t.region_end(),
+                        &t.injection_language,
+                        &t.region_id,
+                        t.offset,
+                        &t.virtual_content,
+                        incarnation,
+                        content_version,
+                        t.upstream_id,
+                        t.client_progress_token,
+                    )
+                    .await
             },
             |opt| matches!(opt, Some(v) if !v.is_empty()),
             cancel_rx,

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -1321,11 +1321,14 @@ print("hello")
             host_pull_enabled: true,
             narrower_than_editor_pull: false,
             host: Some(HostRequestContext {
-                incarnation: 1,
-                content_version: 0,
                 uri: uri.clone(),
                 language_id: "rust".to_string(),
                 text: std::sync::Arc::from("fn debounce_snapshot() {}"),
+                // The pool's host lifetime for this URI is 1 and the eager
+                // re-sync is fenced on it; the varying store revision drives
+                // the snapshot lineage only.
+                incarnation: 1,
+                content_version: 0,
                 configs: configs.clone(),
                 priorities: vec![],
                 strategy: AggregationStrategy::Concatenated,
@@ -1449,11 +1452,11 @@ print("hello")
             host_pull_enabled: true,
             narrower_than_editor_pull: false,
             host: Some(HostRequestContext {
-                incarnation: 1,
-                content_version: 0,
                 uri: uri.clone(),
                 language_id: "rust".to_string(),
                 text: Arc::from("fn stale() {}"),
+                incarnation: 0,
+                content_version: 0,
                 configs,
                 priorities: vec![],
                 strategy: AggregationStrategy::Concatenated,

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -1771,8 +1771,12 @@ fn main() {
                     .and_then(Value::as_str)
                     .filter(|uri| documents.contains_key(*uri))
                     .map(|uri| {
+                        let position = message.pointer("/params/position").map(|position| {
+                            format!("{}:{}", position["line"], position["character"])
+                        });
                         json!([{
                             "name": "mock-call",
+                            "detail": position,
                             "kind": 12,
                             "uri": uri,
                             "range": {

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -91,6 +91,8 @@
 //!   `documentLinkProvider` with `resolveProvider: false` and answer with a
 //!   link carrying opaque `data`: an ordinary payload, and one that occupies
 //!   the reserved `kakehashi` key.
+//! - `call-hierarchy-prepare` — advertises `callHierarchyProvider` and returns
+//!   one preparation item that echoes the requested document URI.
 //! - `document-link` / `document-link-resolve` / `document-link-resolve-replacement` — advertise
 //!   `textDocument/documentLink` with one link whose tooltip identifies the
 //!   requested URI. The resolve mode initially returns data only and materializes
@@ -250,6 +252,10 @@ fn main() {
                     "definition" => json!({
                         "definitionProvider": true,
                         "hoverProvider": true,
+                        "textDocumentSync": 1
+                    }),
+                    "call-hierarchy-prepare" => json!({
+                        "callHierarchyProvider": true,
                         "textDocumentSync": 1
                     }),
                     "code-lens"
@@ -1754,6 +1760,30 @@ fn main() {
                                 "newText": "existing "
                             }],
                             "data": data
+                        }])
+                    })
+                    .unwrap_or(Value::Null);
+                respond(&mut writer, id, result);
+            }
+            "textDocument/prepareCallHierarchy" => {
+                let result = message
+                    .pointer("/params/textDocument/uri")
+                    .and_then(Value::as_str)
+                    .filter(|uri| documents.contains_key(*uri))
+                    .map(|uri| {
+                        json!([{
+                            "name": "mock-call",
+                            "kind": 12,
+                            "uri": uri,
+                            "range": {
+                                "start": { "line": 0, "character": 0 },
+                                "end": { "line": 0, "character": 5 }
+                            },
+                            "selectionRange": {
+                                "start": { "line": 0, "character": 0 },
+                                "end": { "line": 0, "character": 4 }
+                            },
+                            "data": { "mock": "call-item" }
                         }])
                     })
                     .unwrap_or(Value::Null);

--- a/tests/e2e/e2e_call_hierarchy.rs
+++ b/tests/e2e/e2e_call_hierarchy.rs
@@ -48,13 +48,13 @@ fn init_client(host_layer: bool) -> (LspClient, tempfile::TempDir) {
     (client, config_dir)
 }
 
-fn prepare_with_retry(client: &mut LspClient, uri: &str, line: u64) -> Vec<Value> {
+fn prepare_with_retry(client: &mut LspClient, uri: &str, line: u64, character: u64) -> Vec<Value> {
     for _ in 0..300 {
         let response = client.send_request(
             "textDocument/prepareCallHierarchy",
             json!({
                 "textDocument": { "uri": uri },
-                "position": { "line": line, "character": 1 }
+                "position": { "line": line, "character": character }
             }),
         );
         assert!(response.get("error").is_none(), "{response}");
@@ -83,18 +83,19 @@ fn prepare_call_hierarchy_translates_virtual_items_and_envelopes_origin() {
             "uri": uri,
             "languageId": "markdown",
             "version": 1,
-            "text": "# Test\n\n```lua\ncall()\n```\n"
+            "text": "> ```lua\n> call()\n> ```\n"
         }}),
     );
 
-    let items = prepare_with_retry(&mut client, uri, 3);
+    let items = prepare_with_retry(&mut client, uri, 1, 3);
     assert_eq!(items.len(), 1);
     let item = &items[0];
     assert_eq!(item["uri"], uri);
-    assert_eq!(item["range"]["start"], json!({ "line": 3, "character": 0 }));
+    assert_eq!(item["detail"], "0:1");
+    assert_eq!(item["range"]["start"], json!({ "line": 1, "character": 2 }));
     assert_eq!(
         item["selectionRange"]["end"],
-        json!({ "line": 3, "character": 4 })
+        json!({ "line": 1, "character": 6 })
     );
     assert_eq!(item["data"]["kakehashi"]["origin"], "mock-call-hierarchy");
     assert_eq!(
@@ -119,7 +120,7 @@ fn prepare_call_hierarchy_envelopes_host_items_without_translation() {
         }}),
     );
 
-    let items = prepare_with_retry(&mut client, uri, 0);
+    let items = prepare_with_retry(&mut client, uri, 0, 1);
     assert_eq!(items.len(), 1);
     let item = &items[0];
     assert_eq!(item["uri"], uri);

--- a/tests/e2e/e2e_call_hierarchy.rs
+++ b/tests/e2e/e2e_call_hierarchy.rs
@@ -1,0 +1,133 @@
+//! End-to-end coverage for staged `textDocument/prepareCallHierarchy` routing.
+
+use std::time::Duration;
+
+use crate::helpers::lsp_client::LspClient;
+use serde_json::{Value, json};
+
+fn mock_formatter_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_mock-lsp-formatter")
+}
+
+fn init_client(host_layer: bool) -> (LspClient, tempfile::TempDir) {
+    let config_dir = tempfile::TempDir::new().expect("config temp dir");
+    let config_path = config_dir.path().join("call_hierarchy.toml");
+    std::fs::write(&config_path, "").expect("write config");
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("UTF-8 config path"))
+        .build();
+    let mut initialization_options = json!({
+        "languageServers": {
+            "mock-call-hierarchy": {
+                "cmd": [mock_formatter_bin(), "call-hierarchy-prepare"],
+                "languages": ["lua"]
+            }
+        }
+    });
+    if host_layer {
+        initialization_options["languages"] = json!({
+            "lua": { "bridge": { "_self": { "enabled": true } } }
+        });
+    }
+    let initialized = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": initialization_options
+        }),
+    );
+    assert!(
+        initialized["result"]["capabilities"]["callHierarchyProvider"].is_null(),
+        "capability stays hidden until incomingCalls and outgoingCalls are implemented"
+    );
+    client.send_notification("initialized", json!({}));
+    (client, config_dir)
+}
+
+fn prepare_with_retry(client: &mut LspClient, uri: &str, line: u64) -> Vec<Value> {
+    for _ in 0..300 {
+        let response = client.send_request(
+            "textDocument/prepareCallHierarchy",
+            json!({
+                "textDocument": { "uri": uri },
+                "position": { "line": line, "character": 1 }
+            }),
+        );
+        assert!(response.get("error").is_none(), "{response}");
+        if let Some(items) = response["result"].as_array()
+            && !items.is_empty()
+        {
+            return items.clone();
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("timed out waiting for call hierarchy items");
+}
+
+fn shutdown(client: &mut LspClient) {
+    let _ = client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
+fn prepare_call_hierarchy_translates_virtual_items_and_envelopes_origin() {
+    let (mut client, _config_dir) = init_client(false);
+    let uri = "file:///test_call_hierarchy.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({ "textDocument": {
+            "uri": uri,
+            "languageId": "markdown",
+            "version": 1,
+            "text": "# Test\n\n```lua\ncall()\n```\n"
+        }}),
+    );
+
+    let items = prepare_with_retry(&mut client, uri, 3);
+    assert_eq!(items.len(), 1);
+    let item = &items[0];
+    assert_eq!(item["uri"], uri);
+    assert_eq!(item["range"]["start"], json!({ "line": 3, "character": 0 }));
+    assert_eq!(
+        item["selectionRange"]["end"],
+        json!({ "line": 3, "character": 4 })
+    );
+    assert_eq!(item["data"]["kakehashi"]["origin"], "mock-call-hierarchy");
+    assert_eq!(
+        item["data"]["kakehashi"]["inner"],
+        json!({ "mock": "call-item" })
+    );
+    assert_eq!(item["data"]["kakehashi"]["host_layer"], Value::Null);
+    shutdown(&mut client);
+}
+
+#[test]
+fn prepare_call_hierarchy_envelopes_host_items_without_translation() {
+    let (mut client, _config_dir) = init_client(true);
+    let uri = "file:///test_call_hierarchy.lua";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({ "textDocument": {
+            "uri": uri,
+            "languageId": "lua",
+            "version": 1,
+            "text": "call()\n"
+        }}),
+    );
+
+    let items = prepare_with_retry(&mut client, uri, 0);
+    assert_eq!(items.len(), 1);
+    let item = &items[0];
+    assert_eq!(item["uri"], uri);
+    assert_eq!(item["range"]["start"], json!({ "line": 0, "character": 0 }));
+    assert_eq!(item["data"]["kakehashi"]["host_layer"], true);
+    assert_eq!(
+        item["data"]["kakehashi"]["inner"],
+        json!({ "mock": "call-item" })
+    );
+    shutdown(&mut client);
+}

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -14,6 +14,7 @@
 
 mod helpers;
 
+mod e2e_call_hierarchy;
 mod e2e_cancel_request;
 mod e2e_cli_diagnose;
 mod e2e_cli_format;


### PR DESCRIPTION
## Summary

- route `textDocument/prepareCallHierarchy` through virtual and opted-in host layers
- translate virtual item URIs/ranges to host coordinates and preserve producer/revision lineage for follow-up requests
- advertise call-hierarchy support to downstream servers while keeping the upstream provider hidden until incoming/outgoing calls are implemented
- reject requests whose source document was closed and reopened before enqueue

## Validation

- `make check`
- `make test` (3632 passed, 2 ignored)
- `cargo test --features e2e --test e2e e2e_call_hierarchy::` (2 passed)
- multi-perspective revise review: lifecycle, protocol, tests/docs all CLEAN

Stacked on #1026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for preparing call hierarchies through the language server.
  * Call-hierarchy results work across host and embedded documents, with positions and ranges mapped to the corresponding source document.
  * Results include metadata identifying their source and context.

* **Bug Fixes**
  * Prevented stale document versions and unrelated embedded regions from returning invalid results.
  * Improved request handling as documents close, reopen, or change.

* **Tests**
  * Added capability, lifecycle, host, embedded-document, and end-to-end coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->