### PR TITLE
fix(lsp): judge codeLens/resolve freshness on the region's effective offset

### DIFF
--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -83,12 +83,13 @@ pub(crate) use protocol::workspace_edit_preserves_line_prefixes;
 pub(crate) use protocol::workspace_edit_within_region;
 pub(crate) use text_document::host::{HostDocument, HostTextReader, normalize_host_goto_result};
 pub(crate) use text_document::{
-    CodeActionEnvelope, CodeLensEnvelope, DocumentLinkEnvelope, UpstreamCodeActionCaps,
-    bridge_code_actions, envelope_host_code_lenses, envelope_host_document_links,
-    extract_code_action_envelope, extract_code_lens_envelope, extract_document_link_envelope,
-    parse_code_actions_leniently,
+    CodeActionEnvelope, CodeLensEnvelope, UpstreamCodeActionCaps, bridge_code_actions,
+    envelope_host_code_lenses, envelope_host_document_links, extract_code_action_envelope,
+    extract_code_lens_envelope, extract_document_link_envelope, parse_code_actions_leniently,
 };
-pub(crate) use text_document::{KakehashiEnvelope, bridge_host_completion_items, extract_envelope};
+pub(crate) use text_document::{
+    EnvelopeOffset, KakehashiEnvelope, bridge_host_completion_items, extract_envelope,
+};
 pub(crate) use text_document::{OpenExpectation, OpenOutcome};
 pub(crate) use workspace::WorkspaceFolderSet;
 

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -83,9 +83,9 @@ pub(crate) use protocol::workspace_edit_preserves_line_prefixes;
 pub(crate) use protocol::workspace_edit_within_region;
 pub(crate) use text_document::host::{HostDocument, HostTextReader, normalize_host_goto_result};
 pub(crate) use text_document::{
-    CodeActionEnvelope, CodeLensEnvelope, UpstreamCodeActionCaps, bridge_code_actions,
-    envelope_host_code_lenses, envelope_host_document_links, extract_code_action_envelope,
-    extract_code_lens_envelope, extract_document_link_envelope, parse_code_actions_leniently,
+    CodeActionEnvelope, UpstreamCodeActionCaps, bridge_code_actions, envelope_host_code_lenses,
+    envelope_host_document_links, extract_code_action_envelope, extract_code_lens_envelope,
+    extract_document_link_envelope, parse_code_actions_leniently,
 };
 pub(crate) use text_document::{
     EnvelopeOffset, KakehashiEnvelope, bridge_host_completion_items, extract_envelope,

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -13,9 +13,7 @@ pub(crate) use code_action::{
     CodeActionEnvelope, UpstreamCodeActionCaps, bridge_code_actions, extract_code_action_envelope,
     parse_code_actions_leniently,
 };
-pub(crate) use code_lens::{
-    CodeLensEnvelope, envelope_host_code_lenses, extract_code_lens_envelope,
-};
+pub(crate) use code_lens::{envelope_host_code_lenses, extract_code_lens_envelope};
 mod completion;
 pub(crate) use completion::{
     EnvelopeOffset, KakehashiEnvelope, bridge_host_completion_items, extract_envelope,

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -17,7 +17,9 @@ pub(crate) use code_lens::{
     CodeLensEnvelope, envelope_host_code_lenses, extract_code_lens_envelope,
 };
 mod completion;
-pub(crate) use completion::{KakehashiEnvelope, bridge_host_completion_items, extract_envelope};
+pub(crate) use completion::{
+    EnvelopeOffset, KakehashiEnvelope, bridge_host_completion_items, extract_envelope,
+};
 mod completion_item;
 mod declaration;
 mod definition;
@@ -29,9 +31,7 @@ pub(crate) use did_open::{OpenExpectation, OpenOutcome};
 mod document_color;
 mod document_highlight;
 mod document_link;
-pub(crate) use document_link::{
-    DocumentLinkEnvelope, envelope_host_document_links, extract_document_link_envelope,
-};
+pub(crate) use document_link::{envelope_host_document_links, extract_document_link_envelope};
 mod document_symbol;
 mod folding_range;
 mod formatting;

--- a/src/lsp/lsp_impl/region_offset.rs
+++ b/src/lsp/lsp_impl/region_offset.rs
@@ -40,8 +40,10 @@ impl Kakehashi {
     /// envelope was minted from, so regions under those directives (markdown
     /// frontmatter, blockquote prose) compare equal while unchanged.
     ///
-    /// One implementation serves every `*/resolve` staleness gate that keys
-    /// on `(host_uri, region_id, offset)`, so the gates cannot drift.
+    /// The code-lens and document-link gates ask exactly this question and
+    /// share this one answer, so they cannot drift. Completion and code
+    /// action need the region end and contiguity as well, so they call
+    /// [`resolve_region_offset`] directly and compare the same offset.
     pub(super) fn region_offset_is_fresh(
         &self,
         host_uri: &str,

--- a/src/lsp/lsp_impl/region_offset.rs
+++ b/src/lsp/lsp_impl/region_offset.rs
@@ -44,6 +44,14 @@ impl Kakehashi {
     /// share this one answer, so they cannot drift. Completion and code
     /// action need the region end and contiguity as well, so they call
     /// [`resolve_region_offset`] directly and compare the same offset.
+    ///
+    /// Contiguity is deliberately NOT required here. A non-contiguous
+    /// combined region masks its host gaps with whitespace, so its line
+    /// geometry — and therefore range translation — stays valid; only
+    /// edit-carrying methods are refused on such regions
+    /// (`method_requires_contiguous_injection`), and code lenses and document
+    /// links are minted for them on purpose. Refusing to resolve what was
+    /// deliberately produced would leave those items permanently unresolved.
     pub(super) fn region_offset_is_fresh(
         &self,
         host_uri: &str,

--- a/src/lsp/lsp_impl/region_offset.rs
+++ b/src/lsp/lsp_impl/region_offset.rs
@@ -3,11 +3,14 @@
 //! Shared by translators of inbound (downstream → editor) payloads that must
 //! map virtual-document coordinates back to the host document —
 //! `window/showDocument` ([`ShowDocumentTranslator`]) and `workspace/applyEdit`
-//! ([`ApplyEditTranslator`]). The offset is rebuilt exactly as the goto request
-//! path does (`region_id → node byte range → resolve injection → RegionOffset`),
-//! so inbound translation can't disagree with goto on the same region. The
-//! region's content-precise host end and contiguity are returned alongside so
-//! an edit translator can reject a range that escapes the region or targets a
+//! ([`ApplyEditTranslator`]) — and by the `*/resolve` staleness gates
+//! (completion, code action, code lens, document link), which compare the
+//! rebuilt offset against the snapshot their envelope carries. The offset is
+//! rebuilt exactly as the goto request path does (`region_id → node byte
+//! range → resolve injection → RegionOffset`), so neither inbound translation
+//! nor a resolve gate can disagree with goto on the same region. The region's
+//! content-precise host end and contiguity are returned alongside so an edit
+//! translator can reject a range that escapes the region or targets a
 //! combined document with masked host gaps.
 //!
 //! [`ShowDocumentTranslator`]: super::show_document_translation::ShowDocumentTranslator

--- a/src/lsp/lsp_impl/region_offset.rs
+++ b/src/lsp/lsp_impl/region_offset.rs
@@ -18,10 +18,46 @@ use std::sync::Arc;
 use tower_lsp_server::ls_types::Position;
 use url::Url;
 
+use super::Kakehashi;
 use crate::document::DocumentStore;
 use crate::language::injection::ResolvedInjection;
 use crate::language::{InjectionResolver, LanguageCoordinator};
-use crate::lsp::bridge::{BridgeCoordinator, RegionOffset, region_host_end};
+use crate::lsp::bridge::{BridgeCoordinator, EnvelopeOffset, RegionOffset, region_host_end};
+
+impl Kakehashi {
+    /// Whether the injection region a resolve envelope names still resolves
+    /// to the offset snapshot the envelope carries.
+    ///
+    /// Re-resolves the region from the live parse and compares the WHOLE
+    /// effective offset (start line plus every per-line column offset), so a
+    /// region that moved, was invalidated, or had an interior blockquote
+    /// prefix edited is reported stale — translating the resolved payload with
+    /// the snapshot offset would bind it to wrong host coordinates then. The
+    /// live offset is the same `#offset!`/`#trim!`-adjusted geometry the
+    /// envelope was minted from, so regions under those directives (markdown
+    /// frontmatter, blockquote prose) compare equal while unchanged.
+    ///
+    /// One implementation serves every `*/resolve` staleness gate that keys
+    /// on `(host_uri, region_id, offset)`, so the gates cannot drift.
+    pub(super) fn region_offset_is_fresh(
+        &self,
+        host_uri: &str,
+        region_id: &str,
+        offset: &EnvelopeOffset,
+    ) -> bool {
+        let Ok(host_url) = Url::parse(host_uri) else {
+            return false;
+        };
+        resolve_region_offset(
+            &self.documents,
+            &self.language,
+            &self.bridge,
+            &host_url,
+            region_id,
+        )
+        .is_some_and(|(live_offset, _, _)| live_offset == RegionOffset::from(offset))
+    }
+}
 
 /// Rebuild the region's current host offset from the live parse, keyed by its
 /// `region_id` (a ULID in production). Returns `None` when the offset can't be

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -26,17 +26,17 @@ use tower_lsp_server::ls_types::{
 use ulid::Ulid;
 use url::Url;
 
+use super::super::Kakehashi;
 use super::super::bridge_context::RangeRequestContext;
-use super::super::{Kakehashi, detect_document_language};
+use super::super::region_offset::resolve_region_offset;
 use crate::config::settings::AggregationStrategy;
-use crate::language::InjectionResolver;
 use crate::lsp::aggregation::server::{
     FanOutTask, HostFanOutTask, dispatch_concatenated, dispatch_host_concatenated,
     dispatch_host_preferred, dispatch_preferred,
 };
 use crate::lsp::bridge::{
     CodeActionEnvelope, HostDocument, RegionOffset, UpstreamCodeActionCaps, bridge_code_actions,
-    extract_code_action_envelope, parse_code_actions_leniently, region_host_end,
+    extract_code_action_envelope, parse_code_actions_leniently,
 };
 
 const METHOD: &str = "textDocument/codeAction";
@@ -300,34 +300,23 @@ impl Kakehashi {
         envelope: &CodeActionEnvelope,
         host_url: &Url,
     ) -> Option<Position> {
-        // Re-resolve the region from the LIVE parse (same construction as the
-        // goto/showDocument offset path), yielding the current per-line offset
-        // and virtual content used to derive the exact mapped host end.
-        let snapshot = self.documents.get(host_url)?.snapshot()?;
-        let language_name = detect_document_language(&self.language, &self.documents, host_url)?;
-        let injection_query = self.language.injection_query(&language_name)?;
-        let resolved = InjectionResolver::resolve_by_region_id(
+        // Re-resolve the region from the LIVE parse (the same construction the
+        // goto/showDocument/applyEdit offset paths use), yielding the current
+        // per-line offset and the exact mapped host end.
+        let (live_offset, region_end, contiguous) = resolve_region_offset(
+            &self.documents,
             &self.language,
-            self.bridge.node_tracker(),
+            &self.bridge,
             host_url,
-            snapshot.tree(),
-            snapshot.text(),
-            injection_query.as_ref(),
             &envelope.region_id,
-            snapshot.incarnation(),
         )?;
         // The action may have been created while a single combined capture was
         // contiguous, then resolved after another capture introduced a masked
         // host gap. The stable first-region ID/offset alone cannot detect that
         // geometry change, so re-check live edit safety here.
-        if !resolved.contiguous {
+        if !contiguous {
             return None;
         }
-        let live_offset = RegionOffset::with_per_line_offsets(
-            resolved.region.line_range.start,
-            resolved.line_column_offsets,
-        );
-        let region_end = region_host_end(&resolved.virtual_content, &live_offset);
         // Compare the WHOLE offset, not just the start: a diverged interior
         // per-line column offset (e.g. a blockquote-prefix edit that left the
         // start line intact) would translate the resolved edit to wrong host

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -260,13 +260,10 @@ impl Kakehashi {
     /// bound the edit (the exact virtual-content end mapped through the live
     /// per-line offset, matching applyEdit).
     ///
-    /// Known limitation (shared with `code_lens_region_is_fresh`): for
-    /// injections whose queries apply `#offset!` (today only YAML/TOML
-    /// frontmatter in the bundled markdown queries), the envelope offset is
-    /// `#offset!`-adjusted while the live resolution isn't, so the comparison
-    /// never matches and resolve always fails soft for those regions. That errs
-    /// in the safe direction (the action stays unresolved) and frontmatter code
-    /// actions have no known real-world producer; revisit if one appears.
+    /// The live resolution applies the injection query's `#offset!` / `#trim!`
+    /// directives exactly as minting did, so a region under one of them
+    /// (markdown frontmatter, blockquote prose) compares equal while unchanged
+    /// and its actions resolve.
     fn code_action_region_end_if_fresh(
         &self,
         envelope: &CodeActionEnvelope,

--- a/src/lsp/lsp_impl/text_document/code_lens.rs
+++ b/src/lsp/lsp_impl/text_document/code_lens.rs
@@ -3,13 +3,10 @@
 
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{CodeLens, CodeLensParams};
-use ulid::Ulid;
-use url::Url;
 
 use super::super::Kakehashi;
-use crate::lsp::bridge::{CodeLensEnvelope, envelope_host_code_lenses, extract_code_lens_envelope};
+use crate::lsp::bridge::{envelope_host_code_lenses, extract_code_lens_envelope};
 use crate::lsp::current_upstream_id;
-use crate::text::PositionMapper;
 
 impl Kakehashi {
     pub(crate) async fn code_lens_impl(
@@ -71,7 +68,13 @@ impl Kakehashi {
         // Fail-soft staleness gate: resolving against a moved or invalidated
         // region would translate coordinates with a stale offset and bind the
         // lens to content the user has since edited.
-        if !envelope.is_host_layer() && !self.code_lens_region_is_fresh(&envelope) {
+        if !envelope.is_host_layer()
+            && !self.region_offset_is_fresh(
+                &envelope.host_uri,
+                &envelope.region_id,
+                &envelope.offset,
+            )
+        {
             log::debug!(
                 target: "kakehashi::bridge",
                 "codeLens/resolve: region {} is stale; returning lens unresolved",
@@ -98,48 +101,5 @@ impl Kakehashi {
             },
             None => Ok(dispatch.await),
         }
-    }
-
-    /// Whether the envelope's injection region still exists at the position it
-    /// had when the lens was minted.
-    ///
-    /// The node tracker's edit-adjusted lookup answers "does the region still
-    /// exist" (a `None` covers invalidation, close, and unknown ULIDs alike);
-    /// comparing the region's CURRENT start position against the envelope's
-    /// offset snapshot additionally catches regions that survived an edit but
-    /// moved — the lens coordinates (and the snapshot offset) are stale then,
-    /// so resolution must fail soft rather than translate wrongly.
-    ///
-    /// Known limitation: for injections whose queries apply `#offset!` (today
-    /// only YAML/TOML frontmatter in the bundled markdown queries), the
-    /// envelope offset is `#offset!`-adjusted while the tracker stores the raw
-    /// content-node position, so this comparison never matches and resolve
-    /// always fails soft for those regions. That errs in the safe direction
-    /// (lenses stay unresolved — still strictly better than the pre-#355
-    /// behavior of dropping them) and frontmatter code lenses have no known
-    /// real-world producer; revisit if one appears.
-    fn code_lens_region_is_fresh(&self, envelope: &CodeLensEnvelope) -> bool {
-        let Ok(uri) = Url::parse(&envelope.host_uri) else {
-            return false;
-        };
-        let Ok(ulid) = envelope.region_id.parse::<Ulid>() else {
-            return false;
-        };
-        let Some((start_byte, _end, _kind, tracked_incarnation)) =
-            self.bridge.node_tracker().lookup_position(&uri, &ulid)
-        else {
-            return false;
-        };
-        let Some(doc) = self.documents.get(&uri) else {
-            return false;
-        };
-        if doc.incarnation() != tracked_incarnation {
-            return false;
-        }
-        let mapper = PositionMapper::new(doc.text());
-        let Some(position) = mapper.byte_to_position(start_byte) else {
-            return false;
-        };
-        position.line == envelope.offset.line && position.character == envelope.offset.column
     }
 }

--- a/src/lsp/lsp_impl/text_document/document_link.rs
+++ b/src/lsp/lsp_impl/text_document/document_link.rs
@@ -1,15 +1,10 @@
 //! Document link method for Kakehashi.
 
+use super::super::Kakehashi;
+use crate::lsp::bridge::{envelope_host_document_links, extract_document_link_envelope};
+use crate::lsp::current_upstream_id;
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{DocumentLink, DocumentLinkParams};
-use url::Url;
-
-use super::super::Kakehashi;
-use super::super::region_offset::resolve_region_offset;
-use crate::lsp::bridge::{
-    DocumentLinkEnvelope, envelope_host_document_links, extract_document_link_envelope,
-};
-use crate::lsp::current_upstream_id;
 
 impl Kakehashi {
     pub(crate) async fn document_link_impl(
@@ -62,7 +57,13 @@ impl Kakehashi {
         let Some(envelope) = extract_document_link_envelope(&link) else {
             return Ok(link);
         };
-        if !envelope.is_host_layer() && !self.document_link_region_is_fresh(&envelope) {
+        if !envelope.is_host_layer()
+            && !self.region_offset_is_fresh(
+                &envelope.host_uri,
+                &envelope.region_id,
+                &envelope.offset,
+            )
+        {
             return Ok(link);
         }
 
@@ -84,21 +85,5 @@ impl Kakehashi {
             },
             None => Ok(dispatch.await),
         }
-    }
-
-    fn document_link_region_is_fresh(&self, envelope: &DocumentLinkEnvelope) -> bool {
-        let Ok(uri) = Url::parse(&envelope.host_uri) else {
-            return false;
-        };
-        resolve_region_offset(
-            &self.documents,
-            &self.language,
-            &self.bridge,
-            &uri,
-            &envelope.region_id,
-        )
-        .is_some_and(|(offset, _, _)| {
-            offset == crate::lsp::bridge::RegionOffset::from(&envelope.offset)
-        })
     }
 }

--- a/src/lsp/lsp_impl/text_document/document_link.rs
+++ b/src/lsp/lsp_impl/text_document/document_link.rs
@@ -1,10 +1,11 @@
 //! Document link method for Kakehashi.
 
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::ls_types::{DocumentLink, DocumentLinkParams};
+
 use super::super::Kakehashi;
 use crate::lsp::bridge::{envelope_host_document_links, extract_document_link_envelope};
 use crate::lsp::current_upstream_id;
-use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::{DocumentLink, DocumentLinkParams};
 
 impl Kakehashi {
     pub(crate) async fn document_link_impl(

--- a/tests/e2e/e2e_code_action.rs
+++ b/tests/e2e/e2e_code_action.rs
@@ -78,6 +78,14 @@ fn init_client_mode(
     mock_mode: &str,
     client_capabilities: Value,
 ) -> (LspClient, Value, tempfile::TempDir) {
+    init_client_mode_for_language(mock_mode, "lua", client_capabilities)
+}
+
+fn init_client_mode_for_language(
+    mock_mode: &str,
+    language: &str,
+    client_capabilities: Value,
+) -> (LspClient, Value, tempfile::TempDir) {
     let bin = mock_formatter_bin();
     let config_dir = tempfile::TempDir::new().expect("Failed to create config temp dir");
     let config_path = config_dir.path().join("code_action.toml");
@@ -96,7 +104,7 @@ fn init_client_mode(
             "capabilities": client_capabilities,
             "workspaceFolders": null,
             "initializationOptions": { "languageServers": {
-                "mock-codeaction": { "cmd": [bin, mock_mode], "languages": ["lua"] }
+                "mock-codeaction": { "cmd": [bin, mock_mode], "languages": [language] }
             }}
         }),
     );
@@ -1097,6 +1105,69 @@ fn lazy_action_is_resolved_via_code_action_resolve() {
     // restored the unsuffixed original before forwarding the resolve — if it
     // forwarded the suffixed title, this would be "organized:... — mock-codeaction".
     assert_eq!(edits[0]["newText"], "organized:Lazy organize imports");
+
+    shutdown(&mut client);
+}
+
+/// A lazy action minted inside a region whose injection query applies
+/// `#offset!` (markdown YAML frontmatter: the content node spans the `---`
+/// fences, the effective region starts one line below) resolves like any
+/// other. The freshness gate compares the envelope's effective offset against
+/// the region's LIVE effective offset, so the unchanged region is fresh and
+/// the resolved edit lands on the host frontmatter line.
+#[test]
+fn lazy_action_resolves_inside_offset_frontmatter_region() {
+    let (mut client, init_response, _config_dir) =
+        init_client_mode_for_language("code-action-lazy", "yaml", resolve_support_caps());
+    assert_advertised(&init_response);
+    let uri = "file:///test_code_action_frontmatter.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({ "textDocument": {
+            "uri": uri,
+            "languageId": "markdown",
+            "version": 1,
+            "text": "---\ntitle: test\n---\n"
+        }}),
+    );
+
+    let mut lazy = None;
+    for _ in 0..300 {
+        let response = client.send_request(
+            "textDocument/codeAction",
+            json!({
+                "textDocument": { "uri": uri },
+                "range": {
+                    "start": { "line": 1, "character": 0 },
+                    "end": { "line": 1, "character": 5 }
+                },
+                "context": { "diagnostics": [] }
+            }),
+        );
+        if let Some(actions) = response["result"].as_array()
+            && let Some(action) = actions.first()
+        {
+            lazy = Some(action.clone());
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let lazy = lazy.expect("textDocument/codeAction never returned the lazy action");
+    assert_eq!(
+        lazy["data"]["kakehashi"]["offset"]["line"],
+        json!(1),
+        "the envelope carries the #offset!-adjusted region start; got: {lazy:?}"
+    );
+
+    let resolved = client.send_request("codeAction/resolve", lazy.clone());
+    let resolved = &resolved["result"];
+    let edits = &resolved["edit"]["changes"][uri];
+    assert!(
+        edits.is_array(),
+        "an unchanged #offset! region is fresh, so the edit must materialize on the host; got: {resolved:?}"
+    );
+    // Virtual line 0 = host line 1 (the frontmatter body below the fence).
+    assert_eq!(edits[0]["range"]["start"]["line"], 1);
 
     shutdown(&mut client);
 }

--- a/tests/e2e/e2e_code_lens_resolve.rs
+++ b/tests/e2e/e2e_code_lens_resolve.rs
@@ -25,6 +25,13 @@ fn init_client() -> (LspClient, tempfile::TempDir) {
 }
 
 fn init_client_with_mode(mode: &str) -> (LspClient, tempfile::TempDir) {
+    init_client_with_mode_and_language(mode, "lua")
+}
+
+fn init_client_with_mode_and_language(
+    mode: &str,
+    language: &str,
+) -> (LspClient, tempfile::TempDir) {
     let bin = mock_formatter_bin();
     let config_dir = tempfile::TempDir::new().expect("Failed to create config temp dir");
     let config_path = config_dir.path().join("code_lens_resolve.toml");
@@ -43,7 +50,7 @@ fn init_client_with_mode(mode: &str) -> (LspClient, tempfile::TempDir) {
             "capabilities": {},
             "workspaceFolders": null,
             "initializationOptions": { "languageServers": {
-                "mock-codelens": { "cmd": [bin, mode], "languages": ["lua"] }
+                "mock-codelens": { "cmd": [bin, mode], "languages": [language] }
             }}
         }),
     );
@@ -132,19 +139,21 @@ fn open_markdown(client: &mut LspClient) {
     std::thread::sleep(Duration::from_millis(1000));
 }
 
-/// Issue `textDocument/codeLens` until a non-empty result satisfies `accept`,
-/// retrying while the result is null (cold downstream still handshaking),
-/// empty (region not resolved yet), or rejected by `accept`. One bounded
-/// loop: a caller's condition must not multiply the retry budget.
+/// Issue `textDocument/codeLens` for `uri` until a non-empty result
+/// satisfies `accept`, retrying while the result is null (cold downstream
+/// still handshaking), empty (region not resolved yet), or rejected by
+/// `accept`. One bounded loop: a caller's condition must not multiply the
+/// retry budget.
 fn code_lenses_until(
     client: &mut LspClient,
+    uri: &str,
     accept: impl Fn(&[Value]) -> bool,
     waiting_for: &str,
 ) -> Vec<Value> {
     for _ in 0..300 {
         let response = client.send_request(
             "textDocument/codeLens",
-            json!({ "textDocument": { "uri": MARKDOWN_URI } }),
+            json!({ "textDocument": { "uri": uri } }),
         );
         assert!(
             response.get("error").is_none(),
@@ -166,8 +175,14 @@ fn code_lenses_until(
     panic!("timed out waiting for {waiting_for}");
 }
 
+/// Issue `textDocument/codeLens` for the shared markdown fixture, retrying
+/// while the result is null (cold downstream still handshaking).
 fn code_lens_with_retry(client: &mut LspClient) -> Vec<Value> {
-    code_lenses_until(client, |_| true, "a non-empty codeLens result")
+    code_lens_with_retry_for(client, MARKDOWN_URI)
+}
+
+fn code_lens_with_retry_for(client: &mut LspClient, uri: &str) -> Vec<Value> {
+    code_lenses_until(client, uri, |_| true, "a non-empty codeLens result")
 }
 
 /// Poll `textDocument/codeLens` until the lens names a producer other than
@@ -176,6 +191,7 @@ fn code_lens_with_retry(client: &mut LspClient) -> Vec<Value> {
 fn replacement_code_lens_with_retry(client: &mut LspClient, old_envelope: &Value) -> Value {
     code_lenses_until(
         client,
+        MARKDOWN_URI,
         |lenses| {
             let envelope = &lenses[0]["data"]["kakehashi"];
             envelope["connection_key"] != old_envelope["connection_key"]
@@ -258,6 +274,45 @@ fn e2e_code_lens_resolve_round_trips_to_origin_server() {
         stale["data"]["kakehashi"]["origin"], "mock-codelens",
         "fail-soft must return the lens with its routing envelope intact; got: {stale:?}"
     );
+
+    shutdown(&mut client);
+}
+
+/// A region whose injection query applies `#offset!` (markdown YAML
+/// frontmatter: the content node spans the `---` fences, the effective
+/// region starts one line below) must resolve like any other region. The
+/// freshness gate compares the envelope's effective offset against the
+/// region's LIVE effective offset, not its raw node position, so the
+/// unchanged region is fresh and the lens comes back with its command.
+#[test]
+fn e2e_code_lens_resolve_accepts_offset_frontmatter_region() {
+    let (mut client, _config_dir) = init_client_with_mode_and_language("code-lens", "yaml");
+    let uri = "file:///test_code_lens_resolve_frontmatter.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({ "textDocument": {
+            "uri": uri,
+            "languageId": "markdown",
+            "version": 1,
+            "text": "---\ntitle: test\n---\n"
+        }}),
+    );
+
+    let lens = code_lens_with_retry_for(&mut client, uri).remove(0);
+    assert_eq!(
+        lens["range"]["start"],
+        json!({ "line": 1, "character": 0 }),
+        "the mock's virtual line 0 is the frontmatter body on host line 1; got: {lens:?}"
+    );
+
+    let response = client.send_request("codeLens/resolve", lens.clone());
+    assert!(response.get("error").is_none(), "{response}");
+    let resolved = &response["result"];
+    assert_eq!(
+        resolved["command"]["title"], "mock resolved:lens-1",
+        "an unchanged #offset! region is fresh, so resolve must reach the origin; got: {resolved:?}"
+    );
+    assert_eq!(resolved["range"], lens["range"]);
 
     shutdown(&mut client);
 }


### PR DESCRIPTION
## Summary

`codeLens/resolve` reported every lens inside an `#offset!` / `#trim!` region (markdown YAML/TOML frontmatter, blockquote prose) as stale and returned it unresolved: its freshness gate compared the envelope's **effective** offset snapshot against the **raw** start byte of the tracked content node, and the two never agree once a directive shifts the region. `documentLink/resolve` already compared effective geometry (re-resolving the region through `resolve_region_offset`) and was correct.

Closes #1044

## What changed

- **One freshness gate.** `Kakehashi::region_offset_is_fresh(host_uri, region_id, offset)` lives next to `resolve_region_offset` and is the only resolve-side "is this region still where the envelope says" check; `codeLens/resolve` and `documentLink/resolve` both call it. It compares the whole effective `RegionOffset` (start line plus every per-line column offset), so an interior blockquote-prefix edit is also caught for lenses now, not just a moved start.
- **codeAction/resolve rebuilds its region the same way.** Its private copy of the snapshot → language → query → resolver → offset/end derivation is replaced by `resolve_region_offset`; the contiguity and whole-offset checks are unchanged.
- **Docs.** The "known limitation: frontmatter lenses/actions always fail soft" paragraphs on the code-lens and code-action gates are gone. The code-action one was already false (its live resolution was `#offset!`-adjusted all along); the region_offset module doc now lists the resolve gates among its callers.
- Unused `CodeLensEnvelope` / `DocumentLinkEnvelope` / `EnvelopeOffset` re-exports adjusted accordingly.

## Tests

- `e2e_code_lens_resolve_accepts_offset_frontmatter_region` (RED on main: lens at host line 1 comes back command-less; GREEN here: `mock resolved:lens-1`).
- `lazy_action_resolves_inside_offset_frontmatter_region` pins the code-action gate's frontmatter behaviour so it cannot regress to a raw-node comparison.
- Existing `e2e_code_lens_resolve` cases (shifted region fails soft, replaced producer, closed incarnation, cancel) and the document-link/code-action suites unchanged and passing; full e2e suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhEfVnacTxTiURX5ftDwmn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution of code actions and code lenses in offset-adjusted regions, including Markdown frontmatter.
  * Added consistent freshness checks for code lenses and document links to prevent stale results from being applied.
  * Fixed cases where valid actions in offset regions were incorrectly rejected during resolution.

* **Tests**
  * Added end-to-end coverage for resolving code actions and code lenses in offset-adjusted regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->