### PR TITLE
feat(lsp): bridge document colors across host and virtual layers

### DIFF
--- a/__ignored/samples/document_color.md
+++ b/__ignored/samples/document_color.md
@@ -1,0 +1,35 @@
+# Document color host/virtual layer sample
+
+Run kakehashi with `KAKEHASHI_EXPERIMENTAL=true`, a Markdown language server
+that provides document colors, and a CSS language server for embedded blocks.
+Configure the Markdown language with:
+
+```toml
+[languages.markdown.bridge._self]
+enabled = true
+
+[languages.markdown.layers.aggregation."textDocument/documentColor"]
+strategy = "concatenated"
+priorities = ["virt", "host"]
+```
+
+A host-language provider can mark this prose color: `#ff0000`.
+
+```css
+.sample {
+  color: #00ff00;
+}
+```
+
+In Neovim, inspect both results. The host range must remain on the prose line,
+while the CSS range must point inside the fenced block:
+
+```vim
+:lua local c=vim.lsp.get_clients({bufnr=0})[1]; vim.lsp.buf_request(0, 'textDocument/documentColor', {textDocument={uri=vim.uri_from_bufnr(0)}}, function(e,r) assert(not e, vim.inspect(e)); vim.print(r) end)
+```
+
+Presentation routing uses the supplied range, not the producing color server:
+the prose range outside the fence routes through Markdown, while the CSS range
+uses the embedded server and translates only safe edits back to this buffer.
+If a host server also reports colors inside a fence, configure
+`textDocument/colorPresentation` as `concatenated` to retain both answers.

--- a/docs/README.md
+++ b/docs/README.md
@@ -675,8 +675,8 @@ Each entry in the `bridge` map configures bridging for one injection language:
 The reserved `_self` key makes the host language its own bridge target: with
 it enabled, requests on the host document are forwarded to servers whose
 `languages` matches the **host** language (including a `"*"` server), with the real URI and no
-coordinate translation. All bridged request methods are wired (exceptions:
-semantic tokens and document color); by default the host layer is
+coordinate translation. All bridged request methods are wired except semantic
+tokens; by default the host layer is
 tried after
 `virt` (see `layers` above), so for `preferred` methods injections keep
 winning inside code fences while the host server answers everywhere else —
@@ -767,7 +767,7 @@ returning the response:
 | Field | Description |
 |-------|-------------|
 | `priorities` | Ordered allowlist of layers, highest priority first (same allowlist rule as the server-name `priorities` above, but over the closed set `virt`/`host`/`native` — no `"*"`). Layers omitted from the list do not participate; `[]` disables the method entirely. Default: `["virt", "host", "native"]`. Omitting `"virt"` turns off injection bridging for that method. |
-| `strategy` | Cross-layer combine strategy: `"preferred"` (first non-empty layer wins) or `"concatenated"`. Consumed by `textDocument/formatting` (default `"concatenated"`: a sequential pipeline — injection regions format first (`virt`), then the host formatter (`host`, see `bridge._self`) formats the resulting text, collapsing into one whole-document edit), by the diagnostics methods (default `"concatenated"`: the `virt` regions' diagnostics and the host servers' diagnostics for the real document merge into one report/publish; `"preferred"` returns the first non-empty layer instead), by `textDocument/codeAction` (default `"concatenated"`: the injection region's actions and the host servers' actions appear in one menu, with at most one `isPreferred` action kept), and by list-shaped whole-document methods such as `textDocument/documentLink`, `textDocument/foldingRange`, and `textDocument/codeLens` when explicitly configured. Every other method combines with `"preferred"` regardless of this field. |
+| `strategy` | Cross-layer combine strategy: `"preferred"` (first non-empty layer wins) or `"concatenated"`. Consumed by `textDocument/formatting` (default `"concatenated"`: a sequential pipeline — injection regions format first (`virt`), then the host formatter (`host`, see `bridge._self`) formats the resulting text, collapsing into one whole-document edit), by the diagnostics methods (default `"concatenated"`: the `virt` regions' diagnostics and the host servers' diagnostics for the real document merge into one report/publish; `"preferred"` returns the first non-empty layer instead), by `textDocument/codeAction` (default `"concatenated"`: the injection region's actions and the host servers' actions appear in one menu, with at most one `isPreferred` action kept), by list-shaped whole-document methods such as `textDocument/documentColor`, `textDocument/documentLink`, `textDocument/foldingRange`, and `textDocument/codeLens`, and by `textDocument/colorPresentation` when explicitly configured. Every other method combines with `"preferred"` regardless of this field. |
 
 Details:
 

--- a/docs/architecture-decisions/cross-layer-aggregation.md
+++ b/docs/architecture-decisions/cross-layer-aggregation.md
@@ -20,8 +20,8 @@ Phased roadmap:
    `resolve_layer_config_from_settings` directly (it already holds a loaded
    settings arc), keyed `textDocument/publishDiagnostics` to match its
    aggregation config. With host bridging (host-document-bridge)
-   implemented for the bridged request methods (documented exceptions:
-   document color is virt-only), handlers run the real
+   implemented for the bridged request methods (semantic tokens remain
+   native-only), handlers run the real
    stage-2 `preferred` walk (`Kakehashi::walk_layers` →
    `race_layers_preferred`): the virt and host layers fan out
    **concurrently** — the layer-level analogue of the stage-1 `preferred`
@@ -93,6 +93,12 @@ Phased roadmap:
    are collapsed to the first occurrence
    (`resolve_preferred_collision`); `preferred` returns the first non-empty
    layer instead.
+6. **List result aggregation** — ✅ implemented for the whole-document
+   `documentColor`, `documentLink`, `foldingRange`, and `codeLens` methods,
+   plus range-based `colorPresentation`. Their default remains `preferred`;
+   an explicit `concatenated` appends non-empty layer results in configured
+   priority order. `colorPresentation` has no producer envelope in the LSP
+   item, so its follow-up routing is determined by the supplied range.
 
 ## Context
 
@@ -162,7 +168,7 @@ priorities = ["virt", "host", "native"]   # innermost-first; mirrors "deeper win
 # enabled flags decide whether a bridge target exists at all.
 # strategy: per-method default (concatenated for diagnostics, codeAction,
 # and formatting; otherwise preferred). List-shaped whole-document methods
-# such as documentLink/foldingRange/codeLens can opt into concatenated.
+# and colorPresentation can opt into concatenated.
 
 # ---- User: markdown hover should prefer the host LS, and drop native ----
 [languages.markdown.layers.aggregation."textDocument/hover"]

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -37,13 +37,14 @@ Partially implemented:
   and documentLink use the shared whole-document winner hook. Covered: definition, hover, declaration,
   typeDefinition, implementation, references, completion, signatureHelp,
   documentHighlight, rename, prepareRename, linkedEditingRange, moniker,
-  inlayHint, documentSymbol, documentLink, foldingRange, codeLens,
+  inlayHint, documentSymbol, documentLink, documentColor, colorPresentation,
+  foldingRange, codeLens,
   formatting, and rangeFormatting (which shares the formatting layer key).
   Diagnostics are covered with real cross-layer `concatenated` (the
   cross-layer-aggregation diagnostics phase): pull and synthetic push both
   merge host-server pulls (real URI) with the virt regions' results per the
-  layer strategy. Not covered: semantic tokens (native-only) and the experimental
-  documentColor/colorPresentation pair. `completionItem/resolve` routes by
+  layer strategy. Not covered: semantic tokens (native-only).
+  `completionItem/resolve` routes by
   the envelope stamped into `CompletionItem.data`; the host layer stamps one
   too (marked `host_layer`, so the resolve forwards VERBATIM — no coordinate
   translation and no injection-region edit guard). Both layers mint under

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -406,7 +406,8 @@ foldingRange, linkedEditingRange, … — lives in `docs/language-features.md`.
 | rangeFormatting | ✅ Implemented | Shares the formatting guards |
 | onTypeFormatting | ✅ Implemented | Shares the formatting guards |
 | inlayHint | ✅ Implemented | Unsafe accept-edit sets dropped whole; hint kept; `inlayHint/resolve` edits pass the same guard |
-| colorPresentation | ✅ Implemented | Experimental opt-in; unsafe presentations dropped |
+| documentColor | ✅ Implemented | Experimental opt-in; whole-document host/virt results follow the configured layer strategy |
+| colorPresentation | ✅ Implemented | Experimental opt-in; host edits pass through verbatim, unsafe virtual presentations are dropped |
 | documentHighlight | ✅ Implemented | Strategy-2 shape (single-document, position-mapped) |
 | diagnostics | ✅ Implemented | Push + pull with host translation |
 | semanticTokens | ❌ Not bridged | Native tree-sitter tokens ARE served (semantic-token-overlap-resolution); downstream-server tokens are not fetched or merged — doing so would enable the parallel fetch strategy |

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -437,17 +437,16 @@ Any reader that must resolve against **live** positions is position-critical
   rarely fires (a parked request records the served version at settle); it
   remains for the backstop path and non-edit token changes. The `CancelToken`
   bail stays narrowed to reclaiming a superseded compute's CPU (§4).
-- **Serve-stale, passively refreshed** — whole-document, no-position reads:
-  `documentSymbol`, `documentColor`, plus the `whole_document_fan_out` family
-  (`documentLink`, `foldingRange`, `codeLens`), and pull-mode
-  `textDocument/diagnostic` (the `virt_enabled` branch that calls
-  `ensure_document_parsed`). `did_save`'s synthetic-diagnostic effect is likewise
-  passive (a notification, not a request — its *diagnostics* may trail a snapshot,
-  self-healing on republish). No server→client refresh exists for these and adding
-  one is out of scope; they serve the latest snapshot and self-correct on the
-  client's **next** request (re-requested on redraw/scroll, not held live). The
-  staleness window is one or more edits (unbounded under sustained typing) but
-  non-visual-jarring; this is the deliberate, user-sanctioned relaxation.
+- **Passively refreshed whole-document reads** — `documentSymbol` and pull-mode
+  `textDocument/diagnostic` may serve the latest stale snapshot. The
+  `whole_document_fan_out` family (`documentColor`, `documentLink`,
+  `foldingRange`, `codeLens`) instead waits up to 200 ms for a current snapshot
+  and contributes no virtual result if it remains stale, because its fallback
+  region resolution can mint tracker identities. `did_save`'s synthetic-diagnostic
+  effect is likewise passive (a notification, not a request — its diagnostics may
+  trail a snapshot, self-healing on republish). No server→client refresh exists
+  for these and adding one is out of scope; they self-correct on the client's
+  **next** request (re-requested on redraw/scroll, not held live).
 - **Staleness-reject** — every **position/range** reader, because its
   coordinates are authored against the **live** text: `semanticTokens/range`,
   `kakehashi/node/*`, `selectionRange`, `formatting`, `rangeFormatting`,

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -106,9 +106,8 @@ embedded blocks. Works for any grammar, no setup required.
 ## Bridged features
 
 The features below are served by a language server configured for the
-embedded language — most of them also on the surrounding document itself,
-by a `bridge._self` host server (document color is the exception and stays
-injection-only).
+embedded language — also on the surrounding document itself where a
+`bridge._self` host server is configured.
 Placing the cursor outside an embedded
 code block yields no result from the injection bridges; with `bridge._self`
 configured, the host language's own servers still answer there.
@@ -335,6 +334,14 @@ palette/registered-list caveats.
 and [`textDocument/colorPresentation`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_colorPresentation)
 
 Shows color swatches and color picker presentations for embedded blocks.
+Document colors can also combine embedded and host-language server results;
+set `layers.aggregation."textDocument/documentColor".strategy = "concatenated"`
+to retain both layers. Presentation routing is range-based because the LSP
+color item carries no producer identity: outside an injection the host server
+receives the real URI, range, and edits unchanged; inside an injection the
+default `virt → host` preference can select the virtual server even for a
+host-produced color. Configure `textDocument/colorPresentation` as
+`concatenated` to retain answers from both layers in that ambiguous case.
 Presentations whose primary edit (explicit, or the implicit label replacement)
 would corrupt the host document around the embedded block are dropped
 fail-closed; unsafe additional edits are dropped as one atomic set while the

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -35,7 +35,7 @@
 //!   (#480) is therefore a liveness fix, not just a latency one; until then
 //!   the exposure is one-time, first open of an uninstalled parser.
 //! - **Readers** (the `semanticTokens` family, the `kakehashi/captures`
-//!   triple, the edit-producing formatting/rename requests, and pull
+//!   triple, the edit-producing formatting/rename/color-presentation requests, and pull
 //!   diagnostics) snapshot the current
 //!   tail ticket at `call` time and run only once that ticket is done, so a
 //!   request observes every edit that preceded it on the wire — without
@@ -355,6 +355,8 @@ fn classify(req: &Request) -> Option<Role> {
         | "textDocument/prepareRename"
         | "textDocument/codeAction"
         | "textDocument/inlayHint"
+        | "textDocument/documentColor"
+        | "textDocument/colorPresentation"
         | "textDocument/diagnostic"
         | "kakehashi/captures/full"
         | "kakehashi/captures/full/delta"
@@ -791,6 +793,8 @@ mod tests {
             "textDocument/prepareRename",
             "textDocument/codeAction",
             "textDocument/inlayHint",
+            "textDocument/documentColor",
+            "textDocument/colorPresentation",
             "textDocument/diagnostic",
             "kakehashi/captures/full",
             "kakehashi/captures/full/delta",
@@ -1006,6 +1010,70 @@ mod tests {
         assert!(reader.is_woken(), "writer completion must wake the reader");
         assert!(reader.poll().is_ready());
 
+        assert_eq!(
+            *log.lock().recover_poison("ingress_order::tests"),
+            vec!["change", "reader"]
+        );
+    }
+
+    #[tokio::test]
+    async fn gate_runs_color_presentation_only_after_preceding_change() {
+        let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let mut gate = IngressOrderGate::new(MockInner {
+            log: Arc::clone(&log),
+            stall_method: "textDocument/didChange",
+            release: Some(release_rx),
+        });
+
+        let writer_fut = gate.call(notification("textDocument/didChange", URI));
+        let presentation_fut = gate.call(notification("textDocument/colorPresentation", URI));
+        let mut writer = tokio_test::task::spawn(writer_fut);
+        let mut presentation = tokio_test::task::spawn(presentation_fut);
+
+        assert!(presentation.poll().is_pending());
+        assert!(
+            writer.poll().is_pending(),
+            "didChange stalls on the oneshot"
+        );
+        assert!(
+            presentation.poll().is_pending(),
+            "colorPresentation must remain behind the preceding didChange"
+        );
+
+        release_tx.send(()).expect("didChange is waiting");
+        assert!(writer.poll().is_ready());
+        assert!(presentation.is_woken());
+        assert!(presentation.poll().is_ready());
+        assert_eq!(
+            *log.lock().recover_poison("ingress_order::tests"),
+            vec!["change", "reader"]
+        );
+    }
+
+    #[tokio::test]
+    async fn gate_runs_document_color_only_after_preceding_change() {
+        let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let mut gate = IngressOrderGate::new(MockInner {
+            log: Arc::clone(&log),
+            stall_method: "textDocument/didChange",
+            release: Some(release_rx),
+        });
+
+        let writer_fut = gate.call(notification("textDocument/didChange", URI));
+        let color_fut = gate.call(notification("textDocument/documentColor", URI));
+        let mut writer = tokio_test::task::spawn(writer_fut);
+        let mut color = tokio_test::task::spawn(color_fut);
+
+        assert!(color.poll().is_pending());
+        assert!(writer.poll().is_pending());
+        assert!(color.poll().is_pending());
+
+        release_tx.send(()).expect("didChange is waiting");
+        assert!(writer.poll().is_ready());
+        assert!(color.is_woken());
+        assert!(color.poll().is_ready());
         assert_eq!(
             *log.lock().recover_poison("ingress_order::tests"),
             vec!["change", "reader"]

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1013,8 +1013,7 @@ impl Kakehashi {
     /// resolved `layers.priorities`, the bridge dispatch is skipped entirely.
     ///
     /// Used by entry points outside the [`Self::walk_layers`] race — the
-    /// shared bridge preamble and the virt-only handlers (rangeFormatting's
-    /// region pass, documentColor) that have no host contributor yet.
+    /// shared bridge preamble and rangeFormatting's virtual-region pass.
     /// Handlers on the walk get layer membership from the race itself, and
     /// the diagnostics paths resolve the full layer config directly (they
     /// gate virt and host independently).

--- a/src/lsp/lsp_impl/text_document/color_presentation.rs
+++ b/src/lsp/lsp_impl/text_document/color_presentation.rs
@@ -1,10 +1,16 @@
 //! Color presentation method for Kakehashi.
 
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::{ColorPresentation, ColorPresentationParams};
+use tower_lsp_server::ls_types::{Color, ColorPresentation, ColorPresentationParams, Range, Uri};
 
 use super::super::Kakehashi;
-use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::aggregation::server::{
+    HostFanOutTask, dispatch_host_preferred, dispatch_preferred,
+};
+use crate::lsp::bridge::HostDocument;
+use crate::lsp::lsp_impl::bridge_context::parse_host_verbatim;
+
+const METHOD: &str = "textDocument/colorPresentation";
 
 impl Kakehashi {
     pub(crate) async fn color_presentation_impl(
@@ -17,15 +23,38 @@ impl Kakehashi {
         if !self.experimental_enabled() {
             return Ok(Vec::new());
         }
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document.uri;
-        let range = params.range;
-        let color = params.color;
+        let virt = self.color_presentation_virt_layer(&lsp_uri, params.range, params.color);
+        let host = self.color_presentation_host_layer(&lsp_uri, raw_params);
+        self.walk_layers_by_strategy(
+            &lsp_uri,
+            METHOD,
+            METHOD,
+            virt,
+            host,
+            std::future::ready(Ok(None)),
+            |presentations: &Vec<ColorPresentation>| !presentations.is_empty(),
+            |mut acc, mut next| {
+                acc.append(&mut next);
+                acc
+            },
+        )
+        .await
+        .map(Option::unwrap_or_default)
+    }
 
+    async fn color_presentation_virt_layer(
+        &self,
+        lsp_uri: &Uri,
+        range: Range,
+        color: Color,
+    ) -> Result<Option<Vec<ColorPresentation>>> {
         let Some(ctx) = self
-            .resolve_bridge_contexts_for_range(&lsp_uri, range, "textDocument/colorPresentation")
+            .resolve_bridge_contexts_for_range(lsp_uri, range, METHOD)
             .await
         else {
-            return Ok(Vec::new());
+            return Ok(None);
         };
 
         let (cancel_rx, _cancel_guard) =
@@ -33,13 +62,6 @@ impl Kakehashi {
 
         // Fan-out color presentation requests to all matching servers
         let pool = self.bridge.pool_arc();
-        // RAII sweep: virt-only handler with no layer race or outer sweep —
-        // clean stale registry entries on every exit, including a dropped
-        // request future (dispatch_preferred aborts losers without joining).
-        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard::new(
-            pool.clone(),
-            ctx.document.upstream_request_id.clone(),
-        );
         let range = ctx.range;
         let result = dispatch_preferred(
             &ctx.document,
@@ -67,7 +89,60 @@ impl Kakehashi {
         .await;
 
         result
-            .handle(&self.notifier(), "color presentation", Vec::new(), Ok)
+            .handle(&self.notifier(), "color presentation", None, |items| {
+                Ok((!items.is_empty()).then_some(items))
+            })
+            .await
+    }
+
+    async fn color_presentation_host_layer(
+        &self,
+        lsp_uri: &Uri,
+        raw_params: serde_json::Value,
+    ) -> Result<Option<Vec<ColorPresentation>>> {
+        let Some(ctx) = self.resolve_host_bridge_context(lsp_uri, METHOD) else {
+            return Ok(None);
+        };
+        let revision = crate::lsp::bridge::HostRevision {
+            incarnation: ctx.incarnation,
+            content_version: ctx.content_version,
+        };
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(ctx.upstream_request_id.as_ref());
+        let pool = self.bridge.pool_arc();
+        let fan_in = dispatch_host_preferred(
+            &ctx,
+            pool,
+            move |t: HostFanOutTask| {
+                let params = raw_params.clone();
+                async move {
+                    let raw = t
+                        .pool
+                        .send_host_raw_request(
+                            &t.server_name,
+                            &t.server_config,
+                            &HostDocument {
+                                uri: &t.uri,
+                                language_id: &t.language_id,
+                                text: &t.text,
+                                revision: Some(revision),
+                            },
+                            METHOD,
+                            params,
+                            t.upstream_id,
+                        )
+                        .await?;
+                    let Some(raw) = raw else {
+                        return Ok(None);
+                    };
+                    Ok(parse_host_verbatim::<Vec<ColorPresentation>>(raw.value)
+                        .filter(|items| !items.is_empty()))
+                }
+            },
+            |opt| matches!(opt, Some(items) if !items.is_empty()),
+            cancel_rx,
+        )
+        .await;
+        self.host_layer_result(fan_in, &ctx, METHOD, |won| won)
             .await
     }
 }

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -1,17 +1,9 @@
 //! Document color method for Kakehashi.
 
-use std::sync::Arc;
-
-use tokio::task::JoinSet;
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{ColorInformation, DocumentColorParams};
 
-use crate::language::InjectionResolver;
-use crate::lsp::aggregation::server::FanInResult;
-use crate::lsp::aggregation::server::dispatch_preferred;
-use crate::lsp::lsp_impl::bridge_context::DocumentRequestContext;
-
-use super::super::{Kakehashi, uri_to_url};
+use super::super::Kakehashi;
 
 impl Kakehashi {
     pub(crate) async fn document_color_impl(
@@ -24,183 +16,31 @@ impl Kakehashi {
         if !self.experimental_enabled() {
             return Ok(Vec::new());
         }
-        let lsp_uri = params.text_document.uri;
-
-        // Convert ls_types::Uri to url::Url for internal use
-        let Ok(uri) = uri_to_url(&lsp_uri) else {
-            log::warn!("Invalid URI in documentColor: {}", lsp_uri.as_str());
-            return Ok(vec![]);
-        };
-
-        log::debug!("documentColor called for {}", uri);
-
-        // Ensure a fresh tree before snapshotting: `didChange` clears the tree and
-        // reparses off-ingress, so without this documentColor (virt-only) returns
-        // empty for the whole reparse window after every edit.
-        self.ensure_document_parsed(&uri).await;
-
-        // Get document snapshot (minimizes lock duration)
-        let snapshot = match self.documents.get(&uri) {
-            None => {
-                log::debug!("documentColor: No document found for {}", uri);
-                return Ok(Vec::new());
-            }
-            Some(doc) => match doc.snapshot() {
-                None => {
-                    log::debug!("documentColor: Document not fully initialized for {}", uri);
-                    return Ok(Vec::new());
-                }
-                Some(snapshot) => snapshot,
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
+        self.whole_document_fan_out(
+            &params.text_document.uri,
+            "textDocument/documentColor",
+            raw_params,
+            None,
+            |t| async move {
+                let colors = t
+                    .pool
+                    .send_document_color_request(
+                        &t.server_name,
+                        &t.server_config,
+                        &t.uri,
+                        &t.injection_language,
+                        &t.region_id,
+                        t.offset,
+                        &t.virtual_content,
+                        t.upstream_id,
+                    )
+                    .await?;
+                Ok((!colors.is_empty()).then_some(colors))
             },
-            // doc automatically dropped here, lock released
-        };
-
-        // Get the language for this document
-        let Some(language_name) = self.document_language(&uri) else {
-            log::debug!(target: "kakehashi::document_color", "No language detected");
-            return Ok(Vec::new());
-        };
-
-        if !self.virt_layer_enabled(&language_name, "textDocument/documentColor") {
-            log::debug!(
-                target: "kakehashi::document_color",
-                "virt layer disabled for {} via layers.aggregation priorities",
-                language_name
-            );
-            return Ok(Vec::new());
-        }
-
-        // Get injection query to detect injection regions
-        let Some(injection_query) = self.language.injection_query(&language_name) else {
-            return Ok(Vec::new());
-        };
-
-        // Collect all injection regions
-        let all_regions = match self
-            .documents
-            .current_resolved_regions(&uri, self.cache.semantic_token_generation())
-        {
-            Some(regions) => regions,
-            None => std::sync::Arc::new(InjectionResolver::resolve_all(
-                &self.language,
-                self.bridge.node_tracker(),
-                &uri,
-                snapshot.tree(),
-                snapshot.text(),
-                injection_query.as_ref(),
-                snapshot.incarnation(),
-            )),
-        };
-
-        if all_regions.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Get upstream request ID from task-local storage (set by RequestIdCapture middleware)
-        let upstream_request_id = crate::lsp::current_upstream_id();
-
-        // Subscribe to cancel notifications so we can abort early on $/cancelRequest.
-        // _cancel_guard ensures automatic unsubscribe when this scope exits.
-        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_request_id.as_ref());
-
-        let pool = self.bridge.pool_arc();
-
-        // Outer JoinSet: one task per injection region, all in parallel
-        let mut outer_join_set: JoinSet<(usize, Option<Vec<ColorInformation>>)> = JoinSet::new();
-
-        // Drop servers already known (a live, `Ready` connection) NOT to support
-        // this method before the per-region fan-out spawns their tasks
-        // (capability-prefilter-fanout). One pool query for the whole request.
-        let incapable_servers = self
-            .incapable_virt_servers(
-                &language_name,
-                all_regions.iter().map(|r| r.injection_language.as_str()),
-                "textDocument/documentColor",
-            )
-            .await;
-
-        for (region_index, resolved) in all_regions.iter().enumerate() {
-            // Get ALL bridge server configs for this injection language
-            let mut configs = self.bridge_configs_for_injection_language(
-                &language_name,
-                &resolved.injection_language,
-            );
-            if !incapable_servers.is_empty() {
-                configs.retain(|c| !incapable_servers.contains(&c.server_name));
-            }
-            if configs.is_empty() {
-                continue;
-            }
-
-            let agg = self.resolve_aggregation_config(
-                &language_name,
-                &resolved.injection_language,
-                "textDocument/documentColor",
-            );
-            let region_ctx = DocumentRequestContext {
-                uri: uri.clone(),
-                resolved: resolved.clone(),
-                region_end: None,
-                configs,
-                upstream_request_id: upstream_request_id.clone(),
-                priorities: agg.priorities,
-                strategy: agg.strategy,
-                max_fan_out: agg.max_fan_out,
-                client_progress_token: None,
-            };
-            let pool = Arc::clone(&pool);
-
-            outer_join_set.spawn(async move {
-                let result = dispatch_preferred(
-                    &region_ctx,
-                    pool.clone(),
-                    |t| async move {
-                        t.pool
-                            .send_document_color_request(
-                                &t.server_name,
-                                &t.server_config,
-                                &t.uri,
-                                &t.injection_language,
-                                &t.region_id,
-                                t.offset,
-                                &t.virtual_content,
-                                t.upstream_id,
-                            )
-                            .await
-                    },
-                    |colors| !colors.is_empty(),
-                    None,
-                )
-                .await;
-                let colors = match result {
-                    FanInResult::Done(colors) => Some(colors),
-                    FanInResult::NoResult { .. } | FanInResult::Cancelled => None,
-                };
-                (region_index, colors)
-            });
-        }
-
-        // RAII sweep of stale upstream registry entries: fires after the
-        // collection settles or the whole request future is dropped — after
-        // the JoinSet is drained/dropped, so cancel forwarding remains intact
-        // for all in-flight downstream requests. Nothing else shares the id
-        // (virt-only handler, no layer race, no outer sweep).
-        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard::new(
-            pool.clone(),
-            upstream_request_id.clone(),
-        );
-        // Collect results, aborting early if $/cancelRequest arrives.
-        let completion_order_items =
-            crate::lsp::aggregation::region::collect_region_results_with_cancel(
-                outer_join_set,
-                cancel_rx,
-                |acc, region_items: (usize, Option<Vec<ColorInformation>>)| acc.push(region_items),
-            )
-            .await?;
-        Ok(
-            crate::lsp::lsp_impl::whole_document::flatten_ordered_region_items(
-                completion_order_items,
-            ),
+            |won| Some(won.items),
         )
+        .await
+        .map(Option::unwrap_or_default)
     }
 }

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -1,6 +1,6 @@
 //! Shared fan-out for whole-document bridged requests.
 //!
-//! documentLink, foldingRange, and codeLens all follow the same shape: no
+//! documentLink, documentColor, foldingRange, and codeLens all follow the same shape: no
 //! position parameter, so the request fans out to every resolved bridge
 //! virtual document, uses the preferred strategy within each document, and
 //! concatenates those results. This module hosts that shape once; the per-method
@@ -287,6 +287,8 @@ impl Kakehashi {
                 incarnation: expected_incarnation,
                 content_version: ctx.content_version,
             };
+            #[cfg(feature = "e2e")]
+            wait_for_host_admission_release().await;
             let pool = self.bridge.pool_arc();
             let fan_in = dispatch_host_preferred(
                 &ctx,
@@ -359,6 +361,26 @@ impl Kakehashi {
             .await?;
 
         Ok(result.and_then(nonempty_whole_document_items))
+    }
+}
+
+#[cfg(feature = "e2e")]
+async fn wait_for_host_admission_release() {
+    let Ok(dir) = std::env::var("KAKEHASHI_E2E_WHOLE_DOCUMENT_HOST_BARRIER_DIR") else {
+        return;
+    };
+    let dir = std::path::Path::new(&dir);
+    if std::fs::create_dir_all(dir).is_err()
+        || std::fs::write(dir.join("captured"), b"captured").is_err()
+    {
+        return;
+    }
+    let release = dir.join("release");
+    for _ in 0..300 {
+        if release.exists() {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
 }
 

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -98,6 +98,8 @@
 //! - `document-link-slow-host` / `document-link-slow-virt` — like
 //!   `document-link`, but sleeps before answering and records request-start
 //!   and downstream `$/cancelRequest` markers under `MOCK_LSP_CANCEL_DIR`.
+//! - `document-color` — advertises `colorProvider`, returns one red color for
+//!   every open document, and presents it as `#ff0000`.
 //! - `diagnostics` — advertises `diagnosticProvider`; answers
 //!   `textDocument/diagnostic` with a full report carrying one diagnostic
 //!   that echoes the requested URI, but only for documents it received via
@@ -279,6 +281,14 @@ fn main() {
                     "document-link-no-resolve-reserved-data"
                     | "document-link-no-resolve-plain-data" => json!({
                         "documentLinkProvider": { "resolveProvider": false },
+                        "textDocumentSync": 1
+                    }),
+                    "document-color"
+                    | "document-color-host"
+                    | "document-color-virt"
+                    | "document-color-empty-presentation"
+                    | "document-color-slow-presentation" => json!({
+                        "colorProvider": true,
                         "textDocumentSync": 1
                     }),
                     "inlay-hint-resolve"
@@ -1599,6 +1609,57 @@ fn main() {
                         json!([link])
                     })
                     .unwrap_or(Value::Null);
+                respond(&mut writer, id, result);
+            }
+            "textDocument/documentColor" => {
+                let result = message
+                    .pointer("/params/textDocument/uri")
+                    .and_then(Value::as_str)
+                    .filter(|uri| documents.contains_key(*uri))
+                    .map(|_| {
+                        json!([{
+                            "range": {
+                                "start": { "line": 0, "character": 0 },
+                                "end": { "line": 0, "character": 4 }
+                            },
+                            "color": {
+                                "red": 1.0,
+                                "green": 0.0,
+                                "blue": 0.0,
+                                "alpha": 1.0
+                            }
+                        }])
+                    })
+                    .unwrap_or(Value::Null);
+                respond(&mut writer, id, result);
+            }
+            "textDocument/colorPresentation" => {
+                if mode == "document-color-slow-presentation" {
+                    record_mock_event(&mode, "request", &message);
+                    std::thread::sleep(std::time::Duration::from_secs(3));
+                }
+                let range = message.pointer("/params/range").cloned();
+                let result = if mode == "document-color-empty-presentation" {
+                    json!([])
+                } else {
+                    let (label, new_text) = if mode == "document-color-virt" {
+                        ("virt-color", "#00ff00")
+                    } else {
+                        ("host-color", "#ff0000")
+                    };
+                    message
+                        .pointer("/params/textDocument/uri")
+                        .and_then(Value::as_str)
+                        .filter(|uri| documents.contains_key(*uri))
+                        .and(range)
+                        .map(|range| {
+                            json!([{
+                                "label": label,
+                                "textEdit": { "range": range, "newText": new_text }
+                            }])
+                        })
+                        .unwrap_or(Value::Null)
+                };
                 respond(&mut writer, id, result);
             }
             "documentLink/resolve" => {

--- a/tests/e2e/e2e_host_bridge.rs
+++ b/tests/e2e/e2e_host_bridge.rs
@@ -186,6 +186,429 @@ priorities = ["virt", "host"]
 }
 
 #[test]
+fn e2e_document_colors_concatenate_virt_and_host_layers() {
+    let config_dir = tempfile::TempDir::new().expect("config dir");
+    let config_path = config_dir.path().join("document_colors.toml");
+    std::fs::write(
+        &config_path,
+        r#"
+[languages.markdown.bridge._self]
+enabled = true
+
+[languages.markdown.layers.aggregation."textDocument/documentColor"]
+strategy = "concatenated"
+priorities = ["virt", "host"]
+
+[languages.markdown.layers.aggregation."textDocument/colorPresentation"]
+strategy = "concatenated"
+priorities = ["virt", "host"]
+"#,
+    )
+    .expect("write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("temp path should be UTF-8"))
+        .env("KAKEHASHI_EXPERIMENTAL", "true")
+        .build();
+    let init = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "languageServers": {
+                    "mock-host-color": {
+                        "cmd": [mock_bin(), "document-color-host"],
+                        "languages": ["markdown"]
+                    },
+                    "mock-virt-color": {
+                        "cmd": [mock_bin(), "document-color-virt"],
+                        "languages": ["lua"]
+                    }
+                }
+            }
+        }),
+    );
+    assert_eq!(
+        init.pointer("/result/capabilities/colorProvider"),
+        Some(&json!(true))
+    );
+    client.send_notification("initialized", json!({}));
+
+    let uri = "file:///test_document_colors.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "markdown",
+                "version": 1,
+                "text": "# Title\n\n> ```lua\n> red!\n> ```\n"
+            }
+        }),
+    );
+
+    let colors = (0..300)
+        .find_map(|_| {
+            let response = client.send_request(
+                "textDocument/documentColor",
+                json!({ "textDocument": { "uri": uri } }),
+            );
+            assert!(
+                response.get("error").is_none(),
+                "documentColor must not surface a top-level error; got: {:?}",
+                response.get("error")
+            );
+            let colors = response["result"].as_array().cloned().unwrap_or_default();
+            if colors.len() >= 2 {
+                Some(colors)
+            } else {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                None
+            }
+        })
+        .expect("concatenated document colors should include virt and host results");
+
+    assert!(
+        colors.iter().any(|color| {
+            color["range"]
+                == json!({
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 0, "character": 4 }
+                })
+        }),
+        "host-layer documentColor should keep the host range: {colors:?}"
+    );
+    assert!(
+        colors.iter().any(|color| {
+            color["range"]
+                == json!({
+                    "start": { "line": 3, "character": 2 },
+                    "end": { "line": 3, "character": 6 }
+                })
+        }),
+        "virt-layer documentColor should translate the injected lua line and column: {colors:?}"
+    );
+
+    let presentation = client.send_request(
+        "textDocument/colorPresentation",
+        json!({
+            "textDocument": { "uri": uri },
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 4 }
+            },
+            "color": { "red": 1.0, "green": 0.0, "blue": 0.0, "alpha": 1.0 }
+        }),
+    );
+    assert_eq!(
+        presentation.pointer("/result/0"),
+        Some(&json!({
+            "label": "host-color",
+            "textEdit": {
+                "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 0, "character": 4 }
+                },
+                "newText": "#ff0000"
+            }
+        })),
+        "a host document color should present through its host server: {presentation:?}"
+    );
+
+    let virtual_presentation = client.send_request(
+        "textDocument/colorPresentation",
+        json!({
+            "textDocument": { "uri": uri },
+            "range": {
+                "start": { "line": 3, "character": 2 },
+                "end": { "line": 3, "character": 6 }
+            },
+            "color": { "red": 1.0, "green": 0.0, "blue": 0.0, "alpha": 1.0 }
+        }),
+    );
+    assert_eq!(
+        virtual_presentation.pointer("/result/0"),
+        Some(&json!({
+            "label": "virt-color",
+            "textEdit": {
+                "range": {
+                    "start": { "line": 3, "character": 2 },
+                    "end": { "line": 3, "character": 6 }
+                },
+                "newText": "#00ff00"
+            }
+        })),
+        "an injected color should use the virtual server and translate its edit: {virtual_presentation:?}"
+    );
+    assert_eq!(
+        virtual_presentation.pointer("/result/1"),
+        Some(&json!({
+            "label": "host-color",
+            "textEdit": {
+                "range": {
+                    "start": { "line": 3, "character": 2 },
+                    "end": { "line": 3, "character": 6 }
+                },
+                "newText": "#ff0000"
+            }
+        })),
+        "concatenated colorPresentation should retain the host answer after virt: {virtual_presentation:?}"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_color_presentation_cancel_reaches_host_after_empty_virt_arm() {
+    let config_dir = tempfile::TempDir::new().expect("config dir");
+    let config_path = config_dir.path().join("color_presentation_cancel.toml");
+    std::fs::write(
+        &config_path,
+        r#"
+[languages.markdown.bridge._self]
+enabled = true
+
+[languages.markdown.layers.aggregation."textDocument/colorPresentation"]
+strategy = "preferred"
+priorities = ["virt", "host"]
+
+[languages.markdown.layers.aggregation."textDocument/documentColor"]
+strategy = "concatenated"
+priorities = ["virt", "host"]
+"#,
+    )
+    .expect("write config");
+
+    let event_dir = tempfile::TempDir::new().expect("event dir");
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("temp path should be UTF-8"))
+        .env("KAKEHASHI_EXPERIMENTAL", "true")
+        .env("MOCK_LSP_CANCEL_DIR", event_dir.path().to_string_lossy())
+        .build();
+    let _init = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "languageServers": {
+                    "mock-host-color": {
+                        "cmd": [mock_bin(), "document-color-slow-presentation"],
+                        "languages": ["markdown"]
+                    },
+                    "mock-virt-color": {
+                        "cmd": [mock_bin(), "document-color-empty-presentation"],
+                        "languages": ["lua"]
+                    }
+                }
+            }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    let uri = "file:///test_color_presentation_cancel.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "markdown",
+                "version": 1,
+                "text": "> ```lua\n> red!\n> ```\n"
+            }
+        }),
+    );
+
+    (0..100)
+        .find_map(|_| {
+            let response = client.send_request(
+                "textDocument/documentColor",
+                json!({ "textDocument": { "uri": uri } }),
+            );
+            if response["result"]
+                .as_array()
+                .is_some_and(|items| items.len() >= 2)
+            {
+                Some(())
+            } else {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                None
+            }
+        })
+        .expect("host and virtual color servers should warm up");
+
+    let request_id = client.send_request_async(
+        "textDocument/colorPresentation",
+        json!({
+            "textDocument": { "uri": uri },
+            "range": {
+                "start": { "line": 1, "character": 2 },
+                "end": { "line": 1, "character": 6 }
+            },
+            "color": { "red": 1.0, "green": 0.0, "blue": 0.0, "alpha": 1.0 }
+        }),
+    );
+    let host_request = event_dir
+        .path()
+        .join("document-color-slow-presentation.request.json");
+    assert!(
+        (0..60).any(|_| {
+            if host_request.exists() {
+                true
+            } else {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                false
+            }
+        }),
+        "host colorPresentation request should start"
+    );
+
+    client.send_notification("$/cancelRequest", json!({ "id": request_id }));
+    let response = client.receive_response_for_id_public(request_id);
+    assert_eq!(
+        response.pointer("/error/code").and_then(Value::as_i64),
+        Some(-32800),
+        "colorPresentation should answer RequestCancelled: {response:?}"
+    );
+
+    let host_cancel = event_dir
+        .path()
+        .join("document-color-slow-presentation.cancel.json");
+    assert!(
+        (0..60).any(|_| {
+            if host_cancel.exists() {
+                true
+            } else {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                false
+            }
+        }),
+        "cancellation should reach the host server after the virt arm settles"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_document_color_rejects_host_reopen_during_connection_admission() {
+    let config_dir = tempfile::TempDir::new().expect("config dir");
+    let config_path = config_dir.path().join("document_color_reopen.toml");
+    std::fs::write(
+        &config_path,
+        r#"
+[languages.markdown.bridge._self]
+enabled = true
+
+[languages.markdown.layers.aggregation."textDocument/documentColor"]
+priorities = ["host"]
+"#,
+    )
+    .expect("write config");
+
+    let barrier_dir = tempfile::TempDir::new().expect("barrier dir");
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("temp path should be UTF-8"))
+        .env("KAKEHASHI_EXPERIMENTAL", "true")
+        .env(
+            "KAKEHASHI_E2E_WHOLE_DOCUMENT_HOST_BARRIER_DIR",
+            barrier_dir.path().to_string_lossy(),
+        )
+        .build();
+    let _init = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "languageServers": {
+                    "mock-host-color": {
+                        "cmd": [mock_bin(), "document-color-host"],
+                        "languages": ["markdown"]
+                    }
+                }
+            }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    let uri = "file:///test_document_color_reopen.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "markdown",
+                "version": 1,
+                "text": "old lifetime"
+            }
+        }),
+    );
+    let request_id = client.send_request_async(
+        "textDocument/documentColor",
+        json!({ "textDocument": { "uri": uri } }),
+    );
+
+    let captured = barrier_dir.path().join("captured");
+    assert!(
+        (0..60).any(|_| {
+            if captured.exists() {
+                true
+            } else {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                false
+            }
+        }),
+        "the old host context should be captured before dispatch admission"
+    );
+
+    client.send_notification(
+        "textDocument/didClose",
+        json!({ "textDocument": { "uri": uri } }),
+    );
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "markdown",
+                "version": 1,
+                "text": "new lifetime"
+            }
+        }),
+    );
+
+    let reopen_barrier = client.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": uri } }),
+    );
+    assert!(
+        reopen_barrier.get("error").is_none(),
+        "the post-reopen reader barrier should complete: {reopen_barrier:?}"
+    );
+    std::fs::write(barrier_dir.path().join("release"), b"release")
+        .expect("release host request admission");
+
+    let response = client.receive_response_for_id_public(request_id);
+    assert_eq!(
+        response["result"],
+        json!([]),
+        "a request carrying the closed incarnation must not answer from the reopened document: {response:?}"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
 fn e2e_whole_document_link_cancel_forwards_to_concatenated_layers() {
     let config_dir = tempfile::TempDir::new().expect("config dir");
     let config_path = config_dir.path().join("whole_doc_links_cancel.toml");


### PR DESCRIPTION
## Summary

With `KAKEHASHI_EXPERIMENTAL=true`, document colors and color presentations now support both embedded-language servers and the `_self` host server. Host results retain real-document coordinates; virtual results retain coordinate translation and the existing edit guards. Both methods honor the configured layer strategy, including explicit `concatenated` results.

This PR targets `main` independently. The color handlers use main's existing `HostRevision` admission and result-lifetime checks; no call-hierarchy or type-hierarchy changes are included. Both color methods wait for preceding document lifecycle writes.

## Behavior and limitations

`ColorInformation` carries no producer identity, so `colorPresentation` routes by the supplied range. Inside an injection, the default `virt → host` preference can choose the virtual server for a host-produced color. Configure both color methods as `concatenated` to retain both layers' answers; this does not preserve producer affinity or deduplicate results.

A sample is provided in `__ignored/samples/document_color.md`.

## Validation

- `make check`
- `make test_all` (4,321 passed, 5 ignored; includes 463 E2E tests)
- `git diff --check`
- Independent code and tests/documentation review of the standalone diff

The existing Resolve E2E CI job runs `e2e_host_bridge::`, including the new coordinate-mapping, cancellation, and close/reopen admission regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added experimental document color support for host and embedded language servers.
  - Document colors and color presentations can now combine results from multiple language layers.
  - Added configurable strategies to prefer one result or retain results from all layers.

- **Bug Fixes**
  - Improved handling of stale documents, close-and-reopen scenarios, cancellation, and request ordering.
  - Prevented invalid or outdated results from being returned.

- **Documentation**
  - Expanded guidance and examples for configuring document colors and color presentations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->