### PR TITLE
fix(bridge): one envelope rule for both layers, one log for every resolve capability miss

### DIFF
--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -45,13 +45,17 @@ Partially implemented:
   documentColor/colorPresentation pair. `completionItem/resolve` routes by
   the envelope stamped into `CompletionItem.data`; the host layer stamps one
   too (marked `host_layer`, so the resolve forwards VERBATIM — no coordinate
-  translation and no injection-region edit guard), but only for a server that
-  advertises `completionItem/resolve`. Without that capability the items stay
-  bare and a resolve falls back gracefully (item returned unresolved).
-  `codeLens/resolve` follows the same host-layer rule: a winning host server
-  that advertises resolve has its lenses stamped with an origin envelope, and
-  resolving one forwards the original payload and coordinates verbatim. A
-  non-resolving server's lens normally stays bare; the reserved-key collision
+  translation and no injection-region edit guard). Both layers mint under
+  one rule, shared by completion, codeLens, and documentLink: only for a
+  server that advertises the matching resolve method. Without that
+  capability the items stay bare — an envelope would be pure wire weight on
+  every item, and its resolve would only fail soft — so a client resolve
+  passes the bare item through unchanged. The resolve side re-checks the
+  capability on the live origin regardless and, finding it gone (a respawn
+  or dynamic unregister under the item), warns and returns the item
+  unresolved with its envelope restored. `codeLens/resolve` forwards the
+  original payload and coordinates verbatim on the host layer. A
+  non-resolving server's item normally stays bare; the reserved-key collision
   exception wraps `data.kakehashi` as opaque `inner` data so a downstream
   payload cannot impersonate bridge routing metadata. The envelope retains
   the host-document incarnation plus the exact producing `ConnectionKey` and

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -51,9 +51,11 @@ Partially implemented:
   capability the items stay bare — an envelope would be pure wire weight on
   every item, and its resolve would only fail soft — so a client resolve
   passes the bare item through unchanged. The resolve side re-checks the
-  capability on the live origin regardless and, finding it gone (a respawn
-  or dynamic unregister under the item), warns and returns the item
-  unresolved with its envelope restored. `codeLens/resolve` forwards the
+  capability on the live origin regardless and, finding it absent, returns
+  the item unresolved with its envelope restored — warning when the
+  capability was withdrawn under the item (a respawn or dynamic
+  unregister), quietly when the envelope existed only to nest a
+  reserved-key payload from a non-resolving origin. `codeLens/resolve` forwards the
   original payload and coordinates verbatim on the host layer. A
   non-resolving server's item normally stays bare; the reserved-key collision
   exception wraps `data.kakehashi` as opaque `inner` data so a downstream

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -54,9 +54,11 @@ Partially implemented:
   only fail soft — so a client resolve passes the bare item through
   unchanged. The resolve side re-checks the capability on the live origin
   regardless and, finding it absent, returns the item unresolved with its
-  envelope restored — warning when the capability was withdrawn under the
-  item (a respawn or dynamic unregister), quietly when the envelope existed
-  only to nest a reserved-key payload from a non-resolving origin. That
+  envelope restored — warning that the capability was withdrawn under the
+  item (a respawn or dynamic unregister), unless the payload itself nests
+  the reserved key, which the resolve side reads as the steady state of a
+  non-resolving origin's collision wrap and logs quietly (a resolving origin
+  with such a payload loses the warning; accepted). That collision
   exception wraps `data.kakehashi` as opaque `inner` data so a downstream
   payload cannot impersonate bridge routing metadata. (codeAction needs no
   such exception: an action that leaves without an envelope leaves with no

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -47,22 +47,21 @@ Partially implemented:
   the envelope stamped into `CompletionItem.data`; the host layer stamps one
   too (marked `host_layer`, so the resolve forwards VERBATIM — no coordinate
   translation and no injection-region edit guard). Both layers mint under
-  one rule, shared by completion, codeLens, and documentLink: only for a
-  server that advertises the matching resolve method. Without that
-  capability the items stay bare — an envelope would be pure wire weight on
-  every item, and its resolve would only fail soft — so a client resolve
-  passes the bare item through unchanged. The resolve side re-checks the
-  capability on the live origin regardless and, finding it absent, returns
-  the item unresolved with its envelope restored — warning when the
-  capability was withdrawn under the item (a respawn or dynamic
-  unregister), quietly when the envelope existed only to nest a
-  reserved-key payload from a non-resolving origin. `codeLens/resolve` forwards the
-  original payload and coordinates verbatim on the host layer. A
-  non-resolving server's item normally stays bare; the reserved-key collision
+  one rule, shared by completion, codeLens, and documentLink: for a server
+  that advertises the matching resolve method, plus the reserved-key
+  exception below. Without that capability the items stay bare — an
+  envelope would be pure wire weight on every item, and its resolve would
+  only fail soft — so a client resolve passes the bare item through
+  unchanged. The resolve side re-checks the capability on the live origin
+  regardless and, finding it absent, returns the item unresolved with its
+  envelope restored — warning when the capability was withdrawn under the
+  item (a respawn or dynamic unregister), quietly when the envelope existed
+  only to nest a reserved-key payload from a non-resolving origin. That
   exception wraps `data.kakehashi` as opaque `inner` data so a downstream
   payload cannot impersonate bridge routing metadata. (codeAction needs no
   such exception: an action that leaves without an envelope leaves with no
-  `data` at all.) The codeLens envelope retains
+  `data` at all.) `codeLens/resolve` forwards the original payload and
+  coordinates verbatim on the host layer. The codeLens envelope retains
   the host-document incarnation plus the exact producing `ConnectionKey` and
   its generation, so an old lens is returned unresolved after either a
   document reopen, a rooted/shared routing-key change, or a downstream process

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -29,11 +29,12 @@ Partially implemented:
   no per-method request builders or response transformers. Handlers run the
   layer walk (`Kakehashi::walk_layers`, cross-layer-aggregation,
   `preferred` semantics): layers are tried lazily in `priorities` — by default
-  virt first, host as fallback. Three methods consume per-server identity in
+  virt first, host as fallback. Four methods consume per-server identity in
   the host arm: codeAction for the `"{title} — {server}"` suffix, completion
-  for its resolve-routing envelope, and codeLens for the winning server's
-  resolve capability and envelope. CodeAction and completion build their own
-  host arms; codeLens uses the shared whole-document winner hook. Covered: definition, hover, declaration,
+  for its resolve-routing envelope, and codeLens and documentLink for the
+  winning server's resolve capability and envelope. CodeAction and completion
+  build their own host arms; codeLens and documentLink use the shared
+  whole-document winner hook. Covered: definition, hover, declaration,
   typeDefinition, implementation, references, completion, signatureHelp,
   documentHighlight, rename, prepareRename, linkedEditingRange, moniker,
   inlayHint, documentSymbol, documentLink, foldingRange, codeLens,
@@ -59,7 +60,9 @@ Partially implemented:
   original payload and coordinates verbatim on the host layer. A
   non-resolving server's item normally stays bare; the reserved-key collision
   exception wraps `data.kakehashi` as opaque `inner` data so a downstream
-  payload cannot impersonate bridge routing metadata. The envelope retains
+  payload cannot impersonate bridge routing metadata. (codeAction needs no
+  such exception: an action that leaves without an envelope leaves with no
+  `data` at all.) The codeLens envelope retains
   the host-document incarnation plus the exact producing `ConnectionKey` and
   its generation, so an old lens is returned unresolved after either a
   document reopen, a rooted/shared routing-key change, or a downstream process

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -29,6 +29,7 @@ mod client;
 mod client_progress;
 mod connection;
 pub(crate) mod coordinator;
+mod envelope;
 mod inbound_request_registry;
 mod pool;
 mod progress_registry;

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -29,7 +29,7 @@ mod client;
 mod client_progress;
 mod connection;
 pub(crate) mod coordinator;
-mod envelope;
+pub(crate) mod envelope;
 mod inbound_request_registry;
 mod pool;
 mod progress_registry;

--- a/src/lsp/bridge/envelope.rs
+++ b/src/lsp/bridge/envelope.rs
@@ -22,9 +22,12 @@ pub(crate) fn should_envelope(data: Option<&Value>, server_resolves: bool) -> bo
 /// Whether a payload occupies the envelope key itself. On the producer side
 /// this is the collision exception above; on the resolve side, once the
 /// envelope is stripped and the payload restored into `data`, an item whose
-/// payload does so was enveloped ONLY for that reason, so a capability miss
-/// on it is the expected steady state of a non-resolving origin, not a
-/// capability that vanished under the item.
+/// payload does so cannot be told apart from one enveloped only for that
+/// reason, so a capability miss on it is read as the steady state of a
+/// non-resolving origin rather than a capability that vanished under the
+/// item. A resolving origin whose payload happens to nest the key loses the
+/// warning in that corner; accepted rather than widen every envelope with a
+/// wrap reason.
 pub(crate) fn nests_reserved_key(data: Option<&Value>) -> bool {
     data.is_some_and(|data| data.get(ENVELOPE_KEY).is_some())
 }

--- a/src/lsp/bridge/envelope.rs
+++ b/src/lsp/bridge/envelope.rs
@@ -16,7 +16,17 @@ pub(crate) const ENVELOPE_KEY: &str = "kakehashi";
 /// envelope would be pure wire weight on every item, and its resolve would
 /// only fail soft back to the unresolved item.
 pub(crate) fn should_envelope(data: Option<&Value>, server_resolves: bool) -> bool {
-    server_resolves || data.is_some_and(|data| data.get(ENVELOPE_KEY).is_some())
+    server_resolves || nests_reserved_key(data)
+}
+
+/// Whether a payload occupies the envelope key itself. On the producer side
+/// this is the collision exception above; on the resolve side, once the
+/// envelope is stripped and the payload restored into `data`, an item whose
+/// payload does so was enveloped ONLY for that reason, so a capability miss
+/// on it is the expected steady state of a non-resolving origin, not a
+/// capability that vanished under the item.
+pub(crate) fn nests_reserved_key(data: Option<&Value>) -> bool {
+    data.is_some_and(|data| data.get(ENVELOPE_KEY).is_some())
 }
 
 #[cfg(test)]

--- a/src/lsp/bridge/envelope.rs
+++ b/src/lsp/bridge/envelope.rs
@@ -1,0 +1,44 @@
+//! The one rule for minting a `*/resolve` routing envelope into an item's
+//! `data`, shared by every producer on both layers (completion, codeLens,
+//! documentLink; codeAction needs no collision rule because a bare action
+//! never leaves with `data`).
+
+use serde_json::Value;
+
+/// Wrapper key inside an item's `data` that marks kakehashi routing metadata.
+pub(crate) const ENVELOPE_KEY: &str = "kakehashi";
+
+/// Whether an item must carry a routing envelope: the origin advertises the
+/// matching `*/resolve` method, or the item's own `data` already occupies the
+/// envelope key — the one case a non-resolving origin's item must still be
+/// wrapped, so its payload is nested as `inner` rather than read back as
+/// routing metadata it never earned. Everything else passes through bare: an
+/// envelope would be pure wire weight on every item, and its resolve would
+/// only fail soft back to the unresolved item.
+pub(crate) fn should_envelope(data: Option<&Value>, server_resolves: bool) -> bool {
+    server_resolves || data.is_some_and(|data| data.get(ENVELOPE_KEY).is_some())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use serde_json::json;
+
+    #[rstest]
+    #[case::resolving_bare(true, Some(json!({"token": 1})), true)]
+    #[case::resolving_no_data(true, None, true)]
+    #[case::bare(false, Some(json!({"token": 1})), false)]
+    #[case::no_data(false, None, false)]
+    #[case::reserved_key(false, Some(json!({ ENVELOPE_KEY: { "origin": "spoofed" } })), true)]
+    #[case::reserved_key_null(false, Some(json!({ ENVELOPE_KEY: null })), true)]
+    #[case::non_object(false, Some(json!(["kakehashi"])), false)]
+    #[case::string(false, Some(json!("kakehashi")), false)]
+    fn envelopes_for_a_resolving_origin_or_a_reserved_key_payload(
+        #[case] server_resolves: bool,
+        #[case] data: Option<Value>,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(should_envelope(data.as_ref(), server_resolves), expected);
+    }
+}

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -733,8 +733,9 @@ impl LanguageServerPool {
             // Anomalous: the envelope was only minted because the origin
             // advertised resolve, so reaching here means a respawn changed
             // capabilities under the action. (Unlike the other resolve kinds,
-            // `codeAction/resolve` has no dynamic-registration path in
-            // `has_capability`, so an unregister cannot flip it.)
+            // `has_capability` reads no `textDocument/codeAction`
+            // registration-options `resolveProvider`, so a standard dynamic
+            // unregister cannot flip it.)
             warn!(
                 target: "kakehashi::bridge",
                 "codeAction/resolve (host): {:?} no longer advertises resolveProvider; \
@@ -834,8 +835,9 @@ impl LanguageServerPool {
             // Anomalous: the envelope was only minted because the origin
             // advertised resolve, so reaching here means a respawn changed
             // capabilities under the action. (Unlike the other resolve kinds,
-            // `codeAction/resolve` has no dynamic-registration path in
-            // `has_capability`, so an unregister cannot flip it.)
+            // `has_capability` reads no `textDocument/codeAction`
+            // registration-options `resolveProvider`, so a standard dynamic
+            // unregister cannot flip it.)
             warn!(
                 target: "kakehashi::bridge",
                 "codeAction/resolve: {:?} no longer advertises resolveProvider; returning unresolved",

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -23,6 +23,7 @@ use serde_json::Value;
 use crate::config::settings::{BridgeServerConfig, WorkspaceSettings};
 use crate::config::{merge_bridge_server_configs, resolve_with_wildcard};
 use crate::lsp::bridge::actor::RouterCleanupGuard;
+use crate::lsp::bridge::envelope::ENVELOPE_KEY;
 use tower_lsp_server::ls_types::{
     CodeAction, CodeActionContext, CodeActionDisabled, CodeActionOrCommand, CodeActionParams,
     CodeActionResponse, DocumentChangeOperation, DocumentChanges, NumberOrString,
@@ -40,9 +41,6 @@ use super::super::protocol::{
     workspace_edit_preserves_line_prefixes, workspace_edit_within_region,
 };
 use super::completion::EnvelopeOffset;
-
-/// Wrapper key inside `CodeAction.data` that identifies the origin server.
-const ENVELOPE_KEY: &str = "kakehashi";
 
 /// Envelope stored in `CodeAction.data` for routing `codeAction/resolve`
 /// (#568 PR 4), mirroring [`CodeLensEnvelope`](super::code_lens::CodeLensEnvelope).

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -112,6 +112,11 @@ pub(crate) struct CodeActionEnvelopeContext<'a> {
 
 /// Wrap `action.data` in a Kakehashi envelope for origin tracking, capturing
 /// the CURRENT (unsuffixed) title as `original_title`. Call before suffixing.
+///
+/// Unlike the other resolve kinds, codeAction needs no reserved-key collision
+/// rule (`bridge::envelope::should_envelope`): every action that leaves
+/// without an envelope leaves with `data = None`, so a downstream payload can
+/// never reach the client bare and be read back as routing metadata.
 fn envelope_action_data(action: &mut CodeAction, ctx: &CodeActionEnvelopeContext) {
     let inner = action.data.take();
     let envelope = CodeActionEnvelope {

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -726,8 +726,10 @@ impl LanguageServerPool {
         };
         if !handle.has_capability("codeAction/resolve") {
             // Anomalous: the envelope was only minted because the origin
-            // advertised resolve, so reaching here means a respawn or dynamic
-            // unregister changed capabilities under the action.
+            // advertised resolve, so reaching here means a respawn changed
+            // capabilities under the action. (Unlike the other resolve kinds,
+            // `codeAction/resolve` has no dynamic-registration path in
+            // `has_capability`, so an unregister cannot flip it.)
             warn!(
                 target: "kakehashi::bridge",
                 "codeAction/resolve (host): {:?} no longer advertises resolveProvider; \
@@ -825,8 +827,10 @@ impl LanguageServerPool {
         };
         if !handle.has_capability("codeAction/resolve") {
             // Anomalous: the envelope was only minted because the origin
-            // advertised resolve, so reaching here means a respawn or dynamic
-            // unregister changed capabilities under the action.
+            // advertised resolve, so reaching here means a respawn changed
+            // capabilities under the action. (Unlike the other resolve kinds,
+            // `codeAction/resolve` has no dynamic-registration path in
+            // `has_capability`, so an unregister cannot flip it.)
             warn!(
                 target: "kakehashi::bridge",
                 "codeAction/resolve: {:?} no longer advertises resolveProvider; returning unresolved",

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -728,11 +728,12 @@ impl LanguageServerPool {
         };
         if !handle.has_capability("codeAction/resolve") {
             // Anomalous: the envelope was only minted because the origin
-            // advertised resolve, so reaching here means a respawn changed
-            // capabilities (or the handle is still initializing).
+            // advertised resolve, so reaching here means a respawn or dynamic
+            // unregister changed capabilities under the action.
             warn!(
                 target: "kakehashi::bridge",
-                "codeAction/resolve: {:?} no longer advertises resolveProvider; returning unresolved",
+                "codeAction/resolve (host): {:?} no longer advertises resolveProvider; \
+                 returning unresolved",
                 envelope.origin
             );
             re_envelope_action(&mut action, &envelope);
@@ -826,8 +827,8 @@ impl LanguageServerPool {
         };
         if !handle.has_capability("codeAction/resolve") {
             // Anomalous: the envelope was only minted because the origin
-            // advertised resolve, so reaching here means a respawn changed
-            // capabilities (or the handle is still initializing).
+            // advertised resolve, so reaching here means a respawn or dynamic
+            // unregister changed capabilities under the action.
             warn!(
                 target: "kakehashi::bridge",
                 "codeAction/resolve: {:?} no longer advertises resolveProvider; returning unresolved",

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -697,7 +697,7 @@ impl LanguageServerPool {
         let Ok(host_url) = Url::parse(&envelope.host_uri) else {
             warn!(
                 target: "kakehashi::bridge",
-                "codeAction/resolve (host): envelope host_uri '{}' is not a valid URL; ignoring",
+                "codeAction/resolve (host): envelope host_uri {:?} is not a valid URL; ignoring",
                 envelope.host_uri
             );
             re_envelope_action(&mut action, &envelope);
@@ -792,7 +792,7 @@ impl LanguageServerPool {
         let Ok(host_url) = Url::parse(&envelope.host_uri) else {
             warn!(
                 target: "kakehashi::bridge",
-                "codeAction/resolve: envelope host_uri '{}' is not a valid URL; ignoring",
+                "codeAction/resolve: envelope host_uri {:?} is not a valid URL; ignoring",
                 envelope.host_uri
             );
             re_envelope_action(&mut action, &envelope);

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -5,12 +5,13 @@
 //! position parameter, like document link); `codeLens/resolve` takes a single
 //! lens as its complete params — see `dispatch_code_lens_resolve`.
 //!
-//! Every injection lens gets a routing envelope in `lens.data` (the
-//! `completionItem/resolve` pattern), as does a winning host lens when its
-//! server advertises resolve, so a later `codeLens/resolve` can be sent to the
-//! origin downstream server. Unresolved lenses (no `command`, only `data`) are
-//! therefore forwarded instead of dropped — servers like rust-analyzer return
-//! mostly-unresolved lenses by design.
+//! A lens gets a routing envelope in `lens.data` on either layer under one
+//! rule (`bridge::envelope::should_envelope`): its origin advertises
+//! `codeLens/resolve`, or its payload squats on the reserved key. That lets a
+//! later `codeLens/resolve` be sent to the origin downstream server; lenses
+//! from a non-resolving origin stay bare. Unresolved lenses (no `command`,
+//! only `data`) are forwarded instead of dropped — servers like rust-analyzer
+//! return mostly-unresolved lenses by design.
 //!
 //! Resolution fails soft for stale regions, missing servers, connection
 //! errors, and parse failures: the lens returns unresolved with its envelope
@@ -1063,7 +1064,8 @@ mod tests {
         assert!(result.command.is_none(), "lens stays unresolved");
     }
 
-    /// dispatch returns a non-envelope lens unchanged (host-layer or foreign).
+    /// dispatch returns a non-envelope lens unchanged (foreign, or from a
+    /// non-resolving origin on either layer).
     #[tokio::test]
     async fn dispatch_returns_non_envelope_lens_unchanged() {
         let pool = std::sync::Arc::new(LanguageServerPool::new());

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -182,16 +182,22 @@ pub(crate) fn envelope_host_code_lenses(
         host_layer: true,
     };
     for lens in lenses {
-        if server_resolves || code_lens_data_carries_envelope_key(lens) {
+        if should_envelope_lens(lens, server_resolves) {
             envelope_lens_data(lens, &ctx);
         }
     }
 }
 
-fn code_lens_data_carries_envelope_key(lens: &CodeLens) -> bool {
-    lens.data
-        .as_ref()
-        .is_some_and(|data| data.get(ENVELOPE_KEY).is_some())
+/// Whether a lens must carry a routing envelope: the origin advertises
+/// `codeLens/resolve`, or the lens's own `data` already occupies the envelope
+/// key — the one case a non-resolving server's lens must still be wrapped, so
+/// its payload is nested rather than read back as routing metadata.
+fn should_envelope_lens(lens: &CodeLens, server_resolves: bool) -> bool {
+    server_resolves
+        || lens
+            .data
+            .as_ref()
+            .is_some_and(|data| data.get(ENVELOPE_KEY).is_some())
 }
 
 impl LanguageServerPool {

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -307,6 +307,13 @@ impl LanguageServerPool {
         upstream_id: Option<UpstreamId>,
     ) -> CodeLens {
         let server_name = &envelope.origin;
+        // One function serves both layers; tag the host one like the
+        // completion and codeAction host paths do.
+        let layer = if envelope.is_host_layer() {
+            " (host)"
+        } else {
+            ""
+        };
         let Ok(host_uri) = Url::parse(&envelope.host_uri) else {
             re_envelope_lens(&mut lens, &envelope);
             return lens;
@@ -358,8 +365,7 @@ impl LanguageServerPool {
             Err(e) => {
                 warn!(
                     target: "kakehashi::bridge",
-                    "codeLens/resolve: failed to connect to {}: {}",
-                    server_name, e
+                    "codeLens/resolve{layer}: failed to connect to {server_name}: {e}"
                 );
                 re_envelope_lens(&mut lens, &envelope);
                 return lens;
@@ -375,13 +381,13 @@ impl LanguageServerPool {
             if nests_reserved_key(lens.data.as_ref()) {
                 debug!(
                     target: "kakehashi::bridge",
-                    "codeLens/resolve: {server_name:?} does not advertise resolveProvider; the lens was \
+                    "codeLens/resolve{layer}: {server_name:?} does not advertise resolveProvider; the lens was \
                      enveloped only to nest a reserved-key payload; returning unresolved"
                 );
             } else {
                 warn!(
                     target: "kakehashi::bridge",
-                    "codeLens/resolve: {server_name:?} no longer advertises resolveProvider; returning unresolved"
+                    "codeLens/resolve{layer}: {server_name:?} no longer advertises resolveProvider; returning unresolved"
                 );
             }
             re_envelope_lens(&mut lens, &envelope);
@@ -421,7 +427,7 @@ impl LanguageServerPool {
                 Err(e) => {
                     warn!(
                         target: "kakehashi::bridge",
-                        "codeLens/resolve: failed to register request for {}: {}",
+                        "codeLens/resolve{layer}: failed to register request for {}: {}",
                         server_name, e
                     );
                     if let Some(ref id) = upstream_id {
@@ -465,7 +471,7 @@ impl LanguageServerPool {
         if let Err(e) = send_result {
             warn!(
                 target: "kakehashi::bridge",
-                "codeLens/resolve: failed to send request for {}: {}",
+                "codeLens/resolve{layer}: failed to send request for {}: {}",
                 server_name, e
             );
             if let Some(ref id) = upstream_id {

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -428,8 +428,7 @@ impl LanguageServerPool {
                 Err(e) => {
                     warn!(
                         target: "kakehashi::bridge",
-                        "codeLens/resolve{layer}: failed to register request for {}: {}",
-                        server_name, e
+                        "codeLens/resolve{layer}: failed to register request for {server_name}: {e}"
                     );
                     if let Some(ref id) = upstream_id {
                         self.unregister_upstream_request(id, connection_key);
@@ -472,8 +471,7 @@ impl LanguageServerPool {
         if let Err(e) = send_result {
             warn!(
                 target: "kakehashi::bridge",
-                "codeLens/resolve{layer}: failed to send request for {}: {}",
-                server_name, e
+                "codeLens/resolve{layer}: failed to send request for {server_name}: {e}"
             );
             if let Some(ref id) = upstream_id {
                 self.unregister_upstream_request(id, connection_key);
@@ -494,8 +492,7 @@ impl LanguageServerPool {
             Err(e) => {
                 warn!(
                     target: "kakehashi::bridge",
-                    "codeLens/resolve failed for server {}: {}",
-                    server_name, e
+                    "codeLens/resolve{layer} failed for server {server_name}: {e}"
                 );
                 re_envelope_lens(&mut lens, &envelope);
                 return lens;

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -1065,4 +1065,62 @@ mod tests {
             .await;
         assert_eq!(result.data, Some(json!({"custom": true})));
     }
+
+    /// The resolve-side capability gate is the authoritative one: an envelope
+    /// is minted for a resolving origin, so reaching a non-resolving handle
+    /// means the origin changed under the lens (dynamic unregister, respawn)
+    /// or the payload was wrapped for squatting on the reserved key. Either
+    /// way the lens comes back unresolved AND the anomaly is logged, as the
+    /// completion and codeAction paths already do.
+    #[test]
+    fn dispatch_warns_and_re_envelopes_when_origin_no_longer_resolves() {
+        use crate::lsp::bridge::test_logging::captured_warnings_for;
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let warnings = captured_warnings_for(|| {
+            runtime.block_on(async {
+                let pool = LanguageServerPool::new();
+                let key = ConnectionKey::for_server("lua-ls");
+                let handle = crate::lsp::bridge::test_helpers::create_handle_with_key(
+                    crate::lsp::bridge::ConnectionState::Ready,
+                    key.clone(),
+                )
+                .await;
+                pool.insert_connection(handle).await;
+                let mut settings = WorkspaceSettings::default();
+                settings.language_servers.insert(
+                    "lua-ls".to_string(),
+                    BridgeServerConfig {
+                        cmd: Some(vec!["lua-language-server".to_string()]),
+                        ..Default::default()
+                    },
+                );
+                let mut lenses = vec![CodeLens {
+                    range: tower_lsp_server::ls_types::Range::default(),
+                    command: None,
+                    data: Some(json!({"kind": "references"})),
+                }];
+                envelope_host_code_lenses(
+                    &mut lenses,
+                    "lua-ls",
+                    "file:///test.md",
+                    None,
+                    pool.document_connection_generation(&key),
+                    &key,
+                    true,
+                );
+
+                let result = pool
+                    .dispatch_code_lens_resolve(lenses.remove(0), &settings, None)
+                    .await;
+                let envelope = extract_code_lens_envelope(&result).expect("envelope restored");
+                assert_eq!(envelope.inner, Some(json!({"kind": "references"})));
+                assert!(result.command.is_none(), "lens stays unresolved");
+            });
+        });
+        assert!(
+            warnings.iter().any(|w| w.contains("codeLens/resolve")
+                && w.contains("no longer advertises resolveProvider")),
+            "the capability miss must be logged, not silently swallowed: {warnings:?}"
+        );
+    }
 }

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -378,6 +378,15 @@ impl LanguageServerPool {
         };
 
         if !handle.has_capability("codeLens/resolve") {
+            // Anomalous: the envelope was only minted because the origin
+            // advertised resolve (or the payload squatted on the reserved
+            // key), so reaching here means a respawn or dynamic unregister
+            // changed capabilities under the lens.
+            warn!(
+                target: "kakehashi::bridge",
+                "codeLens/resolve: {:?} no longer advertises resolveProvider; returning unresolved",
+                envelope.origin
+            );
             re_envelope_lens(&mut lens, &envelope);
             return lens;
         }

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -596,14 +596,16 @@ mod tests {
     use serde_json::json;
 
     /// Run the virt transform for a resolving origin: every lens is enveloped.
-    fn transform_for_test(
+    /// (The completion twin defaults the other way — its helper is named for
+    /// a non-resolving origin.)
+    fn transform_for_resolving_server(
         response: serde_json::Value,
         offset: &RegionOffset,
     ) -> Option<Vec<CodeLens>> {
-        transform_for_resolving_server(response, offset, true)
+        transform_with_resolve_support(response, offset, true)
     }
 
-    fn transform_for_resolving_server(
+    fn transform_with_resolve_support(
         response: serde_json::Value,
         offset: &RegionOffset,
         server_resolves: bool,
@@ -629,14 +631,14 @@ mod tests {
         let offset = RegionOffset::new(3, 0);
 
         let resolvable =
-            transform_for_resolving_server(response(json!({"token": 1})), &offset, true).unwrap();
+            transform_with_resolve_support(response(json!({"token": 1})), &offset, true).unwrap();
         let envelope =
             extract_code_lens_envelope(&resolvable[0]).expect("resolving origin envelopes");
         assert_eq!(envelope.origin, "lua-ls");
         assert_eq!(envelope.inner, Some(json!({"token": 1})));
 
         let bare =
-            transform_for_resolving_server(response(json!({"token": 1})), &offset, false).unwrap();
+            transform_with_resolve_support(response(json!({"token": 1})), &offset, false).unwrap();
         assert_eq!(
             bare[0].data,
             Some(json!({"token": 1})),
@@ -645,7 +647,7 @@ mod tests {
         );
         assert_eq!(bare[0].range.start.line, 3, "ranges are still translated");
 
-        let forged = transform_for_resolving_server(
+        let forged = transform_with_resolve_support(
             response(json!({ ENVELOPE_KEY: { "origin": "spoofed" } })),
             &offset,
             false,
@@ -764,7 +766,7 @@ mod tests {
         });
 
         let offset = RegionOffset::new(5, 0);
-        let transformed = transform_for_test(response, &offset);
+        let transformed = transform_for_resolving_server(response, &offset);
 
         let lenses = transformed.expect("Should parse code lenses");
         assert_eq!(lenses.len(), 1);
@@ -800,7 +802,7 @@ mod tests {
         });
 
         let offset = RegionOffset::new(3, 0);
-        let transformed = transform_for_test(response, &offset);
+        let transformed = transform_for_resolving_server(response, &offset);
 
         let lenses = transformed.expect("Should parse code lenses");
         assert_eq!(
@@ -831,7 +833,7 @@ mod tests {
     #[case::malformed_result(json!({"jsonrpc": "2.0", "id": 42, "result": "not_an_array"}))]
     fn code_lens_response_returns_none_for_invalid(#[case] response: serde_json::Value) {
         let offset = RegionOffset::new(5, 0);
-        let transformed = transform_for_test(response, &offset);
+        let transformed = transform_for_resolving_server(response, &offset);
         assert!(transformed.is_none());
     }
 
@@ -840,7 +842,7 @@ mod tests {
         let response = json!({ "jsonrpc": "2.0", "id": 42, "result": [] });
 
         let offset = RegionOffset::new(5, 0);
-        let transformed = transform_for_test(response, &offset);
+        let transformed = transform_for_resolving_server(response, &offset);
         assert!(transformed.expect("Should parse empty array").is_empty());
     }
 
@@ -859,7 +861,7 @@ mod tests {
         });
 
         let offset = RegionOffset::new(10, 0);
-        let transformed = transform_for_test(response, &offset);
+        let transformed = transform_for_resolving_server(response, &offset);
 
         let lenses = transformed.expect("Should parse code lenses");
         assert_eq!(

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -24,7 +24,7 @@
 use std::io;
 use std::sync::Arc;
 
-use log::warn;
+use log::{debug, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tower_lsp_server::ls_types::{CodeLens, NumberOrString};
@@ -40,7 +40,7 @@ use super::completion::EnvelopeOffset;
 use crate::config::settings::{BridgeServerConfig, WorkspaceSettings};
 use crate::config::{merge_bridge_server_configs, resolve_with_wildcard};
 use crate::lsp::bridge::actor::RouterCleanupGuard;
-use crate::lsp::bridge::envelope::{ENVELOPE_KEY, should_envelope};
+use crate::lsp::bridge::envelope::{ENVELOPE_KEY, nests_reserved_key, should_envelope};
 
 /// Envelope stored in `CodeLens.data` for routing `codeLens/resolve` (#355).
 ///
@@ -367,15 +367,23 @@ impl LanguageServerPool {
         };
 
         if !handle.has_capability("codeLens/resolve") {
-            // Anomalous: the envelope was only minted because the origin
-            // advertised resolve (or the payload squatted on the reserved
-            // key), so reaching here means a respawn or dynamic unregister
-            // changed capabilities under the lens.
-            warn!(
-                target: "kakehashi::bridge",
-                "codeLens/resolve: {:?} no longer advertises resolveProvider; returning unresolved",
-                envelope.origin
-            );
+            // Two ways here. The origin never advertised resolve and its
+            // payload was wrapped only for squatting on the reserved key:
+            // steady state, every client resolve of that lens lands here,
+            // so say so quietly. Or it did advertise and a respawn or dynamic
+            // unregister withdrew the capability under the lens: anomalous.
+            if nests_reserved_key(lens.data.as_ref()) {
+                debug!(
+                    target: "kakehashi::bridge",
+                    "codeLens/resolve: {server_name:?} does not advertise resolveProvider; the lens was \
+                     enveloped only to nest a reserved-key payload; returning unresolved"
+                );
+            } else {
+                warn!(
+                    target: "kakehashi::bridge",
+                    "codeLens/resolve: {server_name:?} no longer advertises resolveProvider; returning unresolved"
+                );
+            }
             re_envelope_lens(&mut lens, &envelope);
             return lens;
         }
@@ -1071,7 +1079,7 @@ mod tests {
     /// means the origin changed under the lens (dynamic unregister, respawn)
     /// or the payload was wrapped for squatting on the reserved key. Either
     /// way the lens comes back unresolved AND the anomaly is logged, as the
-    /// completion and codeAction paths already do.
+    /// codeAction and host-completion paths already did.
     #[test]
     fn dispatch_warns_and_re_envelopes_when_origin_no_longer_resolves() {
         use crate::lsp::bridge::test_logging::captured_warnings_for;

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -1123,4 +1123,64 @@ mod tests {
             "the capability miss must be logged, not silently swallowed: {warnings:?}"
         );
     }
+
+    /// The other way to reach the capability miss is steady state, not an
+    /// anomaly: a NON-resolving origin's payload squatted on the reserved key,
+    /// so it was wrapped only to nest it, and every client resolve of that
+    /// lens lands here. It must come back unresolved with the payload intact
+    /// and must NOT be reported as a lost capability.
+    #[test]
+    fn dispatch_does_not_warn_for_a_reserved_key_wrap_from_a_non_resolving_origin() {
+        use crate::lsp::bridge::test_logging::captured_warnings_for;
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let warnings = captured_warnings_for(|| {
+            runtime.block_on(async {
+                let pool = LanguageServerPool::new();
+                let key = ConnectionKey::for_server("lua-ls");
+                let handle = crate::lsp::bridge::test_helpers::create_handle_with_key(
+                    crate::lsp::bridge::ConnectionState::Ready,
+                    key.clone(),
+                )
+                .await;
+                pool.insert_connection(handle).await;
+                let mut settings = WorkspaceSettings::default();
+                settings.language_servers.insert(
+                    "lua-ls".to_string(),
+                    BridgeServerConfig {
+                        cmd: Some(vec!["lua-language-server".to_string()]),
+                        ..Default::default()
+                    },
+                );
+                let forged = json!({ ENVELOPE_KEY: { "origin": "forged" } });
+                let mut lenses = vec![CodeLens {
+                    range: tower_lsp_server::ls_types::Range::default(),
+                    command: None,
+                    data: Some(forged.clone()),
+                }];
+                envelope_host_code_lenses(
+                    &mut lenses,
+                    "lua-ls",
+                    "file:///test.md",
+                    None,
+                    pool.document_connection_generation(&key),
+                    &key,
+                    false,
+                );
+
+                let result = pool
+                    .dispatch_code_lens_resolve(lenses.remove(0), &settings, None)
+                    .await;
+                let envelope = extract_code_lens_envelope(&result).expect("envelope restored");
+                assert_eq!(envelope.origin, "lua-ls");
+                assert_eq!(envelope.inner, Some(forged));
+                assert!(result.command.is_none(), "lens stays unresolved");
+            });
+        });
+        assert!(
+            !warnings
+                .iter()
+                .any(|w| w.contains("no longer advertises resolveProvider")),
+            "a reserved-key wrap is not a lost capability: {warnings:?}"
+        );
+    }
 }

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -40,9 +40,7 @@ use super::completion::EnvelopeOffset;
 use crate::config::settings::{BridgeServerConfig, WorkspaceSettings};
 use crate::config::{merge_bridge_server_configs, resolve_with_wildcard};
 use crate::lsp::bridge::actor::RouterCleanupGuard;
-
-/// Wrapper key inside `CodeLens.data` that identifies the origin server.
-const ENVELOPE_KEY: &str = "kakehashi";
+use crate::lsp::bridge::envelope::{ENVELOPE_KEY, should_envelope};
 
 /// Envelope stored in `CodeLens.data` for routing `codeLens/resolve` (#355).
 ///
@@ -182,22 +180,10 @@ pub(crate) fn envelope_host_code_lenses(
         host_layer: true,
     };
     for lens in lenses {
-        if should_envelope_lens(lens, server_resolves) {
+        if should_envelope(lens.data.as_ref(), server_resolves) {
             envelope_lens_data(lens, &ctx);
         }
     }
-}
-
-/// Whether a lens must carry a routing envelope: the origin advertises
-/// `codeLens/resolve`, or the lens's own `data` already occupies the envelope
-/// key — the one case a non-resolving server's lens must still be wrapped, so
-/// its payload is nested rather than read back as routing metadata.
-fn should_envelope_lens(lens: &CodeLens, server_resolves: bool) -> bool {
-    server_resolves
-        || lens
-            .data
-            .as_ref()
-            .is_some_and(|data| data.get(ENVELOPE_KEY).is_some())
 }
 
 impl LanguageServerPool {
@@ -569,7 +555,7 @@ fn parse_code_lens_resolve_response(mut response: serde_json::Value) -> Option<C
 /// Transform a code lens response from virtual to host document coordinates.
 ///
 /// Each lens's `range` is translated by `offset`, and the `data` of each lens
-/// that [`should_envelope_lens`] selects — the origin advertises
+/// that [`should_envelope`] selects — the origin advertises
 /// `codeLens/resolve`, or the payload squats on the reserved key — is wrapped
 /// in a routing envelope so `codeLens/resolve` can find the origin server
 /// later; the rest pass through bare. Unresolved lenses (no `command`) are
@@ -594,7 +580,7 @@ fn transform_code_lens_response_to_host(
 
     for lens in &mut lenses {
         translate_virtual_range_to_host(&mut lens.range, offset);
-        if should_envelope_lens(lens, server_resolves) {
+        if should_envelope(lens.data.as_ref(), server_resolves) {
             envelope_lens_data(lens, envelope_ctx);
         }
     }

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -374,11 +374,13 @@ impl LanguageServerPool {
         };
 
         if !handle.has_capability("codeLens/resolve") {
-            // Two ways here. The origin never advertised resolve and its
-            // payload was wrapped only for squatting on the reserved key:
-            // steady state, every client resolve of that lens lands here,
-            // so say so quietly. Or it did advertise and a respawn or dynamic
-            // unregister withdrew the capability under the lens: anomalous.
+            // Two ways here. The payload nests the reserved key: as far as
+            // this branch can tell, the origin never advertised resolve and
+            // the wrap existed only to nest it — steady state, so every
+            // client resolve of that lens that clears the gates above
+            // lands here; say so quietly. Otherwise the origin did advertise
+            // and a respawn or dynamic unregister withdrew the capability
+            // under the lens: anomalous.
             if nests_reserved_key(lens.data.as_ref()) {
                 debug!(
                     target: "kakehashi::bridge",
@@ -1083,8 +1085,9 @@ mod tests {
     /// is minted for a resolving origin, so reaching a non-resolving handle
     /// means the origin changed under the lens (dynamic unregister, respawn)
     /// or the payload was wrapped for squatting on the reserved key. Either
-    /// way the lens comes back unresolved AND the anomaly is logged, as the
-    /// codeAction and host-completion paths already did.
+    /// way the lens comes back unresolved; the withdrawn-capability way is
+    /// logged as an anomaly, as the codeAction and host-completion paths
+    /// already did (the reserved-key way is the sibling test below).
     #[test]
     fn dispatch_warns_and_re_envelopes_when_origin_no_longer_resolves() {
         use crate::lsp::bridge::test_logging::captured_warnings_for;

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -218,7 +218,10 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/codeLens") {
             return Ok(None);
         }
-        let server_resolves = handle.has_capability("codeLens/resolve");
+        // Read resolve support when the RESPONSE arrives, as the host layer
+        // does: a dynamic `resolveProvider` registration can land between
+        // send and reply, and the envelope decision should see it.
+        let origin = Arc::clone(&handle);
         let host_uri_string = host_uri.to_string();
         self.execute_bridge_request_with_handle(
             handle,
@@ -246,7 +249,7 @@ impl LanguageServerPool {
                 transform_code_lens_response_to_host(
                     response,
                     ctx.offset,
-                    server_resolves,
+                    origin.has_capability("codeLens/resolve"),
                     &envelope_ctx,
                 )
             },

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -232,6 +232,7 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/codeLens") {
             return Ok(None);
         }
+        let server_resolves = handle.has_capability("codeLens/resolve");
         let host_uri_string = host_uri.to_string();
         self.execute_bridge_request_with_handle(
             handle,
@@ -256,7 +257,12 @@ impl LanguageServerPool {
                     offset: ctx.offset,
                     host_layer: false,
                 };
-                transform_code_lens_response_to_host(response, ctx.offset, &envelope_ctx)
+                transform_code_lens_response_to_host(
+                    response,
+                    ctx.offset,
+                    server_resolves,
+                    &envelope_ctx,
+                )
             },
         )
         .await
@@ -553,13 +559,17 @@ fn parse_code_lens_resolve_response(mut response: serde_json::Value) -> Option<C
 
 /// Transform a code lens response from virtual to host document coordinates.
 ///
-/// Each lens's `range` is translated by `offset` and its `data` is wrapped in
-/// a routing envelope so `codeLens/resolve` can find the origin server later.
-/// Unresolved lenses (no `command`) are kept now that resolve is supported
-/// (#355) — dropping them wholesale destroyed most of rust-analyzer's lenses.
+/// Each lens's `range` is translated by `offset`, and the `data` of each lens
+/// that [`should_envelope_lens`] selects — the origin advertises
+/// `codeLens/resolve`, or the payload squats on the reserved key — is wrapped
+/// in a routing envelope so `codeLens/resolve` can find the origin server
+/// later; the rest pass through bare. Unresolved lenses (no `command`) are
+/// kept now that resolve is supported (#355) — dropping them wholesale
+/// destroyed most of rust-analyzer's lenses.
 fn transform_code_lens_response_to_host(
     mut response: serde_json::Value,
     offset: &RegionOffset,
+    server_resolves: bool,
     envelope_ctx: &CodeLensEnvelopeContext<'_>,
 ) -> Option<Vec<CodeLens>> {
     if response_has_jsonrpc_error(&response, "textDocument/codeLens") {
@@ -575,7 +585,9 @@ fn transform_code_lens_response_to_host(
 
     for lens in &mut lenses {
         translate_virtual_range_to_host(&mut lens.range, offset);
-        envelope_lens_data(lens, envelope_ctx);
+        if should_envelope_lens(lens, server_resolves) {
+            envelope_lens_data(lens, envelope_ctx);
+        }
     }
 
     Some(lenses)

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -588,6 +588,71 @@ mod tests {
     use rstest::rstest;
     use serde_json::json;
 
+    /// Run the virt transform for a resolving origin: every lens is enveloped.
+    fn transform_for_test(
+        response: serde_json::Value,
+        offset: &RegionOffset,
+    ) -> Option<Vec<CodeLens>> {
+        transform_for_resolving_server(response, offset, true)
+    }
+
+    fn transform_for_resolving_server(
+        response: serde_json::Value,
+        offset: &RegionOffset,
+        server_resolves: bool,
+    ) -> Option<Vec<CodeLens>> {
+        transform_code_lens_response_to_host(response, offset, server_resolves, &ctx_with(offset))
+    }
+
+    #[test]
+    fn virt_lenses_are_enveloped_only_when_the_server_resolves() {
+        let response = |data: serde_json::Value| {
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": [{
+                    "range": {
+                        "start": { "line": 0, "character": 0 },
+                        "end": { "line": 0, "character": 5 }
+                    },
+                    "data": data
+                }]
+            })
+        };
+        let offset = RegionOffset::new(3, 0);
+
+        let resolvable =
+            transform_for_resolving_server(response(json!({"token": 1})), &offset, true).unwrap();
+        let envelope =
+            extract_code_lens_envelope(&resolvable[0]).expect("resolving origin envelopes");
+        assert_eq!(envelope.origin, "lua-ls");
+        assert_eq!(envelope.inner, Some(json!({"token": 1})));
+
+        let bare =
+            transform_for_resolving_server(response(json!({"token": 1})), &offset, false).unwrap();
+        assert_eq!(
+            bare[0].data,
+            Some(json!({"token": 1})),
+            "a non-resolving origin's payload must pass through untouched: the resolve \
+             would only fail soft back to it, so the envelope is pure wire weight"
+        );
+        assert_eq!(bare[0].range.start.line, 3, "ranges are still translated");
+
+        let forged = transform_for_resolving_server(
+            response(json!({ ENVELOPE_KEY: { "origin": "spoofed" } })),
+            &offset,
+            false,
+        )
+        .unwrap();
+        let envelope = extract_code_lens_envelope(&forged[0]).expect("collision envelope");
+        assert_eq!(envelope.origin, "lua-ls");
+        assert_eq!(
+            envelope.inner,
+            Some(json!({ ENVELOPE_KEY: { "origin": "spoofed" } })),
+            "the foreign payload must be nested, not honored as routing metadata"
+        );
+    }
+
     fn ctx_with<'a>(offset: &'a RegionOffset) -> CodeLensEnvelopeContext<'a> {
         CodeLensEnvelopeContext {
             server_name: "lua-ls",
@@ -692,8 +757,7 @@ mod tests {
         });
 
         let offset = RegionOffset::new(5, 0);
-        let transformed =
-            transform_code_lens_response_to_host(response, &offset, &ctx_with(&offset));
+        let transformed = transform_for_test(response, &offset);
 
         let lenses = transformed.expect("Should parse code lenses");
         assert_eq!(lenses.len(), 1);
@@ -729,8 +793,7 @@ mod tests {
         });
 
         let offset = RegionOffset::new(3, 0);
-        let transformed =
-            transform_code_lens_response_to_host(response, &offset, &ctx_with(&offset));
+        let transformed = transform_for_test(response, &offset);
 
         let lenses = transformed.expect("Should parse code lenses");
         assert_eq!(
@@ -761,8 +824,7 @@ mod tests {
     #[case::malformed_result(json!({"jsonrpc": "2.0", "id": 42, "result": "not_an_array"}))]
     fn code_lens_response_returns_none_for_invalid(#[case] response: serde_json::Value) {
         let offset = RegionOffset::new(5, 0);
-        let transformed =
-            transform_code_lens_response_to_host(response, &offset, &ctx_with(&offset));
+        let transformed = transform_for_test(response, &offset);
         assert!(transformed.is_none());
     }
 
@@ -771,8 +833,7 @@ mod tests {
         let response = json!({ "jsonrpc": "2.0", "id": 42, "result": [] });
 
         let offset = RegionOffset::new(5, 0);
-        let transformed =
-            transform_code_lens_response_to_host(response, &offset, &ctx_with(&offset));
+        let transformed = transform_for_test(response, &offset);
         assert!(transformed.expect("Should parse empty array").is_empty());
     }
 
@@ -791,8 +852,7 @@ mod tests {
         });
 
         let offset = RegionOffset::new(10, 0);
-        let transformed =
-            transform_code_lens_response_to_host(response, &offset, &ctx_with(&offset));
+        let transformed = transform_for_test(response, &offset);
 
         let lenses = transformed.expect("Should parse code lenses");
         assert_eq!(

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -62,6 +62,7 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/completion") {
             return Ok(None);
         }
+        let server_resolves = handle.has_capability("completionItem/resolve");
         self.execute_position_bridge_request_with_handle(
             handle,
             host_uri,
@@ -82,7 +83,8 @@ impl LanguageServerPool {
                     ctx.offset,
                     region_end,
                     Some(host_position.line),
-                    Some(EnvelopeContext {
+                    server_resolves,
+                    &EnvelopeContext {
                         server_name,
                         injection_language,
                         incarnation: host_incarnation,
@@ -91,7 +93,7 @@ impl LanguageServerPool {
                         offset: ctx.offset,
                         region_end: Some(region_end),
                         host_layer: false,
-                    }),
+                    },
                 )
             },
         )
@@ -119,14 +121,17 @@ fn build_completion_request(
 ///
 /// Normalizes all responses to `CompletionList` (an array result is wrapped as
 /// `CompletionList { isIncomplete: false, items }`). Returns `None` for null
-/// results, missing results, and deserialization failures. When `envelope_ctx`
-/// is `Some`, each item's `data` is wrapped in a routing envelope.
+/// results, missing results, and deserialization failures. Each item that
+/// [`should_envelope_item`] selects — the origin advertises
+/// `completionItem/resolve`, or the payload squats on the reserved key — has
+/// its `data` wrapped in a routing envelope; the rest pass through bare.
 fn transform_completion_response_to_host(
     mut response: serde_json::Value,
     offset: &RegionOffset,
     region_end: Position,
     request_host_line: Option<u32>,
-    envelope_ctx: Option<EnvelopeContext<'_>>,
+    server_resolves: bool,
+    envelope_ctx: &EnvelopeContext<'_>,
 ) -> Option<CompletionList> {
     if response_has_jsonrpc_error(&response, "textDocument/completion") {
         return None;
@@ -155,15 +160,15 @@ fn transform_completion_response_to_host(
     };
 
     // Transform all items in the list (dropping any whose primary edit is
-    // unsafe for the injection region), then optionally envelope for resolve
-    // routing
+    // unsafe for the injection region), then envelope for resolve routing
+    // under the same policy as the host layer.
     let before = list.items.len();
     list.items.retain_mut(|item| {
         if !transform_completion_item(item, offset, region_end, request_host_line) {
             return false;
         }
-        if let Some(ref ctx) = envelope_ctx {
-            envelope_item_data(item, ctx);
+        if should_envelope_item(item, server_resolves) {
+            envelope_item_data(item, envelope_ctx);
         }
         true
     });

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -664,6 +664,96 @@ mod tests {
     use rstest::rstest;
     use serde_json::json;
 
+    /// Run the virt transform for a NON-resolving origin, the shape most
+    /// coordinate tests want: ranges translate, `data` passes through bare.
+    fn transform_for_test(
+        response: serde_json::Value,
+        offset: &RegionOffset,
+        region_end: Position,
+        request_host_line: Option<u32>,
+    ) -> Option<CompletionList> {
+        transform_for_resolving_server(response, offset, region_end, request_host_line, false)
+    }
+
+    fn transform_for_resolving_server(
+        response: serde_json::Value,
+        offset: &RegionOffset,
+        region_end: Position,
+        request_host_line: Option<u32>,
+        server_resolves: bool,
+    ) -> Option<CompletionList> {
+        transform_completion_response_to_host(
+            response,
+            offset,
+            region_end,
+            request_host_line,
+            server_resolves,
+            &EnvelopeContext {
+                server_name: "lua-ls",
+                injection_language: "lua",
+                incarnation: Some(1),
+                host_uri: "file:///test.md",
+                region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                offset,
+                region_end: Some(region_end),
+                host_layer: false,
+            },
+        )
+    }
+
+    #[test]
+    fn virt_items_are_enveloped_only_when_the_server_resolves() {
+        let response = |data: serde_json::Value| {
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": [{ "label": "print", "data": data }]
+            })
+        };
+        let offset = RegionOffset::new(3, 2);
+
+        let resolvable = transform_for_resolving_server(
+            response(json!({"token": 1})),
+            &offset,
+            TEST_REGION_END,
+            None,
+            true,
+        )
+        .unwrap();
+        let envelope = extract_envelope(&resolvable.items[0]).expect("resolving origin envelopes");
+        assert_eq!(envelope.origin, "lua-ls");
+        assert_eq!(envelope.inner, Some(json!({"token": 1})));
+
+        let bare = transform_for_test(
+            response(json!({"token": 1})),
+            &offset,
+            TEST_REGION_END,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            bare.items[0].data,
+            Some(json!({"token": 1})),
+            "a non-resolving origin's payload must pass through untouched: the resolve \
+             would only fail soft back to it, so the envelope is pure wire weight"
+        );
+
+        let forged = transform_for_test(
+            response(json!({ ENVELOPE_KEY: { "origin": "spoofed" } })),
+            &offset,
+            TEST_REGION_END,
+            None,
+        )
+        .unwrap();
+        let envelope = extract_envelope(&forged.items[0]).expect("collision envelope");
+        assert_eq!(envelope.origin, "lua-ls");
+        assert_eq!(
+            envelope.inner,
+            Some(json!({ ENVELOPE_KEY: { "origin": "spoofed" } })),
+            "the foreign payload must be nested, not honored as routing metadata"
+        );
+    }
+
     // ==========================================================================
     // Completion request tests
     // ==========================================================================
@@ -724,11 +814,10 @@ mod tests {
         });
         let region_start_line = 3;
 
-        let transformed = transform_completion_response_to_host(
+        let transformed = transform_for_test(
             response,
             &RegionOffset::new(region_start_line, 0),
             TEST_REGION_END,
-            None,
             None,
         );
 
@@ -758,13 +847,8 @@ mod tests {
     #[case::malformed_result(json!({"jsonrpc": "2.0", "id": 42, "result": "not_a_completion_response"}))]
     #[case::error_response(json!({"jsonrpc": "2.0", "id": 42, "error": {"code": -32600, "message": "Invalid Request"}}))]
     fn completion_response_returns_none_for_invalid_response(#[case] response: serde_json::Value) {
-        let transformed = transform_completion_response_to_host(
-            response,
-            &RegionOffset::new(3, 0),
-            TEST_REGION_END,
-            None,
-            None,
-        );
+        let transformed =
+            transform_for_test(response, &RegionOffset::new(3, 0), TEST_REGION_END, None);
         assert!(transformed.is_none());
     }
 
@@ -786,11 +870,10 @@ mod tests {
         });
         let region_start_line = 5;
 
-        let transformed = transform_completion_response_to_host(
+        let transformed = transform_for_test(
             response,
             &RegionOffset::new(region_start_line, 0),
             TEST_REGION_END,
-            None,
             None,
         );
 
@@ -836,11 +919,10 @@ mod tests {
         });
         let region_start_line = 10;
 
-        let transformed = transform_completion_response_to_host(
+        let transformed = transform_for_test(
             response,
             &RegionOffset::new(region_start_line, 0),
             TEST_REGION_END,
-            None,
             None,
         );
 
@@ -883,11 +965,10 @@ mod tests {
         });
         let region_start_line = 5;
 
-        let transformed = transform_completion_response_to_host(
+        let transformed = transform_for_test(
             response,
             &RegionOffset::new(region_start_line, 0),
             TEST_REGION_END,
-            None,
             None,
         );
 
@@ -926,13 +1007,8 @@ mod tests {
             }
         });
 
-        let transformed = transform_completion_response_to_host(
-            response,
-            &RegionOffset::new(10, 4),
-            TEST_REGION_END,
-            None,
-            None,
-        );
+        let transformed =
+            transform_for_test(response, &RegionOffset::new(10, 4), TEST_REGION_END, None);
 
         let list = transformed.unwrap();
         if let Some(tower_lsp_server::ls_types::CompletionTextEdit::Edit(ref edit)) =
@@ -968,13 +1044,8 @@ mod tests {
             }
         });
 
-        let transformed = transform_completion_response_to_host(
-            response,
-            &RegionOffset::new(10, 4),
-            TEST_REGION_END,
-            None,
-            None,
-        );
+        let transformed =
+            transform_for_test(response, &RegionOffset::new(10, 4), TEST_REGION_END, None);
 
         let list = transformed.unwrap();
         if let Some(tower_lsp_server::ls_types::CompletionTextEdit::Edit(ref edit)) =
@@ -1014,13 +1085,8 @@ mod tests {
             }
         });
 
-        let transformed = transform_completion_response_to_host(
-            response,
-            &RegionOffset::new(5, 7),
-            TEST_REGION_END,
-            None,
-            None,
-        );
+        let transformed =
+            transform_for_test(response, &RegionOffset::new(5, 7), TEST_REGION_END, None);
 
         let list = transformed.unwrap();
         if let Some(tower_lsp_server::ls_types::CompletionTextEdit::InsertAndReplace(ref edit)) =
@@ -1062,13 +1128,8 @@ mod tests {
             }
         });
 
-        let transformed = transform_completion_response_to_host(
-            response,
-            &RegionOffset::new(5, 3),
-            TEST_REGION_END,
-            None,
-            None,
-        );
+        let transformed =
+            transform_for_test(response, &RegionOffset::new(5, 3), TEST_REGION_END, None);
 
         let list = transformed.unwrap();
         let edits = list.items[0].additional_text_edits.as_ref().unwrap();
@@ -1137,11 +1198,10 @@ mod tests {
         });
         let region_start_line = 10;
 
-        let transformed = transform_completion_response_to_host(
+        let transformed = transform_for_test(
             response,
             &RegionOffset::new(region_start_line, 0),
             TEST_REGION_END,
-            None,
             None,
         );
 
@@ -1584,8 +1644,7 @@ mod tests {
             ]
         });
 
-        let list = transform_completion_response_to_host(response, &offset, region_end, None, None)
-            .unwrap();
+        let list = transform_for_test(response, &offset, region_end, None).unwrap();
 
         assert_eq!(list.items.len(), 1, "prefix-breaking item must be dropped");
         assert_eq!(list.items[0].label, "safe");
@@ -1621,8 +1680,7 @@ mod tests {
             ]
         });
 
-        let list = transform_completion_response_to_host(response, &offset, region_end, None, None)
-            .unwrap();
+        let list = transform_for_test(response, &offset, region_end, None).unwrap();
 
         assert_eq!(list.items.len(), 1, "item with safe primary edit is kept");
         assert!(
@@ -1652,8 +1710,7 @@ mod tests {
             ]
         });
 
-        let list = transform_completion_response_to_host(response, &offset, region_end, None, None)
-            .unwrap();
+        let list = transform_for_test(response, &offset, region_end, None).unwrap();
 
         assert!(
             list.items.is_empty(),
@@ -1685,8 +1742,7 @@ mod tests {
             ]
         });
 
-        let list = transform_completion_response_to_host(response, &offset, region_end, None, None)
-            .unwrap();
+        let list = transform_for_test(response, &offset, region_end, None).unwrap();
 
         assert_eq!(list.items.len(), 1, "region-escaping item must drop");
         assert_eq!(list.items[0].label, "contained");
@@ -1711,21 +1767,13 @@ mod tests {
             ]
         });
 
-        let list = transform_completion_response_to_host(
-            response.clone(),
-            &offset,
-            region_end,
-            None,
-            None,
-        )
-        .unwrap();
+        let list = transform_for_test(response.clone(), &offset, region_end, None).unwrap();
         assert_eq!(list.items.len(), 1, "multiline fallback must drop");
         assert_eq!(list.items[0].label, "single");
 
         // Same response in a plain fenced region: both survive.
         let plain = RegionOffset::with_per_line_offsets(3, vec![0, 0, 0]);
-        let list = transform_completion_response_to_host(response, &plain, region_end, None, None)
-            .unwrap();
+        let list = transform_for_test(response, &plain, region_end, None).unwrap();
         assert_eq!(list.items.len(), 2, "plain regions take multiline inserts");
     }
 
@@ -1756,14 +1804,7 @@ mod tests {
             ]
         });
 
-        let list = transform_completion_response_to_host(
-            response.clone(),
-            &offset,
-            region_end,
-            None,
-            None,
-        )
-        .unwrap();
+        let list = transform_for_test(response.clone(), &offset, region_end, None).unwrap();
         let labels: Vec<_> = list.items.iter().map(|i| i.label.as_str()).collect();
         assert_eq!(
             labels,
@@ -1773,8 +1814,7 @@ mod tests {
 
         // Plain (all-zero) region: everything survives.
         let plain = RegionOffset::with_per_line_offsets(3, vec![0, 0, 0]);
-        let list = transform_completion_response_to_host(response, &plain, region_end, None, None)
-            .unwrap();
+        let list = transform_for_test(response, &plain, region_end, None).unwrap();
         assert_eq!(list.items.len(), 3, "plain regions are exempt");
     }
 
@@ -1812,27 +1852,13 @@ mod tests {
         });
 
         // Requested on host line 5 (virtual line 2, unprefixed): kept.
-        let list = transform_completion_response_to_host(
-            response.clone(),
-            &offset,
-            region_end,
-            Some(5),
-            None,
-        )
-        .unwrap();
+        let list = transform_for_test(response.clone(), &offset, region_end, Some(5)).unwrap();
         assert_eq!(list.items.len(), 1, "later-line insertion is safe");
 
         // Requested on host line 3 (virtual line 0): in a MULTI-LINE region
         // line 0's captured content runs to end-of-line, so the inserted
         // newline splits only injected content — kept.
-        let list = transform_completion_response_to_host(
-            response.clone(),
-            &offset,
-            region_end,
-            Some(3),
-            None,
-        )
-        .unwrap();
+        let list = transform_for_test(response.clone(), &offset, region_end, Some(3)).unwrap();
         assert_eq!(list.items.len(), 1, "multi-line region line 0 is safe");
 
         // Same shape but a SAME-LINE inline region (region end on the start
@@ -1842,9 +1868,7 @@ mod tests {
             line: 3,
             character: 20,
         };
-        let list =
-            transform_completion_response_to_host(response, &offset, inline_end, Some(3), None)
-                .unwrap();
+        let list = transform_for_test(response, &offset, inline_end, Some(3)).unwrap();
         assert!(
             list.items.is_empty(),
             "inline-region line-0 insertion would split the host line"
@@ -1876,8 +1900,7 @@ mod tests {
             ]
         });
 
-        let list = transform_completion_response_to_host(response, &offset, region_end, None, None)
-            .unwrap();
+        let list = transform_for_test(response, &offset, region_end, None).unwrap();
         assert!(
             list.items.is_empty(),
             "either prefixed start line must reject the snippet variable"
@@ -1903,23 +1926,14 @@ mod tests {
         });
 
         let mixed = RegionOffset::with_per_line_offsets(3, vec![2, 0, 0]);
-        let list = transform_completion_response_to_host(
-            response.clone(),
-            &mixed,
-            region_end,
-            Some(4),
-            None,
-        )
-        .unwrap();
+        let list = transform_for_test(response.clone(), &mixed, region_end, Some(4)).unwrap();
         assert!(
             list.items.is_empty(),
             "boundary-adjacent insertion in a prefixed region must drop"
         );
 
         let plain = RegionOffset::with_per_line_offsets(3, vec![0, 0, 0]);
-        let list =
-            transform_completion_response_to_host(response, &plain, region_end, Some(4), None)
-                .unwrap();
+        let list = transform_for_test(response, &plain, region_end, Some(4)).unwrap();
         assert_eq!(list.items.len(), 1, "all-zero regions keep no boundary");
     }
 }

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -392,9 +392,11 @@ fn snippet_contains_variable(text: &str) -> bool {
 
 /// Envelope stored in `CompletionItem.data` for routing `completionItem/resolve`.
 ///
-/// When Kakehashi fans out completion to multiple downstream servers, each item's
-/// `data` field is wrapped in this envelope so that a later `completionItem/resolve`
-/// can be routed back to the correct server.
+/// When Kakehashi fans out completion to multiple downstream servers, the
+/// `data` of each item whose origin advertises `completionItem/resolve` (or
+/// whose payload squats on the reserved key) is wrapped in this envelope so
+/// that a later `completionItem/resolve` can be routed back to the correct
+/// server.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) struct KakehashiEnvelope {
     /// Server name identifying which downstream produced the item.
@@ -421,7 +423,8 @@ pub(crate) struct KakehashiEnvelope {
     /// Stable injection region identity for live resolve-time geometry checks.
     /// Empty for envelopes minted before this field existed, and for every
     /// host-layer envelope (which has no region) — skipped on the wire in
-    /// that case, since this rides in EVERY item of every completion response.
+    /// that case, since this rides in every enveloped item of a completion
+    /// response.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub region_id: String,
     /// The downstream server's original `data` value (preserved verbatim).
@@ -1463,8 +1466,8 @@ mod tests {
             "a region-carrying envelope stays on the virt resolve path"
         );
 
-        // The virt envelope — minted for every item of every completion —
-        // must not carry the host marker on the wire at all.
+        // The virt envelope — minted for every item of a resolving origin's
+        // completion — must not carry the host marker on the wire at all.
         let mut virt = CompletionItem::default();
         envelope_item_data(
             &mut virt,

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -63,7 +63,10 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/completion") {
             return Ok(None);
         }
-        let server_resolves = handle.has_capability("completionItem/resolve");
+        // Read resolve support when the RESPONSE arrives, as the host layer
+        // does: a dynamic `resolveProvider` registration can land between
+        // send and reply, and the envelope decision should see it.
+        let origin = std::sync::Arc::clone(&handle);
         self.execute_position_bridge_request_with_handle(
             handle,
             host_uri,
@@ -84,7 +87,7 @@ impl LanguageServerPool {
                     ctx.offset,
                     region_end,
                     Some(host_position.line),
-                    server_resolves,
+                    origin.has_capability("completionItem/resolve"),
                     &EnvelopeContext {
                         server_name,
                         injection_language,

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -705,7 +705,17 @@ mod tests {
             json!({
                 "jsonrpc": "2.0",
                 "id": 1,
-                "result": [{ "label": "print", "data": data }]
+                "result": [{
+                    "label": "print",
+                    "textEdit": {
+                        "range": {
+                            "start": { "line": 0, "character": 0 },
+                            "end": { "line": 0, "character": 2 }
+                        },
+                        "newText": "print"
+                    },
+                    "data": data
+                }]
             })
         };
         let offset = RegionOffset::new(3, 2);
@@ -734,6 +744,16 @@ mod tests {
             Some(json!({"token": 1})),
             "a non-resolving origin's payload must pass through untouched: the resolve \
              would only fail soft back to it, so the envelope is pure wire weight"
+        );
+        let Some(tower_lsp_server::ls_types::CompletionTextEdit::Edit(edit)) =
+            &bare.items[0].text_edit
+        else {
+            panic!("the bare item keeps its edit");
+        };
+        assert_eq!(
+            (edit.range.start.line, edit.range.start.character),
+            (3, 2),
+            "ranges are still translated for a bare item"
         );
 
         let forged = transform_for_non_resolving_server(

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -593,18 +593,23 @@ pub(crate) fn bridge_host_completion_items(
         CompletionResponse::List(list) => &mut list.items,
     };
     for item in items.iter_mut() {
-        if server_resolves || data_carries_envelope_key(item) {
+        if should_envelope_item(item, server_resolves) {
             envelope_host_item(item, server_name, host_uri);
         }
     }
 }
 
-/// Whether an item's own `data` already occupies the envelope key — the one
-/// case a non-resolving server's item must still be wrapped.
-fn data_carries_envelope_key(item: &CompletionItem) -> bool {
-    item.data
-        .as_ref()
-        .is_some_and(|data| data.get(ENVELOPE_KEY).is_some())
+/// Whether an item must carry a routing envelope: the origin advertises
+/// `completionItem/resolve`, or the item's own `data` already occupies the
+/// envelope key — the one case a non-resolving server's item must still be
+/// wrapped, so its payload is nested rather than read back as routing
+/// metadata it never earned.
+fn should_envelope_item(item: &CompletionItem, server_resolves: bool) -> bool {
+    server_resolves
+        || item
+            .data
+            .as_ref()
+            .is_some_and(|data| data.get(ENVELOPE_KEY).is_some())
 }
 
 /// Wrap a HOST-layer item's `data` in a routing envelope so a later

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -656,16 +656,18 @@ mod tests {
 
     /// Run the virt transform for a NON-resolving origin, the shape most
     /// coordinate tests want: ranges translate, `data` passes through bare.
-    fn transform_for_test(
+    /// (The codeLens and documentLink twins default the other way — their
+    /// helper is named for a resolving origin.)
+    fn transform_for_non_resolving_server(
         response: serde_json::Value,
         offset: &RegionOffset,
         region_end: Position,
         request_host_line: Option<u32>,
     ) -> Option<CompletionList> {
-        transform_for_resolving_server(response, offset, region_end, request_host_line, false)
+        transform_with_resolve_support(response, offset, region_end, request_host_line, false)
     }
 
-    fn transform_for_resolving_server(
+    fn transform_with_resolve_support(
         response: serde_json::Value,
         offset: &RegionOffset,
         region_end: Position,
@@ -702,7 +704,7 @@ mod tests {
         };
         let offset = RegionOffset::new(3, 2);
 
-        let resolvable = transform_for_resolving_server(
+        let resolvable = transform_with_resolve_support(
             response(json!({"token": 1})),
             &offset,
             TEST_REGION_END,
@@ -714,7 +716,7 @@ mod tests {
         assert_eq!(envelope.origin, "lua-ls");
         assert_eq!(envelope.inner, Some(json!({"token": 1})));
 
-        let bare = transform_for_test(
+        let bare = transform_for_non_resolving_server(
             response(json!({"token": 1})),
             &offset,
             TEST_REGION_END,
@@ -728,7 +730,7 @@ mod tests {
              would only fail soft back to it, so the envelope is pure wire weight"
         );
 
-        let forged = transform_for_test(
+        let forged = transform_for_non_resolving_server(
             response(json!({ ENVELOPE_KEY: { "origin": "spoofed" } })),
             &offset,
             TEST_REGION_END,
@@ -804,7 +806,7 @@ mod tests {
         });
         let region_start_line = 3;
 
-        let transformed = transform_for_test(
+        let transformed = transform_for_non_resolving_server(
             response,
             &RegionOffset::new(region_start_line, 0),
             TEST_REGION_END,
@@ -837,8 +839,12 @@ mod tests {
     #[case::malformed_result(json!({"jsonrpc": "2.0", "id": 42, "result": "not_a_completion_response"}))]
     #[case::error_response(json!({"jsonrpc": "2.0", "id": 42, "error": {"code": -32600, "message": "Invalid Request"}}))]
     fn completion_response_returns_none_for_invalid_response(#[case] response: serde_json::Value) {
-        let transformed =
-            transform_for_test(response, &RegionOffset::new(3, 0), TEST_REGION_END, None);
+        let transformed = transform_for_non_resolving_server(
+            response,
+            &RegionOffset::new(3, 0),
+            TEST_REGION_END,
+            None,
+        );
         assert!(transformed.is_none());
     }
 
@@ -860,7 +866,7 @@ mod tests {
         });
         let region_start_line = 5;
 
-        let transformed = transform_for_test(
+        let transformed = transform_for_non_resolving_server(
             response,
             &RegionOffset::new(region_start_line, 0),
             TEST_REGION_END,
@@ -909,7 +915,7 @@ mod tests {
         });
         let region_start_line = 10;
 
-        let transformed = transform_for_test(
+        let transformed = transform_for_non_resolving_server(
             response,
             &RegionOffset::new(region_start_line, 0),
             TEST_REGION_END,
@@ -955,7 +961,7 @@ mod tests {
         });
         let region_start_line = 5;
 
-        let transformed = transform_for_test(
+        let transformed = transform_for_non_resolving_server(
             response,
             &RegionOffset::new(region_start_line, 0),
             TEST_REGION_END,
@@ -997,8 +1003,12 @@ mod tests {
             }
         });
 
-        let transformed =
-            transform_for_test(response, &RegionOffset::new(10, 4), TEST_REGION_END, None);
+        let transformed = transform_for_non_resolving_server(
+            response,
+            &RegionOffset::new(10, 4),
+            TEST_REGION_END,
+            None,
+        );
 
         let list = transformed.unwrap();
         if let Some(tower_lsp_server::ls_types::CompletionTextEdit::Edit(ref edit)) =
@@ -1034,8 +1044,12 @@ mod tests {
             }
         });
 
-        let transformed =
-            transform_for_test(response, &RegionOffset::new(10, 4), TEST_REGION_END, None);
+        let transformed = transform_for_non_resolving_server(
+            response,
+            &RegionOffset::new(10, 4),
+            TEST_REGION_END,
+            None,
+        );
 
         let list = transformed.unwrap();
         if let Some(tower_lsp_server::ls_types::CompletionTextEdit::Edit(ref edit)) =
@@ -1075,8 +1089,12 @@ mod tests {
             }
         });
 
-        let transformed =
-            transform_for_test(response, &RegionOffset::new(5, 7), TEST_REGION_END, None);
+        let transformed = transform_for_non_resolving_server(
+            response,
+            &RegionOffset::new(5, 7),
+            TEST_REGION_END,
+            None,
+        );
 
         let list = transformed.unwrap();
         if let Some(tower_lsp_server::ls_types::CompletionTextEdit::InsertAndReplace(ref edit)) =
@@ -1118,8 +1136,12 @@ mod tests {
             }
         });
 
-        let transformed =
-            transform_for_test(response, &RegionOffset::new(5, 3), TEST_REGION_END, None);
+        let transformed = transform_for_non_resolving_server(
+            response,
+            &RegionOffset::new(5, 3),
+            TEST_REGION_END,
+            None,
+        );
 
         let list = transformed.unwrap();
         let edits = list.items[0].additional_text_edits.as_ref().unwrap();
@@ -1188,7 +1210,7 @@ mod tests {
         });
         let region_start_line = 10;
 
-        let transformed = transform_for_test(
+        let transformed = transform_for_non_resolving_server(
             response,
             &RegionOffset::new(region_start_line, 0),
             TEST_REGION_END,
@@ -1634,7 +1656,7 @@ mod tests {
             ]
         });
 
-        let list = transform_for_test(response, &offset, region_end, None).unwrap();
+        let list = transform_for_non_resolving_server(response, &offset, region_end, None).unwrap();
 
         assert_eq!(list.items.len(), 1, "prefix-breaking item must be dropped");
         assert_eq!(list.items[0].label, "safe");
@@ -1670,7 +1692,7 @@ mod tests {
             ]
         });
 
-        let list = transform_for_test(response, &offset, region_end, None).unwrap();
+        let list = transform_for_non_resolving_server(response, &offset, region_end, None).unwrap();
 
         assert_eq!(list.items.len(), 1, "item with safe primary edit is kept");
         assert!(
@@ -1700,7 +1722,7 @@ mod tests {
             ]
         });
 
-        let list = transform_for_test(response, &offset, region_end, None).unwrap();
+        let list = transform_for_non_resolving_server(response, &offset, region_end, None).unwrap();
 
         assert!(
             list.items.is_empty(),
@@ -1732,7 +1754,7 @@ mod tests {
             ]
         });
 
-        let list = transform_for_test(response, &offset, region_end, None).unwrap();
+        let list = transform_for_non_resolving_server(response, &offset, region_end, None).unwrap();
 
         assert_eq!(list.items.len(), 1, "region-escaping item must drop");
         assert_eq!(list.items[0].label, "contained");
@@ -1757,13 +1779,14 @@ mod tests {
             ]
         });
 
-        let list = transform_for_test(response.clone(), &offset, region_end, None).unwrap();
+        let list = transform_for_non_resolving_server(response.clone(), &offset, region_end, None)
+            .unwrap();
         assert_eq!(list.items.len(), 1, "multiline fallback must drop");
         assert_eq!(list.items[0].label, "single");
 
         // Same response in a plain fenced region: both survive.
         let plain = RegionOffset::with_per_line_offsets(3, vec![0, 0, 0]);
-        let list = transform_for_test(response, &plain, region_end, None).unwrap();
+        let list = transform_for_non_resolving_server(response, &plain, region_end, None).unwrap();
         assert_eq!(list.items.len(), 2, "plain regions take multiline inserts");
     }
 
@@ -1794,7 +1817,8 @@ mod tests {
             ]
         });
 
-        let list = transform_for_test(response.clone(), &offset, region_end, None).unwrap();
+        let list = transform_for_non_resolving_server(response.clone(), &offset, region_end, None)
+            .unwrap();
         let labels: Vec<_> = list.items.iter().map(|i| i.label.as_str()).collect();
         assert_eq!(
             labels,
@@ -1804,7 +1828,7 @@ mod tests {
 
         // Plain (all-zero) region: everything survives.
         let plain = RegionOffset::with_per_line_offsets(3, vec![0, 0, 0]);
-        let list = transform_for_test(response, &plain, region_end, None).unwrap();
+        let list = transform_for_non_resolving_server(response, &plain, region_end, None).unwrap();
         assert_eq!(list.items.len(), 3, "plain regions are exempt");
     }
 
@@ -1842,13 +1866,17 @@ mod tests {
         });
 
         // Requested on host line 5 (virtual line 2, unprefixed): kept.
-        let list = transform_for_test(response.clone(), &offset, region_end, Some(5)).unwrap();
+        let list =
+            transform_for_non_resolving_server(response.clone(), &offset, region_end, Some(5))
+                .unwrap();
         assert_eq!(list.items.len(), 1, "later-line insertion is safe");
 
         // Requested on host line 3 (virtual line 0): in a MULTI-LINE region
         // line 0's captured content runs to end-of-line, so the inserted
         // newline splits only injected content — kept.
-        let list = transform_for_test(response.clone(), &offset, region_end, Some(3)).unwrap();
+        let list =
+            transform_for_non_resolving_server(response.clone(), &offset, region_end, Some(3))
+                .unwrap();
         assert_eq!(list.items.len(), 1, "multi-line region line 0 is safe");
 
         // Same shape but a SAME-LINE inline region (region end on the start
@@ -1858,7 +1886,8 @@ mod tests {
             line: 3,
             character: 20,
         };
-        let list = transform_for_test(response, &offset, inline_end, Some(3)).unwrap();
+        let list =
+            transform_for_non_resolving_server(response, &offset, inline_end, Some(3)).unwrap();
         assert!(
             list.items.is_empty(),
             "inline-region line-0 insertion would split the host line"
@@ -1890,7 +1919,7 @@ mod tests {
             ]
         });
 
-        let list = transform_for_test(response, &offset, region_end, None).unwrap();
+        let list = transform_for_non_resolving_server(response, &offset, region_end, None).unwrap();
         assert!(
             list.items.is_empty(),
             "either prefixed start line must reject the snippet variable"
@@ -1916,14 +1945,17 @@ mod tests {
         });
 
         let mixed = RegionOffset::with_per_line_offsets(3, vec![2, 0, 0]);
-        let list = transform_for_test(response.clone(), &mixed, region_end, Some(4)).unwrap();
+        let list =
+            transform_for_non_resolving_server(response.clone(), &mixed, region_end, Some(4))
+                .unwrap();
         assert!(
             list.items.is_empty(),
             "boundary-adjacent insertion in a prefixed region must drop"
         );
 
         let plain = RegionOffset::with_per_line_offsets(3, vec![0, 0, 0]);
-        let list = transform_for_test(response, &plain, region_end, Some(4)).unwrap();
+        let list =
+            transform_for_non_resolving_server(response, &plain, region_end, Some(4)).unwrap();
         assert_eq!(list.items.len(), 1, "all-zero regions keep no boundary");
     }
 }

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::config::settings::BridgeServerConfig;
+use crate::lsp::bridge::envelope::{ENVELOPE_KEY, should_envelope};
 use tower_lsp_server::ls_types::{CompletionItem, CompletionList, Position};
 use url::Url;
 
@@ -122,7 +123,7 @@ fn build_completion_request(
 /// Normalizes all responses to `CompletionList` (an array result is wrapped as
 /// `CompletionList { isIncomplete: false, items }`). Returns `None` for null
 /// results, missing results, and deserialization failures. Each item that
-/// [`should_envelope_item`] selects — the origin advertises
+/// [`should_envelope`] selects — the origin advertises
 /// `completionItem/resolve`, or the payload squats on the reserved key — has
 /// its `data` wrapped in a routing envelope; the rest pass through bare.
 fn transform_completion_response_to_host(
@@ -167,7 +168,7 @@ fn transform_completion_response_to_host(
         if !transform_completion_item(item, offset, region_end, request_host_line) {
             return false;
         }
-        if should_envelope_item(item, server_resolves) {
+        if should_envelope(item.data.as_ref(), server_resolves) {
             envelope_item_data(item, envelope_ctx);
         }
         true
@@ -386,9 +387,6 @@ fn snippet_contains_variable(text: &str) -> bool {
 // Envelope types for completionItem/resolve routing
 // =============================================================================
 
-/// Wrapper key inside `CompletionItem.data` that identifies the origin server.
-const ENVELOPE_KEY: &str = "kakehashi";
-
 /// Envelope stored in `CompletionItem.data` for routing `completionItem/resolve`.
 ///
 /// When Kakehashi fans out completion to multiple downstream servers, each item's
@@ -598,23 +596,10 @@ pub(crate) fn bridge_host_completion_items(
         CompletionResponse::List(list) => &mut list.items,
     };
     for item in items.iter_mut() {
-        if should_envelope_item(item, server_resolves) {
+        if should_envelope(item.data.as_ref(), server_resolves) {
             envelope_host_item(item, server_name, host_uri);
         }
     }
-}
-
-/// Whether an item must carry a routing envelope: the origin advertises
-/// `completionItem/resolve`, or the item's own `data` already occupies the
-/// envelope key — the one case a non-resolving server's item must still be
-/// wrapped, so its payload is nested rather than read back as routing
-/// metadata it never earned.
-fn should_envelope_item(item: &CompletionItem, server_resolves: bool) -> bool {
-    server_resolves
-        || item
-            .data
-            .as_ref()
-            .is_some_and(|data| data.get(ENVELOPE_KEY).is_some())
 }
 
 /// Wrap a HOST-layer item's `data` in a routing envelope so a later

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -1435,7 +1435,7 @@ mod tests {
         envelope_host_item(&mut item, "tsudoi-ls", "file:///test/doc.txt");
 
         // The two fields a host envelope leaves at their defaults must not
-        // ride the wire — this rides in every item of every response.
+        // ride the wire — this rides in every enveloped item of a response.
         let wire = item.data.clone().expect("enveloped");
         assert!(
             wire["kakehashi"].get("region_id").is_none(),

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -487,6 +487,8 @@ fn resolve_guard_region_end(envelope: &KakehashiEnvelope, offset: &RegionOffset)
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lsp::bridge::envelope::ENVELOPE_KEY;
+    use crate::lsp::bridge::text_document::completion::envelope_host_item;
     use serde_json::json;
     use tower_lsp_server::ls_types::CompletionItem;
 
@@ -712,13 +714,17 @@ mod tests {
 
     /// Helper to create a completion item with a Kakehashi envelope.
     fn enveloped_item(server: &str) -> CompletionItem {
+        enveloped_item_with_payload(server, json!({"resolve_id": 42}))
+    }
+
+    fn enveloped_item_with_payload(server: &str, payload: serde_json::Value) -> CompletionItem {
         let envelope = KakehashiEnvelope {
             origin: server.to_string(),
             injection_language: "markdown".to_string(),
             incarnation: Some(1),
             host_uri: "file:///test/doc.md".to_string(),
             region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
-            inner: Some(json!({"resolve_id": 42})),
+            inner: Some(payload.clone()),
             offset: EnvelopeOffset {
                 line: 5,
                 column: 0,
@@ -729,11 +735,56 @@ mod tests {
         };
         let mut item = CompletionItem {
             label: "print".to_string(),
-            data: Some(json!({"resolve_id": 42})),
+            data: Some(payload),
             ..Default::default()
         };
         re_envelope_item(&mut item, &envelope);
         item
+    }
+
+    /// A pool whose only connection is a Ready `lua-ls` that advertises
+    /// nothing, under the key both the virt lookup (no root marker under
+    /// `/test`) and the host lookup resolve to, with the host incarnation the
+    /// virt fixtures carry already open; plus settings that make `lua-ls`
+    /// spawnable. Everything a resolve needs to reach the capability check.
+    async fn pool_with_capability_less_origin() -> (LanguageServerPool, WorkspaceSettings) {
+        let pool = LanguageServerPool::new();
+        let key = crate::lsp::bridge::ConnectionKey::for_server("lua-ls");
+        let handle = crate::lsp::bridge::test_helpers::create_handle_with_key(
+            crate::lsp::bridge::ConnectionState::Ready,
+            key,
+        )
+        .await;
+        pool.insert_connection(handle).await;
+        pool.open_host_incarnation(&Url::parse("file:///test/doc.md").unwrap(), 1)
+            .await;
+        let mut settings = WorkspaceSettings::default();
+        settings.language_servers.insert(
+            "lua-ls".to_string(),
+            BridgeServerConfig {
+                cmd: Some(vec!["lua-language-server".to_string()]),
+                ..Default::default()
+            },
+        );
+        (pool, settings)
+    }
+
+    fn resolve_warnings_for(item: CompletionItem) -> (CompletionItem, Vec<String>) {
+        use crate::lsp::bridge::test_logging::captured_warnings_for;
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let mut resolved = None;
+        let warnings = captured_warnings_for(|| {
+            resolved = Some(runtime.block_on(async {
+                let (pool, settings) = pool_with_capability_less_origin().await;
+                pool.dispatch_completion_resolve(item, &settings, None)
+                    .await
+            }));
+        });
+        (resolved.expect("dispatch ran"), warnings)
+    }
+
+    fn lost_capability_warning(w: &str) -> bool {
+        w.contains("completionItem/resolve") && w.contains("no longer advertises resolveProvider")
     }
 
     /// dispatch returns item unchanged when it has no envelope.
@@ -975,48 +1026,82 @@ mod tests {
     }
 
     /// The virt resolve path's capability miss is logged like the host one,
-    /// without the host tag. The origin is a Ready connection that advertises
-    /// nothing, pre-inserted under the key the virt lookup resolves to; the
-    /// host incarnation is opened so the staleness gate lets the item through.
+    /// without the host tag.
     #[test]
     fn dispatch_warns_and_re_envelopes_when_virt_origin_no_longer_resolves() {
-        use crate::lsp::bridge::test_logging::captured_warnings_for;
-        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
-        let warnings = captured_warnings_for(|| {
-            runtime.block_on(async {
-                let pool = LanguageServerPool::new();
-                let key = crate::lsp::bridge::ConnectionKey::for_server("lua-ls");
-                let handle = crate::lsp::bridge::test_helpers::create_handle_with_key(
-                    crate::lsp::bridge::ConnectionState::Ready,
-                    key,
-                )
-                .await;
-                pool.insert_connection(handle).await;
-                pool.open_host_incarnation(&Url::parse("file:///test/doc.md").unwrap(), 1)
-                    .await;
-                let mut settings = WorkspaceSettings::default();
-                settings.language_servers.insert(
-                    "lua-ls".to_string(),
-                    BridgeServerConfig {
-                        cmd: Some(vec!["lua-language-server".to_string()]),
-                        ..Default::default()
-                    },
-                );
-
-                let result = pool
-                    .dispatch_completion_resolve(enveloped_item("lua-ls"), &settings, None)
-                    .await;
-                let envelope = extract_envelope(&result).expect("envelope restored");
-                assert_eq!(envelope.origin, "lua-ls");
-                assert_eq!(envelope.inner, Some(json!({"resolve_id": 42})));
-                assert!(result.detail.is_none(), "item stays unresolved");
-            });
-        });
+        let (result, warnings) = resolve_warnings_for(enveloped_item("lua-ls"));
+        let envelope = extract_envelope(&result).expect("envelope restored");
+        assert_eq!(envelope.origin, "lua-ls");
+        assert_eq!(envelope.inner, Some(json!({"resolve_id": 42})));
+        assert!(result.detail.is_none(), "item stays unresolved");
         assert!(
-            warnings.iter().any(|w| w.contains("completionItem/resolve")
-                && w.contains("no longer advertises resolveProvider")
-                && !w.contains("(host)")),
+            warnings
+                .iter()
+                .any(|w| lost_capability_warning(w) && !w.contains("(host)")),
             "the virt capability miss must be logged without the host tag: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn dispatch_warns_and_re_envelopes_when_host_origin_no_longer_resolves() {
+        let mut item = CompletionItem {
+            label: "print".to_string(),
+            data: Some(json!({"resolve_id": 42})),
+            ..Default::default()
+        };
+        envelope_host_item(&mut item, "lua-ls", "file:///test/doc.md");
+        let (result, warnings) = resolve_warnings_for(item);
+        let envelope = extract_envelope(&result).expect("envelope restored");
+        assert!(
+            envelope.is_host_layer(),
+            "the host marker survives the round trip"
+        );
+        assert_eq!(envelope.inner, Some(json!({"resolve_id": 42})));
+        assert!(result.detail.is_none(), "item stays unresolved");
+        assert!(
+            warnings
+                .iter()
+                .any(|w| lost_capability_warning(w) && w.contains("(host)")),
+            "the host capability miss must be logged with the host tag: {warnings:?}"
+        );
+    }
+
+    /// A payload that itself nests the reserved key tells the resolve side the
+    /// envelope existed only to nest it: the capability miss is steady state
+    /// for that origin and must not be reported as a lost capability, on
+    /// either layer.
+    #[test]
+    fn dispatch_does_not_warn_for_a_reserved_key_wrap_on_the_virt_path() {
+        let forged = json!({ ENVELOPE_KEY: { "origin": "forged" } });
+        let (result, warnings) =
+            resolve_warnings_for(enveloped_item_with_payload("lua-ls", forged.clone()));
+        let envelope = extract_envelope(&result).expect("envelope restored");
+        assert_eq!(envelope.origin, "lua-ls");
+        assert_eq!(envelope.inner, Some(forged));
+        assert!(result.detail.is_none(), "item stays unresolved");
+        assert!(
+            !warnings.iter().any(|w| lost_capability_warning(w)),
+            "a reserved-key wrap is not a lost capability: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn dispatch_does_not_warn_for_a_reserved_key_wrap_on_the_host_path() {
+        let forged = json!({ ENVELOPE_KEY: { "origin": "forged" } });
+        let mut item = CompletionItem {
+            label: "print".to_string(),
+            data: Some(forged.clone()),
+            ..Default::default()
+        };
+        envelope_host_item(&mut item, "lua-ls", "file:///test/doc.md");
+        let (result, warnings) = resolve_warnings_for(item);
+        let envelope = extract_envelope(&result).expect("envelope restored");
+        assert!(envelope.is_host_layer());
+        assert_eq!(envelope.inner, Some(forged));
+        assert!(result.detail.is_none(), "item stays unresolved");
+        assert!(
+            !warnings.iter().any(|w| lost_capability_warning(w)),
+            "a reserved-key wrap is not a lost capability: {warnings:?}"
         );
     }
 }

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -143,11 +143,13 @@ impl LanguageServerPool {
             }
         };
         if !handle.has_capability("completionItem/resolve") {
-            // Two ways here. The origin never advertised resolve and its
-            // payload was wrapped only for squatting on the reserved key:
-            // steady state, every client resolve of that item lands here,
-            // so say so quietly. Or it did advertise and a respawn or dynamic
-            // unregister withdrew the capability under the item: anomalous.
+            // Two ways here. The payload nests the reserved key: as far as
+            // this branch can tell, the origin never advertised resolve and
+            // the wrap existed only to nest it — steady state, so every
+            // client resolve of that item that clears the gates above
+            // lands here; say so quietly. Otherwise the origin did advertise
+            // and a respawn or dynamic unregister withdrew the capability
+            // under the item: anomalous.
             if nests_reserved_key(item.data.as_ref()) {
                 debug!(
                     target: "kakehashi::bridge",
@@ -239,11 +241,13 @@ impl LanguageServerPool {
         };
 
         if !handle.has_capability("completionItem/resolve") {
-            // Two ways here. The origin never advertised resolve and its
-            // payload was wrapped only for squatting on the reserved key:
-            // steady state, every client resolve of that item lands here,
-            // so say so quietly. Or it did advertise and a respawn or dynamic
-            // unregister withdrew the capability under the item: anomalous.
+            // Two ways here. The payload nests the reserved key: as far as
+            // this branch can tell, the origin never advertised resolve and
+            // the wrap existed only to nest it — steady state, so every
+            // client resolve of that item that clears the gates above
+            // lands here; say so quietly. Otherwise the origin did advertise
+            // and a respawn or dynamic unregister withdrew the capability
+            // under the item: anomalous.
             if nests_reserved_key(item.data.as_ref()) {
                 debug!(
                     target: "kakehashi::bridge",

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -973,4 +973,50 @@ mod tests {
         };
         assert_eq!(edit.range.start.line, 5);
     }
+
+    /// The virt resolve path's capability miss is logged like the host one,
+    /// without the host tag. The origin is a Ready connection that advertises
+    /// nothing, pre-inserted under the key the virt lookup resolves to; the
+    /// host incarnation is opened so the staleness gate lets the item through.
+    #[test]
+    fn dispatch_warns_and_re_envelopes_when_virt_origin_no_longer_resolves() {
+        use crate::lsp::bridge::test_logging::captured_warnings_for;
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let warnings = captured_warnings_for(|| {
+            runtime.block_on(async {
+                let pool = LanguageServerPool::new();
+                let key = crate::lsp::bridge::ConnectionKey::for_server("lua-ls");
+                let handle = crate::lsp::bridge::test_helpers::create_handle_with_key(
+                    crate::lsp::bridge::ConnectionState::Ready,
+                    key,
+                )
+                .await;
+                pool.insert_connection(handle).await;
+                pool.open_host_incarnation(&Url::parse("file:///test/doc.md").unwrap(), 1)
+                    .await;
+                let mut settings = WorkspaceSettings::default();
+                settings.language_servers.insert(
+                    "lua-ls".to_string(),
+                    BridgeServerConfig {
+                        cmd: Some(vec!["lua-language-server".to_string()]),
+                        ..Default::default()
+                    },
+                );
+
+                let result = pool
+                    .dispatch_completion_resolve(enveloped_item("lua-ls"), &settings, None)
+                    .await;
+                let envelope = extract_envelope(&result).expect("envelope restored");
+                assert_eq!(envelope.origin, "lua-ls");
+                assert_eq!(envelope.inner, Some(json!({"resolve_id": 42})));
+                assert!(result.detail.is_none(), "item stays unresolved");
+            });
+        });
+        assert!(
+            warnings.iter().any(|w| w.contains("completionItem/resolve")
+                && w.contains("no longer advertises resolveProvider")
+                && !w.contains("(host)")),
+            "the virt capability miss must be logged without the host tag: {warnings:?}"
+        );
+    }
 }

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -142,13 +142,13 @@ impl LanguageServerPool {
             }
         };
         if !handle.has_capability("completionItem/resolve") {
-            // Anomalous, unlike on the virt path (which envelopes
-            // unconditionally): a host envelope is minted ONLY for a server
-            // that advertised resolve, so reaching here means a respawn
-            // changed capabilities (or the handle is still initializing).
+            // Anomalous: the envelope was only minted because the origin
+            // advertised resolve (or the payload squatted on the reserved
+            // key), so reaching here means a respawn or dynamic unregister
+            // changed capabilities under the item.
             warn!(
                 target: "kakehashi::bridge",
-                "completionItem/resolve: host server {server_name:?} no longer advertises \
+                "completionItem/resolve (host): {server_name:?} no longer advertises \
                  resolveProvider; returning unresolved"
             );
             re_envelope_item(&mut item, &envelope);
@@ -230,6 +230,15 @@ impl LanguageServerPool {
         };
 
         if !handle.has_capability("completionItem/resolve") {
+            // Anomalous: the envelope was only minted because the origin
+            // advertised resolve (or the payload squatted on the reserved
+            // key), so reaching here means a respawn or dynamic unregister
+            // changed capabilities under the item.
+            warn!(
+                target: "kakehashi::bridge",
+                "completionItem/resolve: {server_name:?} no longer advertises resolveProvider; \
+                 returning unresolved"
+            );
             re_envelope_item(&mut item, &envelope);
             return item;
         }

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -19,7 +19,7 @@
 
 use std::sync::Arc;
 
-use log::warn;
+use log::{debug, warn};
 use tower_lsp_server::ls_types::{CompletionItem, Position};
 use url::Url;
 
@@ -37,6 +37,7 @@ use crate::config::{
     merge_bridge_server_configs, resolve_with_wildcard, settings::BridgeServerConfig,
 };
 use crate::lsp::bridge::actor::RouterCleanupGuard;
+use crate::lsp::bridge::envelope::nests_reserved_key;
 
 impl LanguageServerPool {
     /// Route a `completionItem/resolve` request to the origin downstream server.
@@ -142,15 +143,23 @@ impl LanguageServerPool {
             }
         };
         if !handle.has_capability("completionItem/resolve") {
-            // Anomalous: the envelope was only minted because the origin
-            // advertised resolve (or the payload squatted on the reserved
-            // key), so reaching here means a respawn or dynamic unregister
-            // changed capabilities under the item.
-            warn!(
-                target: "kakehashi::bridge",
-                "completionItem/resolve (host): {server_name:?} no longer advertises \
-                 resolveProvider; returning unresolved"
-            );
+            // Two ways here. The origin never advertised resolve and its
+            // payload was wrapped only for squatting on the reserved key:
+            // steady state, every client resolve of that item lands here,
+            // so say so quietly. Or it did advertise and a respawn or dynamic
+            // unregister withdrew the capability under the item: anomalous.
+            if nests_reserved_key(item.data.as_ref()) {
+                debug!(
+                    target: "kakehashi::bridge",
+                    "completionItem/resolve (host): {server_name:?} does not advertise resolveProvider; the item was \
+                     enveloped only to nest a reserved-key payload; returning unresolved"
+                );
+            } else {
+                warn!(
+                    target: "kakehashi::bridge",
+                    "completionItem/resolve (host): {server_name:?} no longer advertises resolveProvider; returning unresolved"
+                );
+            }
             re_envelope_item(&mut item, &envelope);
             return item;
         }
@@ -230,15 +239,23 @@ impl LanguageServerPool {
         };
 
         if !handle.has_capability("completionItem/resolve") {
-            // Anomalous: the envelope was only minted because the origin
-            // advertised resolve (or the payload squatted on the reserved
-            // key), so reaching here means a respawn or dynamic unregister
-            // changed capabilities under the item.
-            warn!(
-                target: "kakehashi::bridge",
-                "completionItem/resolve: {server_name:?} no longer advertises resolveProvider; \
-                 returning unresolved"
-            );
+            // Two ways here. The origin never advertised resolve and its
+            // payload was wrapped only for squatting on the reserved key:
+            // steady state, every client resolve of that item lands here,
+            // so say so quietly. Or it did advertise and a respawn or dynamic
+            // unregister withdrew the capability under the item: anomalous.
+            if nests_reserved_key(item.data.as_ref()) {
+                debug!(
+                    target: "kakehashi::bridge",
+                    "completionItem/resolve: {server_name:?} does not advertise resolveProvider; the item was \
+                     enveloped only to nest a reserved-key payload; returning unresolved"
+                );
+            } else {
+                warn!(
+                    target: "kakehashi::bridge",
+                    "completionItem/resolve: {server_name:?} no longer advertises resolveProvider; returning unresolved"
+                );
+            }
             re_envelope_item(&mut item, &envelope);
             return item;
         }

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -122,7 +122,7 @@ impl LanguageServerPool {
         let Ok(host_url) = Url::parse(&envelope.host_uri) else {
             warn!(
                 target: "kakehashi::bridge",
-                "completionItem/resolve (host): envelope host_uri '{}' is not a valid URL; ignoring",
+                "completionItem/resolve (host): envelope host_uri {:?} is not a valid URL; ignoring",
                 envelope.host_uri
             );
             re_envelope_item(&mut item, &envelope);

--- a/src/lsp/bridge/text_document/document_link.rs
+++ b/src/lsp/bridge/text_document/document_link.rs
@@ -302,11 +302,13 @@ impl LanguageServerPool {
         };
 
         if !handle.has_capability("documentLink/resolve") {
-            // Two ways here. The origin never advertised resolve and its
-            // payload was wrapped only for squatting on the reserved key:
-            // steady state, every client resolve of that link lands here,
-            // so say so quietly. Or it did advertise and a respawn or dynamic
-            // unregister withdrew the capability under the link: anomalous.
+            // Two ways here. The payload nests the reserved key: as far as
+            // this branch can tell, the origin never advertised resolve and
+            // the wrap existed only to nest it — steady state, so every
+            // client resolve of that link that clears the gates above
+            // lands here; say so quietly. Otherwise the origin did advertise
+            // and a respawn or dynamic unregister withdrew the capability
+            // under the link: anomalous.
             if nests_reserved_key(link.data.as_ref()) {
                 debug!(
                     target: "kakehashi::bridge",
@@ -896,8 +898,9 @@ mod tests {
     /// is minted for a resolving origin, so reaching a non-resolving handle
     /// means the origin changed under the link (dynamic unregister, respawn)
     /// or the payload was wrapped for squatting on the reserved key. Either
-    /// way the link comes back unresolved AND the anomaly is logged, as the
-    /// codeAction and host-completion paths already did.
+    /// way the link comes back unresolved; the withdrawn-capability way is
+    /// logged as an anomaly, as the codeAction and host-completion paths
+    /// already did (the reserved-key way is the sibling test below).
     #[test]
     fn dispatch_warns_and_re_envelopes_when_origin_no_longer_resolves() {
         use crate::lsp::bridge::test_logging::captured_warnings_for;

--- a/src/lsp/bridge/text_document/document_link.rs
+++ b/src/lsp/bridge/text_document/document_link.rs
@@ -11,6 +11,7 @@ use std::io;
 use std::sync::Arc;
 
 use crate::config::settings::BridgeServerConfig;
+use crate::lsp::bridge::envelope::{ENVELOPE_KEY, should_envelope};
 use log::warn;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -26,8 +27,6 @@ use super::super::protocol::{translate_host_range_to_virtual, translate_virtual_
 use super::completion::EnvelopeOffset;
 use crate::config::{merge_bridge_server_configs, resolve_with_wildcard};
 use crate::lsp::bridge::actor::RouterCleanupGuard;
-
-const ENVELOPE_KEY: &str = "kakehashi";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) struct DocumentLinkEnvelope {
@@ -115,19 +114,6 @@ fn re_envelope_link(link: &mut DocumentLink, envelope: &DocumentLinkEnvelope) {
     );
 }
 
-/// A downstream that cannot resolve gains nothing from the routing envelope,
-/// so its opaque `data` passes through untouched — except when that data
-/// carries the reserved key itself, which would otherwise let a downstream
-/// present a payload of its own choosing as kakehashi routing metadata. Those
-/// are wrapped anyway, with the foreign object nested as `inner`.
-fn should_envelope_link(link: &DocumentLink, server_resolves: bool) -> bool {
-    server_resolves
-        || link
-            .data
-            .as_ref()
-            .is_some_and(|data| data.get(ENVELOPE_KEY).is_some())
-}
-
 pub(crate) fn envelope_host_document_links(
     links: &mut [DocumentLink],
     server_name: &str,
@@ -150,7 +136,7 @@ pub(crate) fn envelope_host_document_links(
         host_layer: true,
     };
     for link in links {
-        if should_envelope_link(link, server_resolves) {
+        if should_envelope(link.data.as_ref(), server_resolves) {
             envelope_link_data(link, &ctx);
         }
     }
@@ -487,7 +473,7 @@ fn transform_document_link_response_to_host(
     // Transform ranges to host coordinates
     for link in &mut links {
         translate_virtual_range_to_host(&mut link.range, offset);
-        if should_envelope_link(link, server_resolves) {
+        if should_envelope(link.data.as_ref(), server_resolves) {
             envelope_link_data(link, envelope_ctx);
         }
     }

--- a/src/lsp/bridge/text_document/document_link.rs
+++ b/src/lsp/bridge/text_document/document_link.rs
@@ -488,14 +488,17 @@ mod tests {
     use rstest::rstest;
     use serde_json::json;
 
-    fn transform_for_test(
+    /// Run the virt transform for a resolving origin: every link is enveloped.
+    /// (The completion twin defaults the other way — its helper is named for
+    /// a non-resolving origin.)
+    fn transform_for_resolving_server(
         response: serde_json::Value,
         offset: &RegionOffset,
     ) -> Option<Vec<DocumentLink>> {
-        transform_for_resolving_server(response, offset, true)
+        transform_with_resolve_support(response, offset, true)
     }
 
-    fn transform_for_resolving_server(
+    fn transform_with_resolve_support(
         response: serde_json::Value,
         offset: &RegionOffset,
         server_resolves: bool,
@@ -579,7 +582,7 @@ mod tests {
             }]
         });
 
-        let links = transform_for_test(response, &RegionOffset::new(3, 2)).unwrap();
+        let links = transform_for_resolving_server(response, &RegionOffset::new(3, 2)).unwrap();
         let envelope = extract_document_link_envelope(&links[0]).expect("routing envelope");
         assert_eq!(envelope.origin, "lua-ls");
         assert_eq!(envelope.host_uri, "file:///test.md");
@@ -614,7 +617,7 @@ mod tests {
             })
         };
 
-        let bare = transform_for_resolving_server(
+        let bare = transform_with_resolve_support(
             response(json!({"token": 1})),
             &RegionOffset::new(3, 2),
             false,
@@ -627,7 +630,7 @@ mod tests {
         );
         assert_eq!(bare[0].range.start.line, 3, "ranges are still translated");
 
-        let forged = transform_for_resolving_server(
+        let forged = transform_with_resolve_support(
             response(json!({ ENVELOPE_KEY: { "origin": "spoofed" } })),
             &RegionOffset::new(3, 2),
             false,
@@ -700,7 +703,8 @@ mod tests {
         });
         let region_start_line = 5;
 
-        let transformed = transform_for_test(response, &RegionOffset::new(region_start_line, 0));
+        let transformed =
+            transform_for_resolving_server(response, &RegionOffset::new(region_start_line, 0));
 
         assert!(transformed.is_some());
         let links = transformed.unwrap();
@@ -723,7 +727,7 @@ mod tests {
     fn document_link_response_returns_none_for_invalid_response(
         #[case] response: serde_json::Value,
     ) {
-        let transformed = transform_for_test(response, &RegionOffset::new(5, 0));
+        let transformed = transform_for_resolving_server(response, &RegionOffset::new(5, 0));
         assert!(transformed.is_none());
     }
 
@@ -731,7 +735,7 @@ mod tests {
     fn document_link_response_with_empty_array_returns_empty_vec() {
         let response = json!({ "jsonrpc": "2.0", "id": 42, "result": [] });
 
-        let transformed = transform_for_test(response, &RegionOffset::new(5, 0));
+        let transformed = transform_for_resolving_server(response, &RegionOffset::new(5, 0));
         assert!(transformed.is_some());
         let links = transformed.unwrap();
         assert!(links.is_empty());
@@ -753,7 +757,8 @@ mod tests {
         });
         let region_start_line = 3;
 
-        let transformed = transform_for_test(response, &RegionOffset::new(region_start_line, 0));
+        let transformed =
+            transform_for_resolving_server(response, &RegionOffset::new(region_start_line, 0));
 
         assert!(transformed.is_some());
         let links = transformed.unwrap();
@@ -779,7 +784,8 @@ mod tests {
         });
         let region_start_line = 10;
 
-        let transformed = transform_for_test(response, &RegionOffset::new(region_start_line, 0));
+        let transformed =
+            transform_for_resolving_server(response, &RegionOffset::new(region_start_line, 0));
 
         assert!(transformed.is_some());
         let links = transformed.unwrap();
@@ -802,7 +808,8 @@ mod tests {
         });
         let region_start_line = 10;
 
-        let transformed = transform_for_test(response, &RegionOffset::new(region_start_line, 0));
+        let transformed =
+            transform_for_resolving_server(response, &RegionOffset::new(region_start_line, 0));
 
         assert!(transformed.is_some());
         let links = transformed.unwrap();

--- a/src/lsp/bridge/text_document/document_link.rs
+++ b/src/lsp/bridge/text_document/document_link.rs
@@ -245,6 +245,13 @@ impl LanguageServerPool {
         upstream_id: Option<UpstreamId>,
     ) -> DocumentLink {
         let server_name = &envelope.origin;
+        // One function serves both layers; tag the host one like the
+        // completion and codeAction host paths do.
+        let layer = if envelope.is_host_layer() {
+            " (host)"
+        } else {
+            ""
+        };
         let Ok(host_uri) = Url::parse(&envelope.host_uri) else {
             re_envelope_link(&mut link, &envelope);
             return link;
@@ -287,7 +294,7 @@ impl LanguageServerPool {
             Err(error) => {
                 warn!(
                     target: "kakehashi::bridge",
-                    "documentLink/resolve: failed to connect to {server_name}: {error}"
+                    "documentLink/resolve{layer}: failed to connect to {server_name}: {error}"
                 );
                 re_envelope_link(&mut link, &envelope);
                 return link;
@@ -303,13 +310,13 @@ impl LanguageServerPool {
             if nests_reserved_key(link.data.as_ref()) {
                 debug!(
                     target: "kakehashi::bridge",
-                    "documentLink/resolve: {server_name:?} does not advertise resolveProvider; the link was \
+                    "documentLink/resolve{layer}: {server_name:?} does not advertise resolveProvider; the link was \
                      enveloped only to nest a reserved-key payload; returning unresolved"
                 );
             } else {
                 warn!(
                     target: "kakehashi::bridge",
-                    "documentLink/resolve: {server_name:?} no longer advertises resolveProvider; returning unresolved"
+                    "documentLink/resolve{layer}: {server_name:?} no longer advertises resolveProvider; returning unresolved"
                 );
             }
             re_envelope_link(&mut link, &envelope);
@@ -346,7 +353,7 @@ impl LanguageServerPool {
             Err(error) => {
                 warn!(
                     target: "kakehashi::bridge",
-                    "documentLink/resolve: failed to register request for {server_name}: {error}"
+                    "documentLink/resolve{layer}: failed to register request for {server_name}: {error}"
                 );
                 if let Some(ref id) = upstream_id {
                     self.unregister_upstream_request(id, connection_key);
@@ -386,7 +393,7 @@ impl LanguageServerPool {
         if let Err(error) = send_result {
             warn!(
                 target: "kakehashi::bridge",
-                "documentLink/resolve: failed to send request for {server_name}: {error}"
+                "documentLink/resolve{layer}: failed to send request for {server_name}: {error}"
             );
             if let Some(ref id) = upstream_id {
                 self.unregister_upstream_request(id, connection_key);

--- a/src/lsp/bridge/text_document/document_link.rs
+++ b/src/lsp/bridge/text_document/document_link.rs
@@ -928,4 +928,60 @@ mod tests {
             "the capability miss must be logged, not silently swallowed: {warnings:?}"
         );
     }
+
+    /// The other way to reach the capability miss is steady state, not an
+    /// anomaly: a NON-resolving origin's payload squatted on the reserved key,
+    /// so it was wrapped only to nest it, and every client resolve of that
+    /// link lands here. It must come back unresolved with the payload intact
+    /// and must NOT be reported as a lost capability.
+    #[test]
+    fn dispatch_does_not_warn_for_a_reserved_key_wrap_from_a_non_resolving_origin() {
+        use crate::lsp::bridge::test_logging::captured_warnings_for;
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let warnings = captured_warnings_for(|| {
+            runtime.block_on(async {
+                let pool = LanguageServerPool::new();
+                let key = ConnectionKey::for_server("lua-ls");
+                let handle = crate::lsp::bridge::test_helpers::create_handle_with_key(
+                    crate::lsp::bridge::ConnectionState::Ready,
+                    key.clone(),
+                )
+                .await;
+                pool.insert_connection(handle).await;
+                let mut settings = crate::config::settings::WorkspaceSettings::default();
+                settings.language_servers.insert(
+                    "lua-ls".to_string(),
+                    crate::config::settings::BridgeServerConfig {
+                        cmd: Some(vec!["lua-language-server".to_string()]),
+                        ..Default::default()
+                    },
+                );
+                let forged = json!({ ENVELOPE_KEY: { "origin": "forged" } });
+                let mut links = vec![unresolved_link(Some(forged.clone()))];
+                envelope_host_document_links(
+                    &mut links,
+                    "lua-ls",
+                    "file:///test.md",
+                    None,
+                    pool.document_connection_generation(&key),
+                    &key,
+                    false,
+                );
+
+                let result = pool
+                    .dispatch_document_link_resolve(links.remove(0), &settings, None)
+                    .await;
+                let envelope = extract_document_link_envelope(&result).expect("envelope restored");
+                assert_eq!(envelope.origin, "lua-ls");
+                assert_eq!(envelope.inner, Some(forged));
+                assert!(result.target.is_none(), "link stays unresolved");
+            });
+        });
+        assert!(
+            !warnings
+                .iter()
+                .any(|w| w.contains("no longer advertises resolveProvider")),
+            "a reserved-key wrap is not a lost capability: {warnings:?}"
+        );
+    }
 }

--- a/src/lsp/bridge/text_document/document_link.rs
+++ b/src/lsp/bridge/text_document/document_link.rs
@@ -11,8 +11,8 @@ use std::io;
 use std::sync::Arc;
 
 use crate::config::settings::BridgeServerConfig;
-use crate::lsp::bridge::envelope::{ENVELOPE_KEY, should_envelope};
-use log::warn;
+use crate::lsp::bridge::envelope::{ENVELOPE_KEY, nests_reserved_key, should_envelope};
+use log::{debug, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tower_lsp_server::ls_types::DocumentLink;
@@ -295,15 +295,23 @@ impl LanguageServerPool {
         };
 
         if !handle.has_capability("documentLink/resolve") {
-            // Anomalous: the envelope was only minted because the origin
-            // advertised resolve (or the payload squatted on the reserved
-            // key), so reaching here means a respawn or dynamic unregister
-            // changed capabilities under the link.
-            warn!(
-                target: "kakehashi::bridge",
-                "documentLink/resolve: {:?} no longer advertises resolveProvider; returning unresolved",
-                envelope.origin
-            );
+            // Two ways here. The origin never advertised resolve and its
+            // payload was wrapped only for squatting on the reserved key:
+            // steady state, every client resolve of that link lands here,
+            // so say so quietly. Or it did advertise and a respawn or dynamic
+            // unregister withdrew the capability under the link: anomalous.
+            if nests_reserved_key(link.data.as_ref()) {
+                debug!(
+                    target: "kakehashi::bridge",
+                    "documentLink/resolve: {server_name:?} does not advertise resolveProvider; the link was \
+                     enveloped only to nest a reserved-key payload; returning unresolved"
+                );
+            } else {
+                warn!(
+                    target: "kakehashi::bridge",
+                    "documentLink/resolve: {server_name:?} no longer advertises resolveProvider; returning unresolved"
+                );
+            }
             re_envelope_link(&mut link, &envelope);
             return link;
         }
@@ -880,7 +888,7 @@ mod tests {
     /// means the origin changed under the link (dynamic unregister, respawn)
     /// or the payload was wrapped for squatting on the reserved key. Either
     /// way the link comes back unresolved AND the anomaly is logged, as the
-    /// completion and codeAction paths already do.
+    /// codeAction and host-completion paths already did.
     #[test]
     fn dispatch_warns_and_re_envelopes_when_origin_no_longer_resolves() {
         use crate::lsp::bridge::test_logging::captured_warnings_for;

--- a/src/lsp/bridge/text_document/document_link.rs
+++ b/src/lsp/bridge/text_document/document_link.rs
@@ -306,6 +306,15 @@ impl LanguageServerPool {
         };
 
         if !handle.has_capability("documentLink/resolve") {
+            // Anomalous: the envelope was only minted because the origin
+            // advertised resolve (or the payload squatted on the reserved
+            // key), so reaching here means a respawn or dynamic unregister
+            // changed capabilities under the link.
+            warn!(
+                target: "kakehashi::bridge",
+                "documentLink/resolve: {:?} no longer advertises resolveProvider; returning unresolved",
+                envelope.origin
+            );
             re_envelope_link(&mut link, &envelope);
             return link;
         }

--- a/src/lsp/bridge/text_document/document_link.rs
+++ b/src/lsp/bridge/text_document/document_link.rs
@@ -175,7 +175,10 @@ impl LanguageServerPool {
         }
         let connection_key = handle.key().clone();
         let connection_generation = self.document_connection_generation(&connection_key);
-        let server_resolves = handle.has_capability("documentLink/resolve");
+        // Read resolve support when the RESPONSE arrives, as the host layer
+        // does: a dynamic `resolveProvider` registration can land between
+        // send and reply, and the envelope decision should see it.
+        let origin = Arc::clone(&handle);
         self.execute_bridge_request_with_handle(
             handle,
             host_uri,
@@ -189,7 +192,7 @@ impl LanguageServerPool {
                 transform_document_link_response_to_host(
                     response,
                     ctx.offset,
-                    server_resolves,
+                    origin.has_capability("documentLink/resolve"),
                     &DocumentLinkEnvelopeContext {
                         server_name,
                         host_uri: host_uri.as_str(),

--- a/src/lsp/bridge/text_document/document_link.rs
+++ b/src/lsp/bridge/text_document/document_link.rs
@@ -413,7 +413,7 @@ impl LanguageServerPool {
             Err(error) => {
                 warn!(
                     target: "kakehashi::bridge",
-                    "documentLink/resolve failed for server {server_name}: {error}"
+                    "documentLink/resolve{layer} failed for server {server_name}: {error}"
                 );
                 re_envelope_link(&mut link, &envelope);
                 return link;

--- a/src/lsp/bridge/text_document/document_link.rs
+++ b/src/lsp/bridge/text_document/document_link.rs
@@ -468,8 +468,10 @@ fn parse_document_link_resolve_response(mut response: serde_json::Value) -> Opti
 
 /// Transform a document link response from virtual to host document coordinates.
 ///
-/// Only each link's `range` is translated by `offset`; target, tooltip, and
-/// data are preserved unchanged.
+/// Each link's `range` is translated by `offset`; `target` and `tooltip` are
+/// preserved. `data` is wrapped in a routing envelope for each link that
+/// `should_envelope` selects (the origin advertises `documentLink/resolve`,
+/// or the payload squats on the reserved key); the rest pass through bare.
 fn transform_document_link_response_to_host(
     mut response: serde_json::Value,
     offset: &RegionOffset,

--- a/src/lsp/bridge/text_document/document_link.rs
+++ b/src/lsp/bridge/text_document/document_link.rs
@@ -869,4 +869,58 @@ mod tests {
         assert_eq!(envelope.inner, Some(json!({"token": "link-1"})));
         assert!(result.target.is_none());
     }
+
+    /// The resolve-side capability gate is the authoritative one: an envelope
+    /// is minted for a resolving origin, so reaching a non-resolving handle
+    /// means the origin changed under the link (dynamic unregister, respawn)
+    /// or the payload was wrapped for squatting on the reserved key. Either
+    /// way the link comes back unresolved AND the anomaly is logged, as the
+    /// completion and codeAction paths already do.
+    #[test]
+    fn dispatch_warns_and_re_envelopes_when_origin_no_longer_resolves() {
+        use crate::lsp::bridge::test_logging::captured_warnings_for;
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let warnings = captured_warnings_for(|| {
+            runtime.block_on(async {
+                let pool = LanguageServerPool::new();
+                let key = ConnectionKey::for_server("lua-ls");
+                let handle = crate::lsp::bridge::test_helpers::create_handle_with_key(
+                    crate::lsp::bridge::ConnectionState::Ready,
+                    key.clone(),
+                )
+                .await;
+                pool.insert_connection(handle).await;
+                let mut settings = crate::config::settings::WorkspaceSettings::default();
+                settings.language_servers.insert(
+                    "lua-ls".to_string(),
+                    crate::config::settings::BridgeServerConfig {
+                        cmd: Some(vec!["lua-language-server".to_string()]),
+                        ..Default::default()
+                    },
+                );
+                let mut links = vec![unresolved_link(Some(json!({"token": "link-1"})))];
+                envelope_host_document_links(
+                    &mut links,
+                    "lua-ls",
+                    "file:///test.md",
+                    None,
+                    pool.document_connection_generation(&key),
+                    &key,
+                    true,
+                );
+
+                let result = pool
+                    .dispatch_document_link_resolve(links.remove(0), &settings, None)
+                    .await;
+                let envelope = extract_document_link_envelope(&result).expect("envelope restored");
+                assert_eq!(envelope.inner, Some(json!({"token": "link-1"})));
+                assert!(result.target.is_none(), "link stays unresolved");
+            });
+        });
+        assert!(
+            warnings.iter().any(|w| w.contains("documentLink/resolve")
+                && w.contains("no longer advertises resolveProvider")),
+            "the capability miss must be logged, not silently swallowed: {warnings:?}"
+        );
+    }
 }

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -55,6 +55,7 @@ use tower::Service;
 use tower_lsp_server::jsonrpc::{Request, Response};
 
 use crate::error::LockResultExt;
+use crate::lsp::bridge::envelope::ENVELOPE_KEY;
 
 tokio::task_local! {
     /// The current writer's ingress ticket, scoped around the gated handler
@@ -359,7 +360,7 @@ fn classify(req: &Request) -> Option<Role> {
             Some(Role::Reader { uri })
         }
         "codeLens/resolve" | "codeAction/resolve" | "documentLink/resolve" => {
-            let raw = req.params()?["data"]["kakehashi"]["host_uri"].as_str()?;
+            let raw = req.params()?["data"][ENVELOPE_KEY]["host_uri"].as_str()?;
             Some(Role::Reader {
                 uri: normalize_uri(raw),
             })

--- a/src/lsp/lsp_impl/text_document/code_lens.rs
+++ b/src/lsp/lsp_impl/text_document/code_lens.rs
@@ -59,10 +59,10 @@ impl Kakehashi {
     /// produced it, identified by the envelope in `lens.data` (#355).
     ///
     /// Fails soft except for client cancellation: a lens without an envelope
-    /// (foreign, or from a host server without resolve support) passes through
-    /// unchanged, and a stale region returns the lens unresolved with its
-    /// envelope intact — clients re-request lenses on change, so the staleness
-    /// window is short.
+    /// (foreign, or from a server without resolve support on either layer)
+    /// passes through unchanged, and a stale region returns the lens
+    /// unresolved with its envelope intact — clients re-request lenses on
+    /// change, so the staleness window is short.
     pub(crate) async fn code_lens_resolve_impl(&self, lens: CodeLens) -> Result<CodeLens> {
         let Some(envelope) = extract_code_lens_envelope(&lens) else {
             return Ok(lens);

--- a/src/lsp/lsp_impl/text_document/completion.rs
+++ b/src/lsp/lsp_impl/text_document/completion.rs
@@ -56,9 +56,10 @@ impl Kakehashi {
     /// untranslated — they are already real.
     ///
     /// The envelope is minted only for a server that advertises
-    /// `completionItem/resolve`: for one that does not, it would be pure wire
-    /// weight on every item of every completion, and the resolve would fail
-    /// soft back to the unresolved item anyway.
+    /// `completionItem/resolve` (reserved-key collision aside): for one that
+    /// does not, it would be pure wire weight on every item of every
+    /// completion, and the resolve would fail soft back to the unresolved
+    /// item anyway.
     ///
     /// Minting also happens only for the server that WINS the fan-in. Each
     /// fanned-out server carries its identity back beside its response

--- a/tests/e2e/e2e_code_lens_resolve.rs
+++ b/tests/e2e/e2e_code_lens_resolve.rs
@@ -21,6 +21,10 @@ fn mock_formatter_bin() -> &'static str {
 }
 
 fn init_client() -> (LspClient, tempfile::TempDir) {
+    init_client_with_mode("code-lens")
+}
+
+fn init_client_with_mode(mode: &str) -> (LspClient, tempfile::TempDir) {
     let bin = mock_formatter_bin();
     let config_dir = tempfile::TempDir::new().expect("Failed to create config temp dir");
     let config_path = config_dir.path().join("code_lens_resolve.toml");
@@ -39,7 +43,7 @@ fn init_client() -> (LspClient, tempfile::TempDir) {
             "capabilities": {},
             "workspaceFolders": null,
             "initializationOptions": { "languageServers": {
-                "mock-codelens": { "cmd": [bin, "code-lens"], "languages": ["lua"] }
+                "mock-codelens": { "cmd": [bin, mode], "languages": ["lua"] }
             }}
         }),
     );
@@ -270,6 +274,31 @@ fn e2e_host_code_lens_resolve_round_trips_verbatim() {
         "the complete host range must pass through without virtual translation"
     );
     assert_eq!(resolved["data"]["kakehashi"]["host_layer"], true);
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_virtual_code_lens_from_non_resolving_server_keeps_its_data() {
+    let (mut client, _config_dir) = init_client_with_mode("code-lens-no-resolve");
+    open_markdown(&mut client);
+
+    let lens = code_lens_with_retry(&mut client).remove(0);
+    assert_eq!(
+        lens["range"]["start"]["line"], 3,
+        "ranges are translated to host coordinates regardless of the envelope"
+    );
+    assert!(
+        lens["data"].get("kakehashi").is_none(),
+        "a producer that cannot resolve must keep its own payload: {lens}"
+    );
+    assert_eq!(lens["data"], json!({ "mock": "lens-1" }));
+
+    let response = client.send_request("codeLens/resolve", lens.clone());
+    assert_eq!(
+        response["result"], lens,
+        "a bare lens has no origin to route to and comes back unchanged"
+    );
 
     shutdown(&mut client);
 }

--- a/tests/e2e/e2e_code_lens_resolve.rs
+++ b/tests/e2e/e2e_code_lens_resolve.rs
@@ -295,6 +295,11 @@ fn e2e_virtual_code_lens_from_non_resolving_server_keeps_its_data() {
     assert_eq!(lens["data"], json!({ "mock": "lens-1" }));
 
     let response = client.send_request("codeLens/resolve", lens.clone());
+    assert!(
+        response.get("error").is_none(),
+        "unexpected resolve error: {:?}",
+        response.get("error")
+    );
     assert_eq!(
         response["result"], lens,
         "a bare lens has no origin to route to and comes back unchanged"

--- a/tests/e2e/e2e_completion_envelope.rs
+++ b/tests/e2e/e2e_completion_envelope.rs
@@ -1,0 +1,125 @@
+//! The completion routing envelope is minted only for an origin that
+//! advertises `completionItem/resolve`; a non-resolving origin's items reach
+//! the client bare, on the virt layer as on the host layer
+//! (`e2e_host_bridge` covers the host side).
+
+use crate::helpers::lsp_client::LspClient;
+use crate::helpers::lua_bridge::shutdown_client;
+use serde_json::{Value, json};
+
+fn mock_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_mock-lsp-formatter")
+}
+
+const MARKDOWN: &str = "# Test\n\n```lua\nlocal x = 1\n```\n";
+const MARKDOWN_URI: &str = "file:///test_completion_envelope.md";
+
+fn init_virtual_completion_client(mode: &str) -> (LspClient, tempfile::TempDir, Value) {
+    let config_dir = tempfile::TempDir::new().expect("temp dir");
+    let config_path = config_dir.path().join("completion_envelope.toml");
+    std::fs::write(&config_path, "").expect("write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("utf-8 path"))
+        .build();
+
+    let init = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "languageServers": {
+                    "mock-completion": {
+                        "cmd": [mock_bin(), mode],
+                        "languages": ["lua"]
+                    }
+                }
+            }
+        }),
+    );
+    assert_eq!(
+        init["result"]["capabilities"]["completionProvider"]["resolveProvider"],
+        json!(true),
+        "kakehashi advertises resolveProvider whatever the downstream does"
+    );
+    client.send_notification("initialized", json!({}));
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": MARKDOWN_URI,
+                "languageId": "markdown",
+                "version": 1,
+                "text": MARKDOWN
+            }
+        }),
+    );
+
+    let item = (0..300)
+        .find_map(|_| {
+            let resp = client.send_request(
+                "textDocument/completion",
+                json!({
+                    "textDocument": { "uri": MARKDOWN_URI },
+                    "position": { "line": 3, "character": 11 }
+                }),
+            );
+            assert!(
+                resp.get("error").is_none(),
+                "unexpected completion error: {:?}",
+                resp.get("error")
+            );
+            let first = resp["result"]["items"]
+                .as_array()
+                .and_then(|items| items.first().cloned());
+            if first.is_none() {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            first
+        })
+        .expect("virt completion returns an item");
+
+    (client, config_dir, item)
+}
+
+#[test]
+fn e2e_virtual_completion_from_non_resolving_server_keeps_its_data() {
+    let (mut client, _config_dir, item) = init_virtual_completion_client("completion-no-resolve");
+
+    assert_eq!(item["label"], "./test");
+    assert!(
+        item["data"].get("kakehashi").is_none(),
+        "a producer that cannot resolve must keep its own payload: {item}"
+    );
+    assert!(
+        item["data"]["mockPath"]
+            .as_str()
+            .is_some_and(|uri| uri.contains("kakehashi-virtual")),
+        "the payload is the downstream's own, minted for the virtual document: {item}"
+    );
+
+    let response = client.send_request("completionItem/resolve", item.clone());
+    assert_eq!(
+        response["result"], item,
+        "a bare item has no origin to route to and comes back unchanged"
+    );
+
+    shutdown_client(&mut client);
+}
+
+#[test]
+fn e2e_virtual_completion_from_resolving_server_is_enveloped() {
+    let (mut client, _config_dir, item) = init_virtual_completion_client("completion-resolve");
+
+    assert_eq!(item["data"]["kakehashi"]["origin"], "mock-completion");
+    assert!(
+        item["data"]["kakehashi"]["inner"]["mockPath"].is_string(),
+        "the downstream payload is nested as inner: {item}"
+    );
+
+    shutdown_client(&mut client);
+}

--- a/tests/e2e/e2e_completion_envelope.rs
+++ b/tests/e2e/e2e_completion_envelope.rs
@@ -103,6 +103,11 @@ fn e2e_virtual_completion_from_non_resolving_server_keeps_its_data() {
     );
 
     let response = client.send_request("completionItem/resolve", item.clone());
+    assert!(
+        response.get("error").is_none(),
+        "unexpected resolve error: {:?}",
+        response.get("error")
+    );
     assert_eq!(
         response["result"], item,
         "a bare item has no origin to route to and comes back unchanged"

--- a/tests/e2e/e2e_completion_envelope.rs
+++ b/tests/e2e/e2e_completion_envelope.rs
@@ -1,7 +1,7 @@
 //! The completion routing envelope is minted only for an origin that
-//! advertises `completionItem/resolve`; a non-resolving origin's items reach
-//! the client bare, on the virt layer as on the host layer
-//! (`e2e_host_bridge` covers the host side).
+//! advertises `completionItem/resolve` (reserved-key collision aside); a
+//! non-resolving origin's items reach the client bare, on the virt layer as
+//! on the host layer (`e2e_host_bridge` covers the host side).
 
 use crate::helpers::lsp_client::LspClient;
 use crate::helpers::lua_bridge::shutdown_client;

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -19,6 +19,7 @@ mod e2e_cli_diagnose;
 mod e2e_cli_format;
 mod e2e_code_action;
 mod e2e_code_lens_resolve;
+mod e2e_completion_envelope;
 mod e2e_concatenated_formatting;
 mod e2e_config_file;
 mod e2e_config_relative_paths;


### PR DESCRIPTION
## Summary

Every producer of a `*/resolve` routing envelope now applies one rule, and every resolve-side capability miss is reported the same way.

**Before.** The host layer (completion, codeLens) and documentLink (both layers) minted the `data.kakehashi` envelope only when the origin advertised the matching resolve capability, or when the payload squatted on the reserved key. The **virt layer for completion and codeLens enveloped every item unconditionally**, so a non-resolving downstream paid the envelope on every item of every completion, and every client resolve of those items round-tripped to a capability check that failed soft — silently for codeLens, documentLink and virt completion, with a warning for host completion and codeAction.

**After.**
- One predicate, `bridge::envelope::should_envelope` (origin resolves, or payload nests the reserved key), gates minting on both layers for completion, codeLens and documentLink. The `"kakehashi"` key lives in one constant. codeAction needs no collision rule and says so: an action that leaves without an envelope leaves with `data = None`.
- The virt producers decide from the origin's capabilities **at reply time**, as the host layer already did, so a dynamic `resolveProvider` registration landing between send and reply is seen.
- On the resolve side, a capability miss on an item whose restored payload nests the reserved key is the steady state of a non-resolving origin and logs at `debug`; a capability that was actually withdrawn under the item (respawn, dynamic unregister) logs one uniform `warn`: `<method>[ (host)]: "<origin>" no longer advertises resolveProvider; returning unresolved`. codeLens and documentLink derive the host tag from the envelope's layer.
- Client-supplied `host_uri` in the resolve logs is now quoted with `{:?}` (pre-existing sibling).

Client-visible behavior is unchanged except for the opaque `data` shape: a non-resolving virt origin's items now reach the client bare instead of enveloped, and resolve returns them unchanged either way.

## Tests
- Unit: `should_envelope` table; virt completion/codeLens envelope-only-when-resolving (plus reserved-key collision and translated range on the bare item); pool-level resolve tests for completion (both layers), codeLens and documentLink asserting the warn on a withdrawn capability and its absence on a reserved-key wrap (mutants: `true ||` on the producer gate, `false &&` on the reserved-key branch, deleting the warn — all killed).
- E2E: virt-layer completion and codeLens against the non-resolving mock (`completion-no-resolve`, `code-lens-no-resolve`): bare data, translated ranges, resolve round-trips unchanged.
- `make test` 3641 passed; full e2e suite passed; clippy/fmt clean.

## Docs
`docs/architecture-decisions/host-document-bridge.md` now states the one rule for both layers, the reserved-key exception, the codeAction aside, and the resolve-side logging.

## Follow-ups (not in this PR)
- #1046: virt-layer code lenses still carry no producing connection key/generation (pre-existing since #355; documentLink got the binding in #1025).
- Stack: #1026 (inlayHint/resolve) and #1039 (workspaceSymbol/resolve) have the same silent capability miss; review comments left there.
- Pre-existing: `envelope_lens_data` serializes `inner` through `json!` (deep copy per lens) where completion's `wrap_envelope` moves it; `EnvelopeOffset::from` clones the column table per enveloped item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhEfVnacTxTiURX5ftDwmn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resolve routing for completion, code lens, code actions, and document links so it is applied only when supported.
  - Preserved original item data from servers without resolve support.
  - Safely handle payloads using reserved routing fields without unnecessary warnings.
  - Resolve requests now detect withdrawn capabilities and return items without losing routing information.

- **Tests**
  - Added coverage for resolve behavior, payload preservation, routing-field collisions, and host-coordinate translation across supported item types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->