### PR TITLE
fix(bridge): bind virt code lenses to the producing connection

### DIFF
--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -63,11 +63,12 @@ Partially implemented:
   payload cannot impersonate bridge routing metadata. (codeAction needs no
   such exception: an action that leaves without an envelope leaves with no
   `data` at all.) `codeLens/resolve` forwards the original payload and
-  coordinates verbatim on the host layer. The codeLens envelope retains
-  the host-document incarnation plus the exact producing `ConnectionKey` and
-  its generation, so an old lens is returned unresolved after either a
-  document reopen, a rooted/shared routing-key change, or a downstream process
-  replacement. Resolve never spawns a replacement for process-owned lens data.
+  coordinates verbatim on the host layer. On both layers the codeLens
+  envelope retains the host-document incarnation plus the exact producing
+  `ConnectionKey` and its generation, so an old lens is returned unresolved
+  after either a document reopen, a rooted/shared routing-key change, or a
+  downstream process replacement. Resolve looks the producer up by that key
+  and never spawns or selects a replacement for process-owned lens data.
   Ordinary downstream failures remain fail-soft,
   while an upstream client cancellation returns `RequestCancelled` and
   cancels the in-flight downstream resolve.

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -659,6 +659,30 @@ impl LanguageServerPool {
             .map(Arc::clone)
     }
 
+    /// The live `Ready` connection under `key` **at** `expected_generation`,
+    /// for the resolve envelopes that name their producer by key and
+    /// generation. The generation is compared under the same `connections`
+    /// lock as the handle read: it only advances under that lock as the old
+    /// handle is retired, so a caller that compared it outside the lock could
+    /// acquire the replacement in the gap. `config` is compared as in
+    /// [`ready_connection_by_key_for_config`](Self::ready_connection_by_key_for_config).
+    pub(crate) async fn ready_producer_by_key(
+        &self,
+        key: &ConnectionKey,
+        config: Option<&crate::config::settings::BridgeServerConfig>,
+        expected_generation: u64,
+    ) -> Option<Arc<ConnectionHandle>> {
+        let connections = self.connections.lock().await;
+        if self.document_connection_generation(key) != expected_generation {
+            return None;
+        }
+        connections
+            .get(key)
+            .filter(|handle| handle.state() == ConnectionState::Ready)
+            .filter(|handle| config.is_none_or(|config| handle.matches_launch_config(config)))
+            .map(Arc::clone)
+    }
+
     /// Shared registry of in-flight forwarded requests, handed to the forwarding
     /// loop so it can await each request's cancel token and drop settled entries
     /// (#404).

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -6495,6 +6495,48 @@ mod tests {
         );
     }
 
+    /// A resolve envelope names its producer by key AND generation. The
+    /// generation advances under the `connections` lock as the old handle is
+    /// retired, so a caller that compared it outside the lock could still
+    /// acquire the replacement in the gap and consult it. The producer lookup
+    /// therefore compares the generation under that same lock: a live handle
+    /// at the expected generation is served, a moved generation misses.
+    #[tokio::test]
+    async fn a_producer_lookup_misses_when_the_generation_moved() {
+        let pool = LanguageServerPool::new();
+        let key = ConnectionKey::for_server("lua");
+        let config = test_helpers::devnull_config_for_language("lua");
+        let handle =
+            test_helpers::create_handle_with_key(ConnectionState::Ready, key.clone()).await;
+        handle.record_launch_config(&config);
+        pool.connections
+            .lock()
+            .await
+            .insert(key.clone(), Arc::clone(&handle));
+        let minted_at = pool.document_connection_generation(&key);
+
+        assert!(
+            pool.ready_producer_by_key(&key, Some(&config), minted_at)
+                .await
+                .is_some_and(|live| Arc::ptr_eq(&live, &handle)),
+            "the live handle at the minted generation is the producer"
+        );
+        assert!(
+            pool.ready_producer_by_key(&key, Some(&config), minted_at + 1)
+                .await
+                .is_none(),
+            "a generation the key never reached names no producer"
+        );
+
+        pool.document_tracker.purge_connection(&key).await;
+        assert!(
+            pool.ready_producer_by_key(&key, Some(&config), minted_at)
+                .await
+                .is_none(),
+            "after a purge the still-inserted handle is not the minted generation's process"
+        );
+    }
+
     /// A connection mid-handshake is LIVE, and for a shared-instance key it is
     /// the only way to reach the instance at all — the revive path cannot
     /// re-root one without a document. Dropping it would fail soft on a

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -219,6 +219,11 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/codeLens") {
             return Ok(None);
         }
+        // Bind the lenses to this exact process: resolve looks the producer
+        // up by key and generation and never hands process-owned data to a
+        // replacement (the host layer stamps the same pair).
+        let connection_key = handle.key().clone();
+        let connection_generation = self.document_connection_generation(&connection_key);
         // Read resolve support when the RESPONSE arrives, as the host layer
         // does: a dynamic `resolveProvider` registration can land between
         // send and reply, and the envelope decision should see it.
@@ -242,8 +247,8 @@ impl LanguageServerPool {
                     region_id,
                     injection_language,
                     incarnation: host_incarnation,
-                    connection_generation: None,
-                    connection_key: None,
+                    connection_generation: Some(connection_generation),
+                    connection_key: Some(&connection_key),
                     offset: ctx.offset,
                     host_layer: false,
                 };
@@ -326,41 +331,36 @@ impl LanguageServerPool {
             re_envelope_lens(&mut lens, &envelope);
             return lens;
         }
-        let handle_result = if envelope.is_host_layer() {
-            let Some(expected_generation) = envelope.connection_generation else {
-                re_envelope_lens(&mut lens, &envelope);
-                return lens;
-            };
-            let Some(connection_key) = envelope
-                .connection_key
-                .as_ref()
-                .filter(|key| key.server() == server_name)
-            else {
-                re_envelope_lens(&mut lens, &envelope);
-                return lens;
-            };
-            if self.document_connection_generation(connection_key) != expected_generation {
-                re_envelope_lens(&mut lens, &envelope);
-                return lens;
-            }
-            self.ready_connection_by_key_for_config(connection_key, Some(server_config))
-                .await
-                .ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::NotConnected,
-                        "producer connection is no longer live",
-                    )
-                })
-        } else {
-            self.get_or_create_virtual_connection(
-                server_name,
-                server_config,
-                &host_uri,
-                &envelope.injection_language,
-                &envelope.region_id,
-            )
-            .await
+        // Both layers bind the lens to the exact process that produced it:
+        // the envelope must name a live connection under the origin's own
+        // key at the generation it was minted for. Anything else fails soft
+        // here, before any connection is consulted — resolve never spawns or
+        // selects a replacement for process-owned lens data.
+        let Some(expected_generation) = envelope.connection_generation else {
+            re_envelope_lens(&mut lens, &envelope);
+            return lens;
         };
+        let Some(connection_key) = envelope
+            .connection_key
+            .as_ref()
+            .filter(|key| key.server() == server_name)
+        else {
+            re_envelope_lens(&mut lens, &envelope);
+            return lens;
+        };
+        if self.document_connection_generation(connection_key) != expected_generation {
+            re_envelope_lens(&mut lens, &envelope);
+            return lens;
+        }
+        let handle_result = self
+            .ready_connection_by_key_for_config(connection_key, Some(server_config))
+            .await
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotConnected,
+                    "producer connection is no longer live",
+                )
+            });
         let handle = match handle_result {
             Ok(h) => h,
             Err(e) => {
@@ -457,10 +457,9 @@ impl LanguageServerPool {
             let producer_is_live = connections
                 .get(connection_key)
                 .is_some_and(|current| Arc::ptr_eq(current, &handle));
-            let generation_matches = !envelope.is_host_layer()
-                || envelope.connection_generation.is_some_and(|expected| {
-                    self.document_connection_generation(connection_key) == expected
-                });
+            let generation_matches = envelope.connection_generation.is_some_and(|expected| {
+                self.document_connection_generation(connection_key) == expected
+            });
             if !producer_is_live || !generation_matches {
                 Err(io::Error::new(
                     io::ErrorKind::NotConnected,

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -21,9 +21,9 @@
 //!
 //! Resolution fails soft for stale regions, missing servers, replaced
 //! producers, connection errors, and parse failures: the lens returns
-//! unresolved with its envelope intact. Client cancellation is the exception and surfaces as
-//! `RequestCancelled`; clients re-request lenses on change, so the ordinary
-//! fail-soft window is short (#355 maintainer decision).
+//! unresolved with its envelope intact. Client cancellation is the exception
+//! and surfaces as `RequestCancelled`; clients re-request lenses on change,
+//! so the ordinary fail-soft window is short (#355 maintainer decision).
 //!
 //! Requests are queued via the channel-based writer task (`send_request()`) for
 //! FIFO ordering with other messages (ls-bridge-message-ordering single-writer loop).

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -1199,4 +1199,73 @@ mod tests {
             "a reserved-key wrap is not a lost capability: {warnings:?}"
         );
     }
+
+    /// A virt-layer lens is bound to the exact pooled process that produced
+    /// it, as a host-layer lens already is: resolve requires the producing
+    /// key and generation, refuses a key that names a different server, and
+    /// fails soft BEFORE touching any connection when they do not match. The
+    /// fixture's live handle advertises nothing, so reaching it would log the
+    /// capability miss; a silent unresolved return therefore proves the gate
+    /// fired before the handle was consulted (and that nothing was spawned).
+    #[rstest]
+    #[case::unbound(None, None)]
+    #[case::stale_generation(Some("lua-ls"), Some(1))]
+    #[case::key_names_another_server(Some("other-ls"), Some(0))]
+    fn virt_dispatch_fails_soft_without_reaching_a_process_it_did_not_bind_to(
+        #[case] key_server: Option<&str>,
+        #[case] generation_delta: Option<u64>,
+    ) {
+        use crate::lsp::bridge::test_logging::captured_warnings_for;
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        let warnings = captured_warnings_for(|| {
+            runtime.block_on(async {
+                let pool = LanguageServerPool::new();
+                let host_uri = Url::parse("file:///test.md").expect("valid url");
+                pool.open_host_incarnation(&host_uri, 1).await;
+                let live_key = ConnectionKey::for_server("lua-ls");
+                let handle = crate::lsp::bridge::test_helpers::create_handle_with_key(
+                    crate::lsp::bridge::ConnectionState::Ready,
+                    live_key.clone(),
+                )
+                .await;
+                pool.insert_connection(handle).await;
+                let mut settings = WorkspaceSettings::default();
+                settings.language_servers.insert(
+                    "lua-ls".to_string(),
+                    BridgeServerConfig {
+                        cmd: Some(vec!["lua-language-server".to_string()]),
+                        ..Default::default()
+                    },
+                );
+                let stamped_key = key_server.map(ConnectionKey::for_server);
+                let stamped_generation = generation_delta
+                    .map(|delta| pool.document_connection_generation(&live_key) + delta);
+                let offset = RegionOffset::new(3, 0);
+                let mut lens = CodeLens {
+                    range: tower_lsp_server::ls_types::Range::default(),
+                    command: None,
+                    data: Some(json!({"kind": "references"})),
+                };
+                envelope_lens_data(
+                    &mut lens,
+                    &CodeLensEnvelopeContext {
+                        connection_generation: stamped_generation,
+                        connection_key: stamped_key.as_ref(),
+                        ..ctx_with(&offset)
+                    },
+                );
+
+                let result = pool.dispatch_code_lens_resolve(lens, &settings, None).await;
+                let envelope = extract_code_lens_envelope(&result).expect("envelope restored");
+                assert_eq!(envelope.inner, Some(json!({"kind": "references"})));
+                assert_eq!(envelope.connection_key, stamped_key);
+                assert_eq!(envelope.connection_generation, stamped_generation);
+                assert!(result.command.is_none(), "lens stays unresolved");
+            });
+        });
+        assert!(
+            warnings.is_empty(),
+            "an unbound or mismatched envelope must fail soft before any connection is consulted: {warnings:?}"
+        );
+    }
 }

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -366,12 +366,16 @@ impl LanguageServerPool {
             re_envelope_lens(&mut lens, &envelope);
             return lens;
         };
+        // Lock-free fail-soft for the steady-state stale lens (a generation
+        // the key has long moved past); the lookup below re-compares under
+        // the `connections` lock, so a purge racing this check cannot hand
+        // back the replacement it installed.
         if self.document_connection_generation(connection_key) != expected_generation {
             re_envelope_lens(&mut lens, &envelope);
             return lens;
         }
         let handle_result = self
-            .ready_connection_by_key_for_config(connection_key, Some(server_config))
+            .ready_producer_by_key(connection_key, Some(server_config), expected_generation)
             .await
             .ok_or_else(|| {
                 io::Error::new(

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -13,9 +13,15 @@
 //! only `data`) are forwarded instead of dropped — servers like rust-analyzer
 //! return mostly-unresolved lenses by design.
 //!
-//! Resolution fails soft for stale regions, missing servers, connection
-//! errors, and parse failures: the lens returns unresolved with its envelope
-//! intact. Client cancellation is the exception and surfaces as
+//! Both layers bind a lens to the exact process that produced it: the
+//! envelope carries the producing connection's pool key and generation, and
+//! resolve looks that connection up by key instead of re-deriving one, so a
+//! relaunch or a routing-key change never hands process-owned lens data to a
+//! replacement (the documentLink twin follows the same rule).
+//!
+//! Resolution fails soft for stale regions, missing servers, replaced
+//! producers, connection errors, and parse failures: the lens returns
+//! unresolved with its envelope intact. Client cancellation is the exception and surfaces as
 //! `RequestCancelled`; clients re-request lenses on change, so the ordinary
 //! fail-soft window is short (#355 maintainer decision).
 //!
@@ -65,12 +71,15 @@ pub(crate) struct CodeLensEnvelope {
     /// Host open incarnation that produced this lens. Missing for legacy data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) incarnation: Option<u64>,
-    /// Generation of the producing pooled connection. Host resolve must not
-    /// hand process-owned data to a replacement process under the same key.
+    /// Generation of the producing pooled connection, on either layer.
+    /// Resolve must not hand process-owned data to a replacement process
+    /// under the same key, so a moved generation fails soft.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) connection_generation: Option<u64>,
-    /// Exact pool key of the producing host connection. Generations are local
-    /// to a key, so the key and generation together identify the process.
+    /// Exact pool key of the producing connection, on either layer.
+    /// Generations are local to a key, so the key and generation together
+    /// identify the process; resolve looks the producer up by this key and
+    /// never re-derives one from the host URI.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) connection_key: Option<ConnectionKey>,
     /// Region offset snapshot for coordinate translation at resolve time.
@@ -303,8 +312,12 @@ impl LanguageServerPool {
             .await
     }
 
-    /// Send a `codeLens/resolve` request to the downstream server that
+    /// Send a `codeLens/resolve` request to the exact downstream process that
     /// produced the lens, re-enveloping the resolved lens for return.
+    ///
+    /// The envelope's connection key and generation identify that process on
+    /// both layers; a lens whose producer was replaced (or that never carried
+    /// the pair) comes back unresolved without any connection being consulted.
     async fn send_code_lens_resolve_request(
         &self,
         server_config: &BridgeServerConfig,

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -230,7 +230,12 @@ impl LanguageServerPool {
         }
         // Bind the lenses to this exact process: resolve looks the producer
         // up by key and generation and never hands process-owned data to a
-        // replacement (the host layer stamps the same pair).
+        // replacement (the host layer stamps the same pair). Reading the
+        // generation before the send is safe: it only advances under the
+        // `connections` lock as the handle is retired, and the send below
+        // re-verifies this handle under that same lock — a bump before the
+        // send fails the send, a bump after it leaves the lenses stamped with
+        // a generation the resolve side rejects.
         let connection_key = handle.key().clone();
         let connection_generation = self.document_connection_generation(&connection_key);
         // Read resolve support when the RESPONSE arrives, as the host layer

--- a/src/lsp/bridge/text_document/document_link.rs
+++ b/src/lsp/bridge/text_document/document_link.rs
@@ -276,12 +276,16 @@ impl LanguageServerPool {
             re_envelope_link(&mut link, &envelope);
             return link;
         };
+        // Lock-free fail-soft for the steady-state stale link (a generation
+        // the key has long moved past); the lookup below re-compares under
+        // the `connections` lock, so a purge racing this check cannot hand
+        // back the replacement it installed.
         if self.document_connection_generation(connection_key) != expected_generation {
             re_envelope_link(&mut link, &envelope);
             return link;
         }
         let handle_result = self
-            .ready_connection_by_key_for_config(connection_key, Some(server_config))
+            .ready_producer_by_key(connection_key, Some(server_config), expected_generation)
             .await
             .ok_or_else(|| {
                 io::Error::new(

--- a/tests/e2e/e2e_code_lens_resolve.rs
+++ b/tests/e2e/e2e_code_lens_resolve.rs
@@ -445,6 +445,101 @@ fn e2e_host_code_lens_from_closed_incarnation_stays_unresolved() {
     shutdown(&mut client);
 }
 
+/// A virt-layer lens is bound to the pooled process that produced it, as
+/// a host-layer lens is: after the origin server is relaunched (same pool
+/// key, new generation) or rerouted (different pool key), data minted by the
+/// old process must not be handed to the replacement. The old lens itself
+/// is already rejected by the incarnation gate (the reopen below), so the
+/// stale probe is the replacement's lens carrying the OLD producer identity.
+fn assert_replaced_virtual_connection_lens_stays_unresolved(change_pool_key: bool) {
+    let bin = mock_formatter_bin();
+    let (mut client, _config_dir) = init_client();
+    open_markdown(&mut client);
+    let old_lens = code_lens_with_retry(&mut client).remove(0);
+
+    let mut server = json!({
+        "cmd": [bin, "code-lens-replacement"],
+        "languages": ["lua"]
+    });
+    if change_pool_key {
+        server["preferSharedInstance"] = json!(true);
+    }
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({ "settings": { "languageServers": { "mock-codelens": server } } }),
+    );
+    client.send_notification(
+        "textDocument/didClose",
+        json!({ "textDocument": { "uri": MARKDOWN_URI } }),
+    );
+    open_markdown(&mut client);
+
+    let replacement_lens = code_lens_with_retry(&mut client).remove(0);
+    let old_envelope = &old_lens["data"]["kakehashi"];
+    let replacement_envelope = &replacement_lens["data"]["kakehashi"];
+    assert!(
+        !old_envelope["connection_key"].is_null(),
+        "virt lenses must be bound to their producing connection: {old_envelope}"
+    );
+    if change_pool_key {
+        assert_ne!(
+            old_envelope["connection_key"], replacement_envelope["connection_key"],
+            "precondition: replacement must move from client-fallback to shared"
+        );
+        assert_eq!(
+            old_envelope["connection_generation"], replacement_envelope["connection_generation"],
+            "different keys should demonstrate the equal-generation collision"
+        );
+    } else {
+        assert_eq!(
+            old_envelope["connection_key"], replacement_envelope["connection_key"],
+            "precondition: replacement must reuse the same pool key"
+        );
+        assert_ne!(
+            old_envelope["connection_generation"], replacement_envelope["connection_generation"],
+            "same-key replacement must advance its generation"
+        );
+    }
+    let replacement = client.send_request("codeLens/resolve", replacement_lens.clone());
+    assert_eq!(
+        replacement["result"]["command"]["title"], "replacement resolved:lens-1",
+        "precondition: the replacement process must be active"
+    );
+
+    let mut stale_lens = replacement_lens;
+    stale_lens["data"]["kakehashi"]["connection_key"] = old_envelope["connection_key"].clone();
+    stale_lens["data"]["kakehashi"]["connection_generation"] =
+        old_envelope["connection_generation"].clone();
+    stale_lens["data"]["kakehashi"]["inner"] = old_envelope["inner"].clone();
+    let stale_data = stale_lens["data"].clone();
+    let response = client.send_request("codeLens/resolve", stale_lens);
+    assert!(
+        response.get("error").is_none(),
+        "stale producer data must fail soft, not as JSON-RPC error: {response}"
+    );
+    assert_eq!(
+        response["result"].get("command"),
+        None,
+        "opaque lens data must not be sent to a replacement process"
+    );
+    assert_eq!(
+        response["result"]["data"], stale_data,
+        "fail-soft resolve must preserve the original routing envelope"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_virtual_code_lens_from_same_key_replacement_stays_unresolved() {
+    assert_replaced_virtual_connection_lens_stays_unresolved(false);
+}
+
+#[test]
+fn e2e_virtual_code_lens_from_different_key_replacement_stays_unresolved() {
+    assert_replaced_virtual_connection_lens_stays_unresolved(true);
+}
+
 #[test]
 fn e2e_host_code_lens_resolve_cancel_returns_request_cancelled() {
     let cancel_dir = tempfile::TempDir::new().expect("cancel dir");

--- a/tests/e2e/e2e_code_lens_resolve.rs
+++ b/tests/e2e/e2e_code_lens_resolve.rs
@@ -132,9 +132,15 @@ fn open_markdown(client: &mut LspClient) {
     std::thread::sleep(Duration::from_millis(1000));
 }
 
-/// Issue `textDocument/codeLens`, retrying while the result is null (cold
-/// downstream still handshaking).
-fn code_lens_with_retry(client: &mut LspClient) -> Vec<Value> {
+/// Issue `textDocument/codeLens` until a non-empty result satisfies `accept`,
+/// retrying while the result is null (cold downstream still handshaking),
+/// empty (region not resolved yet), or rejected by `accept`. One bounded
+/// loop: a caller's condition must not multiply the retry budget.
+fn code_lenses_until(
+    client: &mut LspClient,
+    accept: impl Fn(&[Value]) -> bool,
+    waiting_for: &str,
+) -> Vec<Value> {
     for _ in 0..300 {
         let response = client.send_request(
             "textDocument/codeLens",
@@ -146,39 +152,38 @@ fn code_lens_with_retry(client: &mut LspClient) -> Vec<Value> {
             response.get("error")
         );
         let result = &response["result"];
-        if result.is_null() {
-            std::thread::sleep(Duration::from_millis(50));
-            continue;
+        if !result.is_null() {
+            let lenses = result
+                .as_array()
+                .cloned()
+                .expect("non-null codeLens result must be an array");
+            if !lenses.is_empty() && accept(&lenses) {
+                return lenses;
+            }
         }
-        let lenses = result
-            .as_array()
-            .cloned()
-            .expect("non-null codeLens result must be an array");
-        if lenses.is_empty() {
-            // Region may not be resolved yet; keep retrying.
-            std::thread::sleep(Duration::from_millis(50));
-            continue;
-        }
-        return lenses;
+        std::thread::sleep(Duration::from_millis(50));
     }
-    panic!("timed out waiting for a non-empty codeLens result");
+    panic!("timed out waiting for {waiting_for}");
+}
+
+fn code_lens_with_retry(client: &mut LspClient) -> Vec<Value> {
+    code_lenses_until(client, |_| true, "a non-empty codeLens result")
 }
 
 /// Poll `textDocument/codeLens` until the lens names a producer other than
 /// `old_envelope`'s. Configuration changes propagate asynchronously, so the
 /// first non-empty result after one may still come from the retired process.
 fn replacement_code_lens_with_retry(client: &mut LspClient, old_envelope: &Value) -> Value {
-    for _ in 0..300 {
-        let lens = code_lens_with_retry(client).remove(0);
-        let envelope = &lens["data"]["kakehashi"];
-        if envelope["connection_key"] != old_envelope["connection_key"]
-            || envelope["connection_generation"] != old_envelope["connection_generation"]
-        {
-            return lens;
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-    panic!("timed out waiting for a lens from the replacement process");
+    code_lenses_until(
+        client,
+        |lenses| {
+            let envelope = &lenses[0]["data"]["kakehashi"];
+            envelope["connection_key"] != old_envelope["connection_key"]
+                || envelope["connection_generation"] != old_envelope["connection_generation"]
+        },
+        "a lens from the replacement process",
+    )
+    .remove(0)
 }
 
 fn shutdown(client: &mut LspClient) {

--- a/tests/e2e/e2e_code_lens_resolve.rs
+++ b/tests/e2e/e2e_code_lens_resolve.rs
@@ -164,6 +164,23 @@ fn code_lens_with_retry(client: &mut LspClient) -> Vec<Value> {
     panic!("timed out waiting for a non-empty codeLens result");
 }
 
+/// Poll `textDocument/codeLens` until the lens names a producer other than
+/// `old_envelope`'s. Configuration changes propagate asynchronously, so the
+/// first non-empty result after one may still come from the retired process.
+fn replacement_code_lens_with_retry(client: &mut LspClient, old_envelope: &Value) -> Value {
+    for _ in 0..300 {
+        let lens = code_lens_with_retry(client).remove(0);
+        let envelope = &lens["data"]["kakehashi"];
+        if envelope["connection_key"] != old_envelope["connection_key"]
+            || envelope["connection_generation"] != old_envelope["connection_generation"]
+        {
+            return lens;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("timed out waiting for a lens from the replacement process");
+}
+
 fn shutdown(client: &mut LspClient) {
     let _ = client.send_request("shutdown", json!(null));
     client.send_notification("exit", json!(null));
@@ -367,8 +384,8 @@ fn assert_replaced_connection_lens_stays_unresolved(change_pool_key: bool) {
             }
         }}),
     );
-    let replacement_lens = code_lens_with_retry(&mut client).remove(0);
     let old_envelope = &old_lens["data"]["kakehashi"];
+    let replacement_lens = replacement_code_lens_with_retry(&mut client, old_envelope);
     let replacement_envelope = &replacement_lens["data"]["kakehashi"];
     if change_pool_key {
         assert_ne!(
@@ -474,8 +491,8 @@ fn assert_replaced_virtual_connection_lens_stays_unresolved(change_pool_key: boo
     );
     open_markdown(&mut client);
 
-    let replacement_lens = code_lens_with_retry(&mut client).remove(0);
     let old_envelope = &old_lens["data"]["kakehashi"];
+    let replacement_lens = replacement_code_lens_with_retry(&mut client, old_envelope);
     let replacement_envelope = &replacement_lens["data"]["kakehashi"];
     assert!(
         !old_envelope["connection_key"].is_null(),


### PR DESCRIPTION
## Summary

A virt-layer code lens carried no producing-connection identity, so `codeLens/resolve` re-derived a connection through `get_or_create_virtual_connection` and could hand process-owned `lens.data` to a replacement process after a downstream relaunch or a routing-key change. The host layer has refused that since #1023, and documentLink binds both layers since #1025. This PR gives virt code lenses the same binding.

## What changed

- `send_code_lens_request` reads the handle's `ConnectionKey` and its generation before the request and stamps both into the virt envelope (`connection_key`, `connection_generation`), exactly as `send_document_link_request` does.
- `send_code_lens_resolve_request` has one path for both layers: require the pair, reject a key naming another server or a moved generation, look the producer up with `ready_connection_by_key_for_config`, and fail soft (re-envelope, return unresolved) **before any connection is consulted**. Resolve never spawns or selects a replacement for process-owned lens data.
- The send-time generation recheck under the connections lock now applies to both layers (it was host-only).
- Incarnation gate, capability re-check, and the send-time `Arc::ptr_eq` recheck are unchanged.
- Docs: envelope field docs, module header, resolve fn docs, and the host-document-bridge ADR now state the rule once for both layers.

## Tests

- Unit (rstest, three cases): an unbound envelope, a moved generation, and a key naming another server each come back unresolved with the envelope intact and **without a single warning** — the fixture's live handle advertises nothing, so reaching it would log the capability miss; silence proves the gate fired first.
- E2E: `e2e_virtual_code_lens_from_same_key_replacement_stays_unresolved` and `..._from_different_key_replacement_stays_unresolved` mirror the document-link twins (relaunch with the same pool key / reroute to a shared key; the replacement resolves, the old producer identity does not).
- Both were verified RED before the fix (the unit cases saw the capability-miss warning; the e2e saw a `null` `connection_key`).

Closes #1046

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhEfVnacTxTiURX5ftDwmn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Code lenses now remain unresolved when their source document is reopened or when the producing process is replaced or rerouted.
  * Prevents stale code lenses from being resolved by a different process, preserving correct routing behavior.
  * Host- and virtual-layer code lens requests now handle stale or unavailable producers consistently without selecting a replacement process.

* **Documentation**
  * Clarified code lens resolution behavior during document and process changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->