### PR TITLE
feat(language): read Neovim query modelines and merge `;; extends` overlays across searchPaths

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Provides LSP semantic tokens based on Tree-sitter `highlights.scm` queries. Work
 
 - Supports language injection (e.g., SQL in JavaScript template strings, code blocks in Markdown)
 - Uses nvim-treesitter query files for compatibility
-- Supports query inheritance (e.g., TypeScript inherits from `ecma`)
+- Supports Neovim's query modelines: `; inherits:` (e.g., TypeScript inherits from `ecma`) and `;; extends` overlays
 
 ### Selection Range
 
@@ -283,7 +283,8 @@ Array of base directories to search for parsers and queries. If not specified, u
 **Important:** Specify base directories, not subdirectories. The resolver automatically appends `parser/` and `queries/` subdirectories.
 
 Parsers are searched as `{searchPath}/parser/{language}.{so,dylib,dll}`.
-Queries are searched as `{searchPath}/queries/{language}/{query_type}.scm`.
+Queries are searched as `{searchPath}/queries/{language}/{query_type}.scm`;
+see [Query modelines](#query-modelines) for how several hits combine.
 For implicit lookup, `{language}` must be one normal path component: values
 containing a path separator or a `.`/`..` component do not resolve, and on
 Windows neither do drive (`C:\…`) or UNC (`\\server\share\…`) prefixes. This
@@ -302,11 +303,57 @@ Then list each kind you need under `languages[*].queries[*].path`. Supplying
 `queries` at all disables the implicit lookup for the kinds you leave out, and
 only `highlights`, `injections`, and `bindings` can be given an explicit path.
 
-`; inherits:` is resolved only for implicitly located queries. A query file
-given an explicit path is loaded as-is, so an `; inherits:` line in it is inert
-— tree-sitter reads it as a comment and the parent's patterns are silently
-absent. Inherit only from queries that follow the implicit layout, whose parent
-is itself resolved by language name and so must follow it too.
+Modelines are resolved only for implicitly located queries. A query file
+given an explicit path is loaded as-is, so an `; inherits:` or `;; extends`
+line in it is inert — tree-sitter reads it as a comment, and the parent's
+patterns are silently absent. Inherit only from queries that follow the
+implicit layout, whose parent is itself resolved by language name and so must
+follow it too. Explicit paths of one kind are concatenated in the order
+listed, which is the explicit-path way to layer an overlay.
+
+#### Query modelines
+
+kakehashi reads the comment modelines Neovim documents under
+`:h treesitter-query-modeline`, with Neovim's grammar: any run of `;`, any
+spacing, the colon after `inherits` optional, and directives may repeat. The
+modeline block is the run of `;` lines at the top of the file; the first line
+that does not start with `;` — a blank line included — ends it.
+
+```query
+;; inherits: ecma,jsx
+;; extends
+```
+
+`inherits: {lang},...` prepends the named languages' query of the same kind,
+each resolved through this same lookup (so a parent brings its own parents and
+overlays). A cycle is an error. A parenthesized name (`(cpp)`) is read as the
+bare name; Neovim uses the parentheses to stop recursion when the file is
+itself being inherited, which kakehashi does not distinguish.
+
+`extends` marks the file as an overlay to merge onto the language's query
+instead of replacing it. Across `searchPaths`, in order, the first file
+*without* `extends` is the base query and any later plain file is shadowed
+(logged at debug level); every file *with* `extends` is appended after the
+base, in search-path order. The combined query is therefore
+`inherited parents, base, overlays`. A language whose only files are overlays
+loads them alone, as Neovim does.
+
+So to add patterns to a language without copying its query, put an overlay in
+a search path of your own:
+
+```toml
+searchPaths = ["~/.config/kakehashi", "~/.local/share/kakehashi"]
+```
+
+```query
+;; ~/.config/kakehashi/queries/markdown/highlights.scm
+;; extends
+((inline) @markup.raw (#match? @markup.raw "^TODO"))
+```
+
+The overlay's position in `searchPaths` does not matter for the merge order,
+only for which plain file is the base. Diagnostics for a skipped pattern in a
+combined query quote line numbers of the combined text, not of any one file.
 
 #### `languages`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -331,9 +331,11 @@ a parent that fails to load.
 
 `inherits: {lang},...` prepends the named languages' query of the same kind,
 each resolved through this same lookup (so a parent brings its own parents and
-overlays). A cycle is an error. A parenthesized name (`(cpp)`) is read as the
-bare name; Neovim uses the parentheses to stop recursion when the file is
-itself being inherited, which kakehashi does not distinguish.
+overlays). A cycle between languages is an error; naming the file's own
+language is Neovim's older spelling of `extends` and marks the file an
+overlay. A parenthesized name (`(cpp)`) is read as the bare name; Neovim uses
+the parentheses to stop recursion when the file is itself being inherited,
+which kakehashi does not distinguish.
 
 `extends` marks the file as an overlay to merge onto the language's query
 instead of replacing it. Across `searchPaths`, in order, the first file

--- a/docs/README.md
+++ b/docs/README.md
@@ -317,7 +317,12 @@ kakehashi reads the comment modelines Neovim documents under
 `:h treesitter-query-modeline`, with Neovim's grammar: any run of `;`, any
 spacing, the colon after `inherits` optional, and directives may repeat. The
 modeline block is the run of `;` lines at the top of the file; the first line
-that does not start with `;` — a blank line included — ends it.
+that does not start with `;` — a blank line included — ends it. The list
+after `inherits` is one run of comma-separated names with no whitespace in
+it, each name `[a-z0-9_]+` (Neovim's own class has no digits; kakehashi adds
+them for languages such as `m68k`). A `;` line that says anything else after
+the keyword — `; inherits the ecma queries` — is a comment, as in Neovim, not
+a parent that fails to load.
 
 ```query
 ;; inherits: ecma,jsx

--- a/docs/README.md
+++ b/docs/README.md
@@ -335,9 +335,9 @@ still count.
 each resolved through this same lookup (so a parent brings its own parents and
 overlays). A cycle between languages is an error; a file naming its own
 language is read as `extends`, as Neovim's `get_files` reads it, and so marks
-the file an overlay. A parenthesized name (`(cpp)`) is read as the bare name;
-Neovim uses the parentheses to stop recursion when the file is itself being
-inherited, which kakehashi does not distinguish.
+the file an overlay. A parenthesized name, `(cpp)`, is inherited only when
+the file is loaded for its own language: a file reached as someone else's
+parent skips its parenthesized parents, as in Neovim, so a chain stops there.
 
 `extends` marks the file as an overlay to merge onto the language's query
 instead of replacing it. Across `searchPaths`, in order, the first file

--- a/docs/README.md
+++ b/docs/README.md
@@ -1306,7 +1306,11 @@ Some languages inherit queries from base languages (see
 | JavaScript | ecma, jsx |
 | TSX | typescript, jsx |
 
-When you install a language with inheritance, the base queries are automatically downloaded.
+When you install a language with inheritance, the base queries its
+`highlights.scm` and `injections.scm` name are downloaded with it. Those are
+the only kinds the installer fetches: a parent named by `bindings.scm`, by a
+captures kind, or by an overlay on another search path must be put on a search
+path by hand (see [Query modelines](#query-modelines)).
 
 ## Logging
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -333,11 +333,12 @@ still count.
 
 `inherits: {lang},...` prepends the named languages' query of the same kind,
 each resolved through this same lookup (so a parent brings its own parents and
-overlays). A cycle between languages is an error; a file naming its own
-language is read as `extends`, as Neovim's `get_files` reads it, and so marks
-the file an overlay. A parenthesized name, `(cpp)`, is inherited only when
-the file is loaded for its own language: a file reached as someone else's
-parent skips its parenthesized parents, as in Neovim, so a chain stops there.
+overlays). A parenthesized name, `(cpp)`, is inherited only when the file is
+loaded for its own language: a file reached as someone else's parent skips
+its parenthesized parents, as in Neovim, so a chain stops there. Along the
+edges actually followed, a cycle between languages is an error; a file naming
+its own language is read as `extends`, as Neovim's `get_files` reads it, and
+so marks the file an overlay.
 
 `extends` marks the file as an overlay to merge onto the language's query
 instead of replacing it. Across `searchPaths`, in order, the first file
@@ -368,15 +369,15 @@ numbers of the combined text, not of any one file.
 
 Two things stay strict when files combine. Every hit must be readable: a
 dangling symlink or an unreadable file in any search path fails the language's
-query, as it would as the only hit, rather than loading without it. And a
-parent must exist as the same kind of file: `child/context.scm` inheriting
-`foo` needs a `foo/context.scm` on some search path. Auto-install fetches the
-parents named by the `highlights.scm` and `injections.scm` it installs into
-the data directory — those two kinds only, and not parents named by an
-overlay elsewhere — so a parent that only your overlay names, or that a
-`bindings.scm` or a captures kind names, must be put on a search path by
-hand or the query fails to load with a message naming the file that named
-it.
+query, as it would as the only hit, rather than loading without it. And every
+parent actually followed must exist as the same kind of file:
+`child/context.scm` inheriting `foo` needs a `foo/context.scm` on some search
+path. Auto-install fetches the parents named by the `highlights.scm` and
+`injections.scm` it installs into the data directory — those two kinds only,
+and not parents named by an overlay elsewhere — so a parent that only your
+overlay names, or that a `bindings.scm` or a captures kind names, must be put
+on a search path by hand or the query fails to load with a message naming the
+file that named it.
 
 #### `languages`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -322,7 +322,9 @@ after `inherits` is one run of comma-separated names with no whitespace in
 it, each name `[a-z0-9_]+` (Neovim's own class has no digits; kakehashi adds
 them for languages such as `m68k`). A `;` line that says anything else after
 the keyword — `; inherits the ecma queries` — is a comment, as in Neovim, not
-a parent that fails to load.
+a parent that fails to load; within a list, an entry that is no name (a stray
+trailing comma, an unmatched parenthesis) is skipped and the names beside it
+still count.
 
 ```query
 ;; inherits: ecma,jsx

--- a/docs/README.md
+++ b/docs/README.md
@@ -369,10 +369,14 @@ numbers of the combined text, not of any one file.
 Two things stay strict when files combine. Every hit must be readable: a
 dangling symlink or an unreadable file in any search path fails the language's
 query, as it would as the only hit, rather than loading without it. And a
-parent must exist: auto-install fetches the parents named by the queries it
-installs into the data directory, not those named by an overlay elsewhere, so
-a parent that only your overlay names must be installed by hand or the query
-fails to load with a message naming the overlay.
+parent must exist as the same kind of file: `child/context.scm` inheriting
+`foo` needs a `foo/context.scm` on some search path. Auto-install fetches the
+parents named by the `highlights.scm` and `injections.scm` it installs into
+the data directory — those two kinds only, and not parents named by an
+overlay elsewhere — so a parent that only your overlay names, or that a
+`bindings.scm` or a captures kind names, must be put on a search path by
+hand or the query fails to load with a message naming the file that named
+it.
 
 #### `languages`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -346,10 +346,11 @@ base, in search-path order. The combined query is therefore
 loads them alone, as Neovim does.
 
 So to add patterns to a language without copying its query, put an overlay in
-a search path of your own:
+a search path of your own. `searchPaths` replaces the default list, so keep
+the data directory in it:
 
 ```toml
-searchPaths = ["~/.config/kakehashi", "~/.local/share/kakehashi"]
+searchPaths = ["~/.config/kakehashi", "${KAKEHASHI_DATA_DIR}"]
 ```
 
 ```query
@@ -358,9 +359,18 @@ searchPaths = ["~/.config/kakehashi", "~/.local/share/kakehashi"]
 ((inline) @markup.raw (#match? @markup.raw "^TODO"))
 ```
 
-The overlay's position in `searchPaths` does not matter for the merge order,
-only for which plain file is the base. Diagnostics for a skipped pattern in a
-combined query quote line numbers of the combined text, not of any one file.
+An overlay follows the base wherever it sits in `searchPaths`; position
+decides only which plain file is the base (the first) and the order among
+overlays. Diagnostics for a skipped pattern in a combined query quote line
+numbers of the combined text, not of any one file.
+
+Two things stay strict when files combine. Every hit must be readable: a
+dangling symlink or an unreadable file in any search path fails the language's
+query, as it would as the only hit, rather than loading without it. And a
+parent must exist: auto-install fetches the parents named by the queries it
+installs into the data directory, not those named by an overlay elsewhere, so
+a parent that only your overlay names must be installed by hand or the query
+fails to load with a message naming the overlay.
 
 #### `languages`
 
@@ -1280,7 +1290,8 @@ Run `kakehashi language list` for the complete list.
 
 ## Query Inheritance
 
-Some languages inherit queries from base languages:
+Some languages inherit queries from base languages (see
+[Query modelines](#query-modelines) for how the loader reads the directive):
 
 | Language | Inherits From |
 |----------|---------------|

--- a/docs/README.md
+++ b/docs/README.md
@@ -334,10 +334,10 @@ still count.
 `inherits: {lang},...` prepends the named languages' query of the same kind,
 each resolved through this same lookup (so a parent brings its own parents and
 overlays). A cycle between languages is an error; a file naming its own
-language is read as `extends`, as Neovim's `get_files` reads it, and so
-marks the file an overlay. A parenthesized name (`(cpp)`) is read as the bare name; Neovim uses
-the parentheses to stop recursion when the file is itself being inherited,
-which kakehashi does not distinguish.
+language is read as `extends`, as Neovim's `get_files` reads it, and so marks
+the file an overlay. A parenthesized name (`(cpp)`) is read as the bare name;
+Neovim uses the parentheses to stop recursion when the file is itself being
+inherited, which kakehashi does not distinguish.
 
 `extends` marks the file as an overlay to merge onto the language's query
 instead of replacing it. Across `searchPaths`, in order, the first file

--- a/docs/README.md
+++ b/docs/README.md
@@ -333,9 +333,9 @@ still count.
 
 `inherits: {lang},...` prepends the named languages' query of the same kind,
 each resolved through this same lookup (so a parent brings its own parents and
-overlays). A cycle between languages is an error; naming the file's own
-language is Neovim's older spelling of `extends` and marks the file an
-overlay. A parenthesized name (`(cpp)`) is read as the bare name; Neovim uses
+overlays). A cycle between languages is an error; a file naming its own
+language is read as `extends`, as Neovim's `get_files` reads it, and so
+marks the file an overlay. A parenthesized name (`(cpp)`) is read as the bare name; Neovim uses
 the parentheses to stop recursion when the file is itself being inherited,
 which kakehashi does not distinguish.
 

--- a/docs/architecture-decisions/captures-protocol.md
+++ b/docs/architecture-decisions/captures-protocol.md
@@ -70,7 +70,7 @@ type CapturesRangeResult = { matches: Match[]; skipped: SkippedPattern[] };
 
 type SkippedPattern = { language: string; startLine: number; endLine: number; reason: string };
 // startLine/endLine are 1-indexed lines in the query file — or in the combined
-// query string when `; inherits:` is used (the loader concatenates parents first).
+// query string when several files combine (the loader concatenates `inherits` parents, then the base, then `extends` overlays).
 ```
 
 `language` is present on every match — including host-only requests — so the
@@ -113,7 +113,7 @@ nvim-treesitter.
 
 ### Kind resolution
 
-`kind` names a query file: the server resolves `queries/<language>/<kind>.scm` across its configured `searchPaths` (first hit wins), honoring `; inherits:` directives and tolerant per-pattern compilation — the identical pipeline used for highlights/bindings/injections. `kind` is validated as `[A-Za-z0-9_-]+`; anything else (path separators, dots) is rejected as `InvalidParams` before touching the filesystem. The fixed `QueryKind` enum remains an internal detail of config-time loading; this protocol deliberately does **not** extend it, so available kinds are defined purely by what files exist — enabling a future `kakehashi/captures/kinds` discovery method with no protocol change.
+`kind` names a query file: the server resolves `queries/<language>/<kind>.scm` across its configured `searchPaths` (the first plain file is the base; `;; extends` overlays in any search path merge onto it), honoring `inherits` modelines and tolerant per-pattern compilation — the identical pipeline used for highlights/bindings/injections. `kind` is validated as `[A-Za-z0-9_-]+`; anything else (path separators, dots) is rejected as `InvalidParams` before touching the filesystem. The fixed `QueryKind` enum remains an internal detail of config-time loading; this protocol deliberately does **not** extend it, so available kinds are defined purely by what files exist — enabling a future `kakehashi/captures/kinds` discovery method with no protocol change.
 
 ### The `injection` parameter
 

--- a/docs/architecture-decisions/captures-protocol.md
+++ b/docs/architecture-decisions/captures-protocol.md
@@ -20,7 +20,7 @@ A first iteration shipped `kakehashi/query`: a one-shot method taking a **client
 * **Live-consumer economy**: repeat requests (cursor move, scroll, edit) must not resend the query or the full unchanged result.
 * **Server-owned, dynamically discovered kinds**: the query is named by a free-form `kind` resolved as `queries/<lang>/<kind>.scm` from `searchPaths` — *not* a hard-coded enum — so new kinds appear by dropping files into a search path, and a future method can enumerate available kinds from the directory structure.
 * **Match correlation preserved**: `@context` and `@context.end` within one pattern must stay grouped; a flat capture stream loses which `.end` bounds which `@context`.
-* **Reuse proven mechanics**: the semanticTokens `full`/`delta`/`range` interaction model, the existing tolerant query compilation (`; inherits:`, per-pattern skip), predicate evaluation, ULID minting, and the prefix/suffix single-edit delta algorithm.
+* **Reuse proven mechanics**: the semanticTokens `full`/`delta`/`range` interaction model, the existing tolerant query compilation (`inherits`/`extends` modelines, per-pattern skip), predicate evaluation, ULID minting, and the prefix/suffix single-edit delta algorithm.
 * **Minimal API surface**: one protocol for query execution; `kakehashi/query` is replaced, not kept alongside.
 * **Raw capture identity**: capture names on this protocol are the query's names
   after removing `@`; semantic-token `captureMappings` never renames or filters

--- a/docs/architecture-decisions/lexical-name-resolution.md
+++ b/docs/architecture-decisions/lexical-name-resolution.md
@@ -409,7 +409,7 @@ the miss policy keeps the resolver silent.
 * The dead `QueryKind::Locals` pipeline is retired instead of accumulating
   semantics by accident.
 * Query loading reuses the proven captures-protocol machinery wholesale:
-  `searchPaths` resolution, `; inherits:`, tolerant per-pattern compilation,
+  `searchPaths` resolution, `inherits`/`extends` modelines, tolerant per-pattern compilation,
   static `#set!` parsing.
 
 ### Negative
@@ -487,7 +487,7 @@ Implemented: `QueryKind::Bindings` replaces the removed `Locals` end-to-end
 resolution algorithm; the native layer feeds
 definition/references/documentHighlight/rename/prepareRename through the
 cross-layer walk's `native` slot. `bindings.scm` files load from
-`searchPaths` like any other query asset, with per-file `; inherits:`
+`searchPaths` like any other query asset, with per-file `inherits`/`extends`
 resolution; experimental queries for
 bash/go/javascript/lua/python/rust/typescript live in-repo under
 `assets/queries/` (not bundled into the binary), validated by fixture

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -486,7 +486,7 @@ extraction, fold-range computation, or a
 The query itself is **not sent by the client**. A `kind` (e.g. `"context"`) names a
 per-language query file, resolved as `queries/<language>/<kind>.scm` across the
 configured `searchPaths` — the same place highlight queries live, with the same
-`; inherits:` support. Drop a file into a search path and the kind exists; no
+`inherits`/`extends` modeline support. Drop a file into a search path and the kind exists; no
 server configuration needed. (nvim-treesitter-context's own `context.scm` files
 work as-is once their directory is on a search path.)
 
@@ -511,7 +511,7 @@ type CapturesResult = {
   skipped: {                         // patterns dropped by tolerant compilation
     language: string;                // which language's kind file had the problem
     startLine: number;               // 1-indexed; in the query file — or in the
-    endLine: number;                 // combined query when `; inherits:` is used
+    endLine: number;                 // combined query when several files combine
     reason: string;                  // Tree-sitter's compile error for that pattern
   }[];
 };

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -162,9 +162,12 @@ fn inherited_languages_on_disk(queries_dir: &Path) -> Option<Vec<String>> {
             // saw, so say the chain cannot be determined instead.
             Err(_) => return None,
         };
+        // An optional parent, `(cpp)`, is skipped by the loader only while
+        // the file is itself being inherited; loaded for its own language it
+        // is needed, so the chain counts it.
         for parent in parse_modeline(&content).inherits {
-            if !parents.contains(&parent) {
-                parents.push(parent);
+            if !parents.contains(&parent.name) {
+                parents.push(parent.name);
             }
         }
     }
@@ -944,6 +947,7 @@ fn stage_queries_recursive(
                 // as one named by highlights.scm. A file naming its own
                 // language is read as `extends`, not as a parent.
                 for parent in parse_modeline(&content).inherits {
+                    let parent = parent.name;
                     if parent != language && !parents_to_install.contains(&parent) {
                         parents_to_install.push(parent);
                     }

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -192,9 +192,8 @@ pub(crate) fn lock_complete_chain(data_dir: &Path, language: &str) -> Option<Vec
         guards: &mut Vec<LanguageLock>,
     ) -> bool {
         // A language already on the path — a file naming its own language
-        // (the older `extends` spelling), or an A↔B cycle for the loader to
-        // report — is not a reason to call the install incomplete and
-        // re-download forever.
+        // (read as `extends`), or an A↔B cycle for the loader to report — is
+        // not a reason to call the install incomplete and re-download forever.
         if seen.iter().any(|visited| visited == language) {
             return true;
         }
@@ -943,7 +942,7 @@ fn stage_queries_recursive(
                 // Every query kind resolves its own `; inherits:` chain at load
                 // time, so a parent named by injections.scm is as load-bearing
                 // as one named by highlights.scm. A file naming its own
-                // language is the older `extends` spelling, not a parent.
+                // language is read as `extends`, not as a parent.
                 for parent in parse_modeline(&content).inherits {
                     if parent != language && !parents_to_install.contains(&parent) {
                         parents_to_install.push(parent);
@@ -2990,9 +2989,8 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let data_dir = temp_dir.path().to_path_buf();
 
-        // Self-cycle: a query file inheriting its own language (Neovim's older
-        // spelling of `extends`). No network: both branches hit the
-        // already-exists path.
+        // Self-cycle: a query file inheriting its own language (read as
+        // `extends`). No network: both branches hit the already-exists path.
         let a_dir = data_dir.join("queries").join("cyclic_a");
         fs::create_dir_all(&a_dir).unwrap();
         std::fs::write(a_dir.join("highlights.scm"), "; inherits: cyclic_a\n").unwrap();

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -230,47 +230,26 @@ pub(crate) fn lock_complete_chain(data_dir: &Path, language: &str) -> Option<Vec
     walk(data_dir, language, &mut Vec::new(), &mut guards).then_some(guards)
 }
 
-/// Strip the parentheses nvim-treesitter puts around some inherited names.
-///
-/// Must match what the query loader does with the same line
-/// (`language::query_loader::normalize_inherited_language_name`): the loader
-/// resolves `(cpp)` as `cpp`, so an installer that dropped it as an unsafe name
-/// would report success and leave the loader looking for a language nothing
-/// fetched.
-fn normalize_inherited_language_name(name: &str) -> String {
-    // Character for character what `query_loader` does, including only
-    // stripping a *matched* pair: on `(cpp` the loader looks for a language
-    // literally called `(cpp`, and an installer that helpfully fetched `cpp`
-    // would report success over a language it still cannot load.
-    name.strip_prefix('(')
-        .and_then(|name| name.strip_suffix(')'))
-        .unwrap_or(name)
-        .trim()
-        .to_string()
-}
-
-/// Parse the `; inherits: lang1,lang2` directive from query content.
-/// Returns the list of parent languages, dropping unsafe names
+/// The parents named by the `; inherits:` directive, dropping unsafe names
 /// (see [`is_safe_language_name`]).
+///
+/// Reads the directive through the same parser as the query loader: the loader
+/// resolves `(cpp)` as `cpp`, so an installer that read the line differently
+/// and dropped it as an unsafe name would report success and leave the loader
+/// looking for a language nothing fetched.
 fn parse_inherits_directive(content: &str) -> Vec<String> {
-    let first_line = content.lines().next().unwrap_or("");
-    if let Some(rest) = first_line.strip_prefix("; inherits:") {
-        rest.split(',')
-            .map(|s| normalize_inherited_language_name(s.trim()))
-            .filter(|s| !s.is_empty())
-            .filter(|s| {
-                let safe = is_safe_language_name(s);
-                if !safe {
-                    // Debug-format: the name is untrusted input and could
-                    // smuggle ANSI escapes into the terminal if printed raw.
-                    eprintln!("Warning: ignoring unsafe inherited language name {:?}", s);
-                }
-                safe
-            })
-            .collect()
-    } else {
-        Vec::new()
-    }
+    crate::language::query_modeline::parse_inherits_directive(content)
+        .into_iter()
+        .filter(|s| {
+            let safe = is_safe_language_name(s);
+            if !safe {
+                // Debug-format: the name is untrusted input and could
+                // smuggle ANSI escapes into the terminal if printed raw.
+                eprintln!("Warning: ignoring unsafe inherited language name {:?}", s);
+            }
+            safe
+        })
+        .collect()
 }
 
 /// Download and install query files for a language, including inherited dependencies.

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -191,9 +191,10 @@ pub(crate) fn lock_complete_chain(data_dir: &Path, language: &str) -> Option<Vec
         seen: &mut Vec<String>,
         guards: &mut Vec<LanguageLock>,
     ) -> bool {
-        // An inheritance cycle among on-disk files (a self-inherit typo, A↔B)
-        // is the loader's problem to report, not a reason to call the install
-        // incomplete and re-download forever.
+        // A language already on the path — a file naming its own language
+        // (the older `extends` spelling), or an A↔B cycle for the loader to
+        // report — is not a reason to call the install incomplete and
+        // re-download forever.
         if seen.iter().any(|visited| visited == language) {
             return true;
         }
@@ -893,9 +894,9 @@ fn stage_queries_recursive(
     // as incomplete so a later install can repair it without --force.
     if query_install_is_complete(&queries_dir) && !force {
         // Mark as staged BEFORE recursing into parents: an inheritance
-        // cycle among on-disk query files (self-inherit typo, A↔B) would
-        // otherwise recurse forever and overflow the stack. The download
-        // branch below already inserts before its parent loop.
+        // cycle among on-disk query files (a file naming its own language,
+        // A↔B) would otherwise recurse forever and overflow the stack. The
+        // download branch below already inserts before its parent loop.
         staged.insert(language.to_string());
 
         // Even if skipping, we need to check for inherited dependencies
@@ -941,9 +942,10 @@ fn stage_queries_recursive(
             Ok(content) => {
                 // Every query kind resolves its own `; inherits:` chain at load
                 // time, so a parent named by injections.scm is as load-bearing
-                // as one named by highlights.scm.
+                // as one named by highlights.scm. A file naming its own
+                // language is the older `extends` spelling, not a parent.
                 for parent in parse_modeline(&content).inherits {
-                    if !parents_to_install.contains(&parent) {
+                    if parent != language && !parents_to_install.contains(&parent) {
                         parents_to_install.push(parent);
                     }
                 }
@@ -2988,8 +2990,8 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let data_dir = temp_dir.path().to_path_buf();
 
-        // Self-cycle: a query file inheriting its own language (a one-word
-        // typo in a real highlights.scm). No network: both branches hit the
+        // Self-cycle: a query file inheriting its own language (Neovim's older
+        // spelling of `extends`). No network: both branches hit the
         // already-exists path.
         let a_dir = data_dir.join("queries").join("cyclic_a");
         fs::create_dir_all(&a_dir).unwrap();

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -1,5 +1,6 @@
 //! Query file downloading from nvim-treesitter repository.
 
+use crate::language::query_modeline::parse_modeline;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -132,18 +133,7 @@ pub struct QueryInstallResult {
     pub files_downloaded: Vec<String>,
 }
 
-/// Whether a language name is safe to use as a path and URL segment.
-///
-/// Language names are used as path segments (`queries/<name>/`) and URL
-/// segments, so anything outside nvim-treesitter's `[a-z0-9_]+` naming is
-/// rejected: a name like `../../x` (from a caller or a `; inherits:` line in
-/// a compromised or custom query source) must not escape the data dir.
-pub fn is_safe_language_name(name: &str) -> bool {
-    !name.is_empty()
-        && name
-            .bytes()
-            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_')
-}
+pub use crate::language::query_modeline::is_safe_language_name;
 
 fn validate_safe_language_name(language: &str) -> Result<(), QueryInstallError> {
     if is_safe_language_name(language) {
@@ -172,7 +162,7 @@ fn inherited_languages_on_disk(queries_dir: &Path) -> Option<Vec<String>> {
             // saw, so say the chain cannot be determined instead.
             Err(_) => return None,
         };
-        for parent in parse_inherits_directive(&content) {
+        for parent in parse_modeline(&content).inherits {
             if !parents.contains(&parent) {
                 parents.push(parent);
             }
@@ -228,29 +218,6 @@ pub(crate) fn lock_complete_chain(data_dir: &Path, language: &str) -> Option<Vec
 
     let mut guards = Vec::new();
     walk(data_dir, language, &mut Vec::new(), &mut guards).then_some(guards)
-}
-
-/// The parents named by the `; inherits:` directive, dropping unsafe names
-/// (see [`is_safe_language_name`]).
-///
-/// Reads the directive through the same parser as the query loader: the loader
-/// resolves `(cpp)` as `cpp`, so an installer that read the line differently
-/// and dropped it as an unsafe name would report success and leave the loader
-/// looking for a language nothing fetched.
-fn parse_inherits_directive(content: &str) -> Vec<String> {
-    crate::language::query_modeline::parse_modeline(content)
-        .inherits
-        .into_iter()
-        .filter(|s| {
-            let safe = is_safe_language_name(s);
-            if !safe {
-                // Debug-format: the name is untrusted input and could
-                // smuggle ANSI escapes into the terminal if printed raw.
-                eprintln!("Warning: ignoring unsafe inherited language name {:?}", s);
-            }
-            safe
-        })
-        .collect()
 }
 
 /// Download and install query files for a language, including inherited dependencies.
@@ -975,7 +942,7 @@ fn stage_queries_recursive(
                 // Every query kind resolves its own `; inherits:` chain at load
                 // time, so a parent named by injections.scm is as load-bearing
                 // as one named by highlights.scm.
-                for parent in parse_inherits_directive(&content) {
+                for parent in parse_modeline(&content).inherits {
                     if !parents_to_install.contains(&parent) {
                         parents_to_install.push(parent);
                     }
@@ -2967,46 +2934,32 @@ mod tests {
     }
 
     /// Inherited language names become path segments (`queries/<name>/`) and
-    /// URL segments, so anything outside nvim-treesitter's `[a-z0-9_]+`
-    /// naming must be dropped — `; inherits: ../../x` from a compromised or
-    /// custom query source must not escape the data dir.
-    /// nvim-treesitter parenthesizes some inherited names, and the query loader
-    /// resolves `(cpp)` as `cpp`. An installer that read it any other way would
-    /// report success and leave the loader looking for a language nothing
-    /// fetched.
+    /// URL segments. The modeline grammar itself admits only `[a-z0-9_]+`
+    /// names — a line naming `../../x` is a comment, not a parent — and that
+    /// grammar is the one the query loader reads, so what the installer walks
+    /// is exactly what the loader will look for, in every form Neovim
+    /// accepts: repeated `;`, no colon, a directive on the second line of
+    /// the block, and parenthesized names read as bare ones.
     #[test]
-    fn parse_inherits_directive_strips_parentheses_like_the_loader() {
-        assert_eq!(
-            parse_inherits_directive("; inherits: c, (cpp), (cuda)\n"),
-            vec!["c".to_string(), "cpp".to_string(), "cuda".to_string()]
-        );
-    }
+    fn on_disk_parents_follow_the_shared_modeline_grammar() {
+        let temp_dir = TempDir::new().unwrap();
+        let queries_dir = temp_dir.path().join("queries").join("child");
+        fs::create_dir_all(&queries_dir).unwrap();
+        fs::write(
+            queries_dir.join("highlights.scm"),
+            ";; extends\n;; inherits c,(cpp)\n(comment) @comment\n",
+        )
+        .unwrap();
+        fs::write(
+            queries_dir.join("injections.scm"),
+            "; inherits: ../../evil, html_tags\n; inherits: c3\n(comment) @injection.content\n",
+        )
+        .unwrap();
 
-    /// Only a matched pair is a wrapper. An unmatched one is part of the name
-    /// as far as the loader is concerned, so it must be part of it here too —
-    /// and such a name is then rejected as unsafe rather than turned into a
-    /// different language's.
-    #[test]
-    fn parse_inherits_directive_keeps_unmatched_parentheses() {
-        assert!(
-            parse_inherits_directive("; inherits: (cpp\n").is_empty(),
-            "an unmatched leading parenthesis is part of the name, and unsafe"
-        );
-        assert!(
-            parse_inherits_directive("; inherits: cpp)\n").is_empty(),
-            "and so is an unmatched trailing one"
-        );
-    }
-
-    #[test]
-    fn parse_inherits_directive_drops_unsafe_language_names() {
-        let parents = parse_inherits_directive(
-            "; inherits: ../../evil, html_tags, UPPER, with-dash, c3\n(comment) @comment\n",
-        );
         assert_eq!(
-            parents,
-            vec!["html_tags".to_string(), "c3".to_string()],
-            "only lowercase/digit/underscore names may survive"
+            inherited_languages_on_disk(&queries_dir),
+            Some(vec!["c".to_string(), "cpp".to_string(), "c3".to_string()]),
+            "a line whose operand is not a name list is a comment, the rest are parents"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -1,6 +1,6 @@
 //! Query file downloading from nvim-treesitter repository.
 
-use crate::language::query_modeline::parse_modeline;
+use crate::language::query_modeline::{InheritedLanguage, parse_modeline};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -154,8 +154,8 @@ fn validate_safe_language_name(language: &str) -> Result<(), QueryInstallError> 
 /// kind the installer does not fetch (bindings, captures kinds) resolves its
 /// parents the same way, but only from files the user placed on a search
 /// path; nothing here can install those.
-fn inherited_languages_on_disk(queries_dir: &Path) -> Option<Vec<String>> {
-    let mut parents: Vec<String> = Vec::new();
+fn inherited_languages_on_disk(queries_dir: &Path) -> Option<Vec<InheritedLanguage>> {
+    let mut parents: Vec<InheritedLanguage> = Vec::new();
     for query_file in QUERY_FILES {
         let content = match fs::read_to_string(queries_dir.join(query_file)) {
             Ok(content) => content,
@@ -166,16 +166,33 @@ fn inherited_languages_on_disk(queries_dir: &Path) -> Option<Vec<String>> {
             // saw, so say the chain cannot be determined instead.
             Err(_) => return None,
         };
-        // An optional parent, `(cpp)`, is skipped by the loader only while
-        // the file is itself being inherited; loaded for its own language it
-        // is needed, so the chain counts it.
         for parent in parse_modeline(&content).inherits {
-            if !parents.contains(&parent.name) {
-                parents.push(parent.name);
+            match parents.iter_mut().find(|p| p.name == parent.name) {
+                // Required by one kind, required for the language.
+                Some(known) => known.optional &= parent.optional,
+                None => parents.push(parent),
             }
         }
     }
     Some(parents)
+}
+
+/// The parents a language actually needs on disk, given how it is reached.
+///
+/// The loader inherits an optional parent, `(cpp)`, only when the file is
+/// loaded for its own language; a language reached as another's parent skips
+/// its optional parents, so a chain stops there. The installer asks the same
+/// question the same way, or it would fetch and lock a grandparent the loader
+/// never looks for — and call a chain incomplete over a language the loader
+/// would load.
+fn required_parents(
+    parents: Vec<InheritedLanguage>,
+    is_included: bool,
+) -> impl Iterator<Item = String> {
+    parents
+        .into_iter()
+        .filter(move |parent| !(parent.optional && is_included))
+        .map(|parent| parent.name)
 }
 
 /// Hold every language in an inheritance chain still, and report whether all of
@@ -195,6 +212,7 @@ pub(crate) fn lock_complete_chain(data_dir: &Path, language: &str) -> Option<Vec
     fn walk(
         data_dir: &Path,
         language: &str,
+        is_included: bool,
         seen: &mut Vec<String>,
         guards: &mut Vec<LanguageLock>,
     ) -> bool {
@@ -217,14 +235,13 @@ pub(crate) fn lock_complete_chain(data_dir: &Path, language: &str) -> Option<Vec
         let queries_dir = data_dir.join("queries").join(language);
         query_install_is_complete(&queries_dir)
             && inherited_languages_on_disk(&queries_dir).is_some_and(|parents| {
-                parents
-                    .into_iter()
-                    .all(|parent| walk(data_dir, &parent, seen, guards))
+                required_parents(parents, is_included)
+                    .all(|parent| walk(data_dir, &parent, true, seen, guards))
             })
     }
 
     let mut guards = Vec::new();
-    walk(data_dir, language, &mut Vec::new(), &mut guards).then_some(guards)
+    walk(data_dir, language, false, &mut Vec::new(), &mut guards).then_some(guards)
 }
 
 /// Download and install query files for a language, including inherited dependencies.
@@ -490,9 +507,12 @@ impl StagedQueryInstall {
             let Some(parents) = inherited_languages_on_disk(&queries_dir) else {
                 return Some(language);
             };
-            if parents
-                .iter()
-                .any(|parent| !self.dependencies.contains(parent))
+            // Only the requested language is loaded for itself; every other
+            // dependency is reached as a parent, where its optional parents
+            // are not needed.
+            let is_included = language != &self.language;
+            if required_parents(parents, is_included)
+                .any(|parent| !self.dependencies.contains(&parent))
             {
                 return Some(language);
             }
@@ -552,7 +572,8 @@ impl StagedQueryInstall {
                 Ok(PublishQueryDirOutcome::AlreadyComplete) => {
                     let chain_matches = inherited_languages_on_disk(&entry.queries_dir)
                         .is_some_and(|parents| {
-                            parents.iter().all(|parent| dependencies.contains(parent))
+                            required_parents(parents, !requested)
+                                .all(|parent| dependencies.contains(&parent))
                         });
                     if !chain_matches {
                         let residue = publish.rollback();
@@ -834,8 +855,8 @@ fn stage_queries_with_dependencies(
     let outcome = stage_queries_recursive(
         base_url,
         language,
+        StageRole::Requested { force },
         data_dir,
-        force,
         &mut staged,
         &mut entries,
         http_policy,
@@ -863,15 +884,38 @@ fn stage_queries_with_dependencies(
 /// the languages it inherits, so `entries` comes out in dependency order and
 /// publishing it forward puts every base language in place before the language
 /// that needs it.
+/// How a language is reached while staging an install.
+///
+/// Only the requested language is loaded for itself, and only it may be
+/// forced; every other language in the chain is reached as a parent, where
+/// its optional parents are not needed and an existing copy is kept.
+#[derive(Clone, Copy)]
+enum StageRole {
+    Requested { force: bool },
+    Parent,
+}
+
+impl StageRole {
+    fn is_included(self) -> bool {
+        matches!(self, Self::Parent)
+    }
+
+    fn force(self) -> bool {
+        matches!(self, Self::Requested { force: true })
+    }
+}
+
 fn stage_queries_recursive(
     base_url: &str,
     language: &str,
+    role: StageRole,
     data_dir: &Path,
-    force: bool,
     staged: &mut std::collections::HashSet<String>,
     entries: &mut Vec<StagedQueryDir>,
     http_policy: QueryHttpPolicy,
 ) -> Result<StageOutcome, QueryInstallError> {
+    let is_included = role.is_included();
+    let force = role.force();
     // The name becomes a path and URL segment below; reject anything that
     // could escape the data dir (e.g. a caller-provided `../../x`).
     // Escape the untrusted name: the error's Display is printed raw by
@@ -911,13 +955,13 @@ fn stage_queries_recursive(
                 "cannot read the query files installed for '{language}' to find what it inherits"
             )))
         })?;
-        for parent in parents {
+        for parent in required_parents(parents, is_included) {
             // Stage parent dependencies (don't force, just ensure they exist)
             stage_queries_recursive(
                 base_url,
                 &parent,
+                StageRole::Parent,
                 data_dir,
-                false,
                 staged,
                 entries,
                 http_policy,
@@ -949,8 +993,13 @@ fn stage_queries_recursive(
                 // Every query kind resolves its own `; inherits:` chain at load
                 // time, so a parent named by injections.scm is as load-bearing
                 // as one named by highlights.scm. A file naming its own
-                // language is read as `extends`, not as a parent.
+                // language is read as `extends`, not as a parent, and an
+                // optional parent is needed only when the language is loaded
+                // for itself (see `required_parents`).
                 for parent in parse_modeline(&content).inherits {
+                    if parent.optional && is_included {
+                        continue;
+                    }
                     let parent = parent.name;
                     if parent != language && !parents_to_install.contains(&parent) {
                         parents_to_install.push(parent);
@@ -1003,8 +1052,8 @@ fn stage_queries_recursive(
         stage_queries_recursive(
             base_url,
             &parent,
+            StageRole::Parent,
             data_dir,
-            false,
             staged,
             entries,
             http_policy,
@@ -2965,10 +3014,53 @@ mod tests {
         )
         .unwrap();
 
+        let parents = inherited_languages_on_disk(&queries_dir).unwrap();
         assert_eq!(
-            inherited_languages_on_disk(&queries_dir),
-            Some(vec!["c".to_string(), "cpp".to_string(), "c3".to_string()]),
+            parents
+                .iter()
+                .map(|parent| (parent.name.as_str(), parent.optional))
+                .collect::<Vec<_>>(),
+            vec![("c", false), ("cpp", true), ("c3", false)],
             "a line whose operand is not a name list is a comment, the rest are parents"
+        );
+        assert_eq!(
+            required_parents(parents, true).collect::<Vec<_>>(),
+            vec!["c".to_string(), "c3".to_string()],
+            "reached as a parent, the language does not need its optional parent"
+        );
+    }
+
+    /// The loader inherits `(cpp)` only when `c` is loaded for itself, so a
+    /// `cuda` that inherits `c` never looks for `cpp`. The installer must ask
+    /// the same question: installing or checking `cuda` must not require —
+    /// or try to fetch — a `cpp` that only a direct load of `c` needs.
+    #[test]
+    fn an_optional_grandparent_is_not_required_through_an_inherited_parent() {
+        let temp_dir = TempDir::new().unwrap();
+        let data_dir = temp_dir.path().to_path_buf();
+        let c_dir = data_dir.join("queries").join("c");
+        let cuda_dir = data_dir.join("queries").join("cuda");
+        fs::create_dir_all(&c_dir).unwrap();
+        fs::create_dir_all(&cuda_dir).unwrap();
+        fs::write(c_dir.join("highlights.scm"), "; inherits: (cpp)\n").unwrap();
+        fs::write(cuda_dir.join("highlights.scm"), "; inherits: c\n").unwrap();
+        write_install_marker_for_tests(&c_dir).unwrap();
+        write_install_marker_for_tests(&cuda_dir).unwrap();
+        // No `cpp` on disk, and no network: reaching for it would fail.
+
+        assert!(
+            lock_complete_chain(&data_dir, "cuda").is_some(),
+            "cuda's chain stops at c, whose optional parent it never loads"
+        );
+        assert!(
+            lock_complete_chain(&data_dir, "c").is_none(),
+            "c loaded for itself does need cpp"
+        );
+        let result = install_queries_with_dependencies("cuda", &data_dir, false);
+        assert!(
+            matches!(result, Err(QueryInstallError::AlreadyExists(_))),
+            "installing cuda must not reach for cpp: {:?}",
+            result.err()
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -238,7 +238,8 @@ pub(crate) fn lock_complete_chain(data_dir: &Path, language: &str) -> Option<Vec
 /// and dropped it as an unsafe name would report success and leave the loader
 /// looking for a language nothing fetched.
 fn parse_inherits_directive(content: &str) -> Vec<String> {
-    crate::language::query_modeline::parse_inherits_directive(content)
+    crate::language::query_modeline::parse_modeline(content)
+        .inherits
         .into_iter()
         .filter(|s| {
             let safe = is_safe_language_name(s);

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -157,10 +157,20 @@ fn validate_safe_language_name(language: &str) -> Result<(), QueryInstallError> 
 fn inherited_languages_on_disk(queries_dir: &Path) -> Option<Vec<InheritedLanguage>> {
     let mut parents: Vec<InheritedLanguage> = Vec::new();
     for query_file in QUERY_FILES {
-        let content = match fs::read_to_string(queries_dir.join(query_file)) {
+        let path = queries_dir.join(query_file);
+        let content = match fs::read_to_string(&path) {
             Ok(content) => content,
-            // A kind this language does not have.
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            // A kind this language does not have — but only when there is no
+            // entry at all. The loader probes with `symlink_metadata` and
+            // counts a dangling symlink as a present, broken hit that fails
+            // the load; calling the chain complete over it would leave the
+            // user with a language nothing will install and nothing can load.
+            Err(e)
+                if e.kind() == std::io::ErrorKind::NotFound
+                    && fs::symlink_metadata(&path).is_err() =>
+            {
+                continue;
+            }
             // A kind it has but that cannot be read. Answering "no parents"
             // would let a caller call the chain complete on a file it never
             // saw, so say the chain cannot be determined instead.
@@ -185,6 +195,12 @@ fn inherited_languages_on_disk(queries_dir: &Path) -> Option<Vec<InheritedLangua
 /// question the same way, or it would fetch and lock a grandparent the loader
 /// never looks for — and call a chain incomplete over a language the loader
 /// would load.
+///
+/// One coarsening remains: the loader resolves each kind's chain on its own,
+/// while the installer works per language, on the union of its kinds. A
+/// parent one kind names bare and another in parentheses is required here
+/// whenever either kind would need it — a superset of what any one kind
+/// loads, never less.
 fn required_parents(
     parents: Vec<InheritedLanguage>,
     is_included: bool,
@@ -2998,6 +3014,25 @@ mod tests {
     /// is exactly what the loader will look for, in every form Neovim
     /// accepts: repeated `;`, no colon, a directive on the second line of
     /// the block, and parenthesized names read as bare ones.
+    /// The loader counts a dangling symlink as a present, broken file and
+    /// fails the load; the chain must not be called complete over one.
+    #[cfg(unix)]
+    #[test]
+    fn a_dangling_query_symlink_leaves_the_chain_undetermined() {
+        use std::os::unix::fs::symlink;
+
+        let temp_dir = TempDir::new().unwrap();
+        let queries_dir = temp_dir.path().join("queries").join("child");
+        fs::create_dir_all(&queries_dir).unwrap();
+        fs::write(queries_dir.join("highlights.scm"), "(comment) @comment\n").unwrap();
+        symlink("missing-target.scm", queries_dir.join("injections.scm")).unwrap();
+
+        assert!(
+            inherited_languages_on_disk(&queries_dir).is_none(),
+            "a present-but-broken kind must not read as absent"
+        );
+    }
+
     #[test]
     fn on_disk_parents_follow_the_shared_modeline_grammar() {
         let temp_dir = TempDir::new().unwrap();

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -145,11 +145,15 @@ fn validate_safe_language_name(language: &str) -> Result<(), QueryInstallError> 
     }
 }
 
-/// Languages an installed query directory inherits, across every query kind.
+/// Languages an installed query directory inherits, across the kinds the
+/// installer manages (`QUERY_FILES`).
 ///
 /// Each kind resolves its own `; inherits:` chain when it loads, and a parent it
 /// names but that is not installed makes that load fail outright — so
-/// injections.scm's parents matter exactly as much as highlights.scm's.
+/// injections.scm's parents matter exactly as much as highlights.scm's. A
+/// kind the installer does not fetch (bindings, captures kinds) resolves its
+/// parents the same way, but only from files the user placed on a search
+/// path; nothing here can install those.
 fn inherited_languages_on_disk(queries_dir: &Path) -> Option<Vec<String>> {
     let mut parents: Vec<String> = Vec::new();
     for query_file in QUERY_FILES {

--- a/src/language.rs
+++ b/src/language.rs
@@ -12,6 +12,7 @@ pub(crate) mod query_assets;
 pub(crate) mod query_directives;
 pub(crate) mod query_exec;
 pub(crate) mod query_loader;
+pub(crate) mod query_modeline;
 pub(crate) mod query_pattern_splitter;
 pub(crate) mod query_predicates;
 pub(crate) mod query_store;

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1067,7 +1067,7 @@ impl LanguageCoordinator {
             // When several files were combined (inherits parents, extends
             // overlays), line numbers refer to the combined query, not any
             // one source file
-            let line_note = if result.combined {
+            let line_note = if result.multi_file {
                 " (in combined query)"
             } else {
                 ""

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1064,9 +1064,10 @@ impl LanguageCoordinator {
         // Log warnings for skipped patterns
         for skipped in &result.skipped {
             let preview = truncate_preview(&skipped.text, MAX_PREVIEW_LEN);
-            // When inheritance is used, line numbers refer to the combined query,
-            // not the original source file
-            let line_note = if result.used_inheritance {
+            // When several files were combined (inherits parents, extends
+            // overlays), line numbers refer to the combined query, not any
+            // one source file
+            let line_note = if result.combined {
                 " (in combined query)"
             } else {
                 ""

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -2320,6 +2320,74 @@ mod tests {
         );
     }
 
+    /// A skipped-pattern warning quotes line numbers of the text that was
+    /// compiled. When an overlay was merged that text is not any one file,
+    /// so the warning must say so; for a single file it must not, or the
+    /// reader hunts for an offset that does not exist.
+    #[test]
+    fn skipped_pattern_warning_notes_a_combined_query_only_when_files_merged() {
+        use tempfile::TempDir;
+
+        fn write_highlights(base: &Path, lang: &str, content: &str) {
+            let dir = base.join("queries").join(lang);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("highlights.scm"), content).unwrap();
+        }
+        fn skipped_warnings(
+            coordinator: &LanguageCoordinator,
+            bases: &[PathBuf],
+            lang: &str,
+        ) -> Vec<String> {
+            let language: Language = tree_sitter_rust::LANGUAGE.into();
+            let mut events = Vec::new();
+            coordinator.load_all_queries(&language, bases, lang, "test", &mut events);
+            events
+                .into_iter()
+                .filter_map(|event| match event {
+                    LanguageEvent::Log { message, .. }
+                        if message.contains("Skipped invalid pattern") =>
+                    {
+                        Some(message)
+                    }
+                    _ => None,
+                })
+                .collect()
+        }
+
+        let coordinator = LanguageCoordinator::new();
+        let base = TempDir::new().unwrap();
+        let overlay = TempDir::new().unwrap();
+        // `(no_such_node)` is invalid against the Rust grammar and is skipped.
+        write_highlights(
+            base.path(),
+            "alone",
+            "(identifier) @variable\n(no_such_node) @bogus\n",
+        );
+        write_highlights(base.path(), "extended", "(identifier) @variable\n");
+        write_highlights(
+            overlay.path(),
+            "extended",
+            ";; extends\n(no_such_node) @bogus\n",
+        );
+        let bases = [base.path().to_path_buf(), overlay.path().to_path_buf()];
+
+        let alone = skipped_warnings(&coordinator, &bases, "alone");
+        assert_eq!(alone.len(), 1, "{alone:?}");
+        assert!(
+            !alone[0].contains("(in combined query)"),
+            "one file, the line numbers are its own: {}",
+            alone[0]
+        );
+
+        let extended = skipped_warnings(&coordinator, &bases, "extended");
+        assert_eq!(extended.len(), 1, "{extended:?}");
+        assert!(
+            extended[0].contains("(in combined query)"),
+            "an overlay shifted the line numbers: {}",
+            extended[0]
+        );
+    }
+
     #[test]
     fn test_load_unified_queries_unknown_patterns_skipped() {
         use crate::config::settings::QueryItem;

--- a/src/language/query_assets.rs
+++ b/src/language/query_assets.rs
@@ -7,6 +7,7 @@
 mod tests {
     use crate::analysis::bindings::collect::collect;
     use crate::analysis::bindings::model::BindingsModel;
+    use crate::language::query_loader::append_file;
 
     /// The on-disk `bindings.scm` asset for a language.
     fn asset_source(lang_name: &str) -> String {
@@ -50,11 +51,10 @@ mod tests {
                 if parent.name == lang || (parent.optional && is_included) {
                     continue;
                 }
-                combined.push_str(&resolve(&parent.name, true, chain));
-                combined.push('\n');
+                append_file(&mut combined, &resolve(&parent.name, true, chain));
             }
             chain.pop();
-            combined.push_str(&source);
+            append_file(&mut combined, &source);
             combined
         }
         resolve(lang, false, &mut Vec::new())

--- a/src/language/query_assets.rs
+++ b/src/language/query_assets.rs
@@ -31,7 +31,7 @@ mod tests {
     }
 
     /// The asset source with `; inherits:` parents concatenated from the
-    /// on-disk assets, mirroring the loader's resolution. Fails fast on an
+    /// on-disk assets, read through the loader's own modeline parser. Fails fast on an
     /// inheritance cycle (the runtime loader guards likewise) instead of
     /// recursing until the test suite hangs.
     fn resolved_source(lang: &str) -> String {
@@ -43,13 +43,9 @@ mod tests {
             chain.push(lang.to_string());
             let source = asset_source(lang);
             let mut combined = String::new();
-            if let Some(first_line) = source.lines().next()
-                && let Some(parents) = first_line.strip_prefix("; inherits:")
-            {
-                for parent in parents.split(',') {
-                    combined.push_str(&resolve(parent.trim(), chain));
-                    combined.push('\n');
-                }
+            for parent in crate::language::query_modeline::parse_inherits_directive(&source) {
+                combined.push_str(&resolve(&parent, chain));
+                combined.push('\n');
             }
             chain.pop();
             combined.push_str(&source);

--- a/src/language/query_assets.rs
+++ b/src/language/query_assets.rs
@@ -31,7 +31,7 @@ mod tests {
     }
 
     /// The asset source with `; inherits:` parents concatenated from the
-    /// on-disk assets, read through the loader's own modeline parser. Fails fast on an
+    /// on-disk assets, read through the shared modeline parser. Fails fast on an
     /// inheritance cycle (the runtime loader guards likewise) instead of
     /// recursing until the test suite hangs.
     fn resolved_source(lang: &str) -> String {

--- a/src/language/query_assets.rs
+++ b/src/language/query_assets.rs
@@ -43,7 +43,7 @@ mod tests {
             chain.push(lang.to_string());
             let source = asset_source(lang);
             let mut combined = String::new();
-            for parent in crate::language::query_modeline::parse_inherits_directive(&source) {
+            for parent in crate::language::query_modeline::parse_modeline(&source).inherits {
                 combined.push_str(&resolve(&parent, chain));
                 combined.push('\n');
             }

--- a/src/language/query_assets.rs
+++ b/src/language/query_assets.rs
@@ -44,7 +44,7 @@ mod tests {
             let source = asset_source(lang);
             let mut combined = String::new();
             for parent in crate::language::query_modeline::parse_modeline(&source).inherits {
-                combined.push_str(&resolve(&parent, chain));
+                combined.push_str(&resolve(&parent.name, chain));
                 combined.push('\n');
             }
             chain.pop();

--- a/src/language/query_assets.rs
+++ b/src/language/query_assets.rs
@@ -31,11 +31,14 @@ mod tests {
     }
 
     /// The asset source with `; inherits:` parents concatenated from the
-    /// on-disk assets, read through the shared modeline parser. Fails fast on an
+    /// on-disk assets, read through the shared modeline parser and following
+    /// the loader's rules for which parents count: a parent equal to the
+    /// language marks an overlay rather than a chain, and a parenthesized
+    /// parent is inherited only at the top of the chain. Fails fast on an
     /// inheritance cycle (the runtime loader guards likewise) instead of
     /// recursing until the test suite hangs.
     fn resolved_source(lang: &str) -> String {
-        fn resolve(lang: &str, chain: &mut Vec<String>) -> String {
+        fn resolve(lang: &str, is_included: bool, chain: &mut Vec<String>) -> String {
             assert!(
                 !chain.iter().any(|l| l == lang),
                 "inheritance cycle in assets: {chain:?} -> {lang}"
@@ -44,14 +47,17 @@ mod tests {
             let source = asset_source(lang);
             let mut combined = String::new();
             for parent in crate::language::query_modeline::parse_modeline(&source).inherits {
-                combined.push_str(&resolve(&parent.name, chain));
+                if parent.name == lang || (parent.optional && is_included) {
+                    continue;
+                }
+                combined.push_str(&resolve(&parent.name, true, chain));
                 combined.push('\n');
             }
             chain.pop();
             combined.push_str(&source);
             combined
         }
-        resolve(lang, &mut Vec::new())
+        resolve(lang, false, &mut Vec::new())
     }
 
     /// Every asset must compile in full against the grammar it

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -190,7 +190,8 @@ impl QueryLoader {
             }
         }
 
-        let mut file_count = paths.len();
+        // A shadowed plain file contributed no text, so it does not count.
+        let mut file_count = usize::from(base.is_some()) + overlays.len();
         let mut combined = String::new();
         for parent in &parents {
             let resolved = match Self::resolve_query_recursive(
@@ -990,6 +991,7 @@ mod tests {
 
     #[test]
     fn a_second_plain_query_is_shadowed_by_the_first() {
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
         let first = tempdir().unwrap();
         let second = tempdir().unwrap();
         write_highlights(first.path(), "rust", "(identifier) @first\n");
@@ -1001,6 +1003,14 @@ mod tests {
         assert!(
             !content.contains("@second"),
             "a plain query in a later search path replaces nothing:\n{content}"
+        );
+
+        let parsed =
+            QueryLoader::load_query_with_inheritance(&language, &bases, "rust", "highlights.scm")
+                .unwrap();
+        assert!(
+            !parsed.combined,
+            "a shadowed file contributed nothing, so line numbers are the base file's own"
         );
     }
 

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -624,10 +624,11 @@ mod tests {
 
     #[test]
     fn resolve_query_rejects_traversing_inherits_parent() {
-        // The parent language name comes from the first line of an on-disk query
-        // file, so it is the content-driven route into find_query_file -- and
-        // parse_inherits_directive, unlike its install-side twin, applies no
-        // filter of its own.
+        // A parent language name comes from a modeline in an on-disk query
+        // file, so it is the content-driven route into the search paths. The
+        // modeline grammar admits only `[a-z0-9_]+` names, and the lookup
+        // itself rejects anything but a single path component; either alone
+        // must keep the smuggled content out of the combined query.
         let dir = tempdir().unwrap();
         let runtime = dir.path().join("runtime");
 
@@ -643,13 +644,16 @@ mod tests {
         )
         .unwrap();
 
-        let result = resolve_query(&[runtime], "child", "highlights.scm");
-
-        // An unresolvable parent fails the whole child query; what matters is
-        // that the smuggled content never reaches the combined output.
+        let content = resolve_query(&[runtime], "child", "highlights.scm")
+            .expect("a traversal-shaped modeline is a comment, and the child loads");
+        assert!(content.contains("@string"));
         assert!(
-            result.is_err(),
-            "expected traversal to fail, got {result:?}"
+            !content.contains("@smuggled"),
+            "content outside queries/ must never reach the combined query:\n{content}"
+        );
+        assert!(
+            QueryLoader::find_query_files(&[dir.path()], "../outside", "highlights.scm").is_empty(),
+            "and the lookup gate holds on its own, without the grammar"
         );
     }
 

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -267,7 +267,7 @@ impl QueryLoader {
     /// unreadable directory) is listed too: presence probing must not
     /// downgrade a broken asset to an ordinary absence, so the real read
     /// reports its concrete I/O error.
-    pub(crate) fn find_query_files<P: AsRef<Path>>(
+    fn find_query_files<P: AsRef<Path>>(
         runtime_bases: &[P],
         lang_name: &str,
         file_name: &str,
@@ -284,21 +284,6 @@ impl QueryLoader {
                 Err(e) => e.kind() != std::io::ErrorKind::NotFound,
             })
             .collect()
-    }
-
-    /// The first search-path hit for a query file, if any.
-    ///
-    /// `pub(crate)` so the captures handler can distinguish "kind file absent"
-    /// (expected, debug log) from "file exists but failed to load" (asset
-    /// trouble, warn) — captures-protocol §"Null vs. error semantics".
-    pub(crate) fn find_query_file<P: AsRef<Path>>(
-        runtime_bases: &[P],
-        lang_name: &str,
-        file_name: &str,
-    ) -> Option<PathBuf> {
-        Self::find_query_files(runtime_bases, lang_name, file_name)
-            .into_iter()
-            .next()
     }
 
     /// Parse a query string with fault tolerance.
@@ -549,7 +534,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_query_file() {
+    fn test_find_query_files() {
         let dir = tempdir().unwrap();
         let base_path = dir.path().to_str().unwrap().to_string();
 
@@ -562,18 +547,17 @@ mod tests {
         fs::write(&query_file, "(identifier) @variable").unwrap();
 
         // Test finding the file
-        let result = QueryLoader::find_query_file(&[base_path], "rust", "highlights.scm");
-        assert!(result.is_some());
-        assert_eq!(result.unwrap(), query_file);
+        let result = QueryLoader::find_query_files(&[base_path], "rust", "highlights.scm");
+        assert_eq!(result, vec![query_file]);
 
         // Test not finding a non-existent file
-        let result = QueryLoader::find_query_file(NO_SEARCH_PATHS, "rust", "highlights.scm");
-        assert!(result.is_none());
+        let result = QueryLoader::find_query_files(NO_SEARCH_PATHS, "rust", "highlights.scm");
+        assert!(result.is_empty());
     }
 
     #[cfg(unix)]
     #[test]
-    fn find_query_file_treats_dangling_symlink_as_present_asset() {
+    fn find_query_files_treats_dangling_symlink_as_present_asset() {
         use std::os::unix::fs::symlink;
 
         let dir = tempdir().unwrap();
@@ -583,8 +567,8 @@ mod tests {
         symlink("missing-target.scm", &query_file).unwrap();
 
         assert_eq!(
-            QueryLoader::find_query_file(&[dir.path()], "rust", "highlights.scm"),
-            Some(query_file),
+            QueryLoader::find_query_files(&[dir.path()], "rust", "highlights.scm"),
+            vec![query_file],
             "a broken configured asset must not be classified as ordinary absence"
         );
 
@@ -596,7 +580,7 @@ mod tests {
     }
 
     #[test]
-    fn find_query_file_rejects_language_path_traversal() {
+    fn find_query_files_rejects_language_path_traversal() {
         let dir = tempdir().unwrap();
         let runtime = dir.path().join("runtime");
         let outside = dir.path().join("outside");
@@ -605,23 +589,23 @@ mod tests {
 
         // `runtime/queries` sits two components below the tempdir root, so the
         // pre-fix join cleaned to exactly the file planted above.
-        let result = QueryLoader::find_query_file(
+        let result = QueryLoader::find_query_files(
             std::slice::from_ref(&runtime),
             "../../outside",
             "highlights.scm",
         );
 
-        assert_eq!(result, None);
+        assert!(result.is_empty());
 
         // An absolute name is the worse variant: `join` discards the base
         // outright, so no `..` arithmetic is needed to escape.
-        let result = QueryLoader::find_query_file(
+        let result = QueryLoader::find_query_files(
             std::slice::from_ref(&runtime),
             outside.to_str().unwrap(),
             "highlights.scm",
         );
 
-        assert_eq!(result, None);
+        assert!(result.is_empty());
 
         // Positive control on the same base: an ordinary name still resolves,
         // so the assertions above pin the gate rather than a broken fixture.
@@ -629,9 +613,9 @@ mod tests {
         fs::create_dir_all(&inside).unwrap();
         fs::write(inside.join("highlights.scm"), "(identifier) @variable").unwrap();
 
-        let result = QueryLoader::find_query_file(&[runtime], "rust", "highlights.scm");
+        let result = QueryLoader::find_query_files(&[runtime], "rust", "highlights.scm");
 
-        assert_eq!(result, Some(inside.join("highlights.scm")));
+        assert_eq!(result, vec![inside.join("highlights.scm")]);
     }
 
     #[test]
@@ -831,7 +815,7 @@ mod tests {
     #[cfg(unix)]
     #[cfg_attr(target_os = "macos", ignore)]
     #[test]
-    fn test_find_query_file_with_non_utf8_search_path() {
+    fn test_find_query_files_with_non_utf8_search_path() {
         let dir = tempdir().unwrap();
         let non_utf8_base = create_non_utf8_base(&dir);
         let query_dir = non_utf8_base.join("queries").join("rust");
@@ -839,9 +823,9 @@ mod tests {
         fs::write(query_dir.join("highlights.scm"), "(identifier) @variable").unwrap();
 
         let search_paths = vec![non_utf8_base];
-        let result = QueryLoader::find_query_file(&search_paths, "rust", "highlights.scm");
+        let result = QueryLoader::find_query_files(&search_paths, "rust", "highlights.scm");
         assert!(
-            result.is_some(),
+            !result.is_empty(),
             "Should find query file under non-UTF-8 path"
         );
     }
@@ -867,7 +851,7 @@ mod tests {
     }
 
     #[test]
-    fn test_find_query_file_with_path_ref() {
+    fn test_find_query_files_with_path_ref() {
         let dir = tempdir().unwrap();
         let query_dir = dir.path().join("queries").join("rust");
         fs::create_dir_all(&query_dir).unwrap();
@@ -875,8 +859,8 @@ mod tests {
         fs::write(&query_file, "(identifier) @variable").unwrap();
 
         let search_paths: Vec<&Path> = vec![dir.path()];
-        let result = QueryLoader::find_query_file(&search_paths, "rust", "highlights.scm");
-        assert_eq!(result.unwrap(), query_file);
+        let result = QueryLoader::find_query_files(&search_paths, "rust", "highlights.scm");
+        assert_eq!(result, vec![query_file]);
     }
 
     #[test]

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -173,9 +173,9 @@ impl QueryLoader {
             })?;
             let modeline = parse_modeline(&content);
             // Neovim's `get_files` reads a file naming its own language as an
-            // extension (`add_included_lang` reports the self-reference so,
-            // instead of a parent), so the file is an overlay, not a parent
-            // of itself.
+            // extension (`add_included_lang` returns true for the
+            // self-reference instead of adding a parent), so the file is an
+            // overlay, not a parent of itself.
             let mut extends = modeline.extends;
             for parent in modeline.inherits {
                 if parent == lang_name {

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -1176,7 +1176,9 @@ mod tests {
             ";; extends\n;; inherits: parent\n(boolean_literal) @overlay\n",
         );
 
-        let bases = [base.path().to_path_buf(), overlay.path().to_path_buf()];
+        // Overlay first in the search paths, so the asserted order is not
+        // the search-path order.
+        let bases = [overlay.path().to_path_buf(), base.path().to_path_buf()];
         let content = resolve_query(&bases, "child", "highlights.scm").unwrap();
         let parent_at = position(&content, "@parent");
         let child_at = position(&content, "@child");
@@ -1228,7 +1230,9 @@ mod tests {
             ";; extends\n(boolean_literal) @parent_overlay\n",
         );
 
-        let bases = [base.path().to_path_buf(), overlay.path().to_path_buf()];
+        // Overlay first in the search paths, so the asserted order is not
+        // the search-path order.
+        let bases = [overlay.path().to_path_buf(), base.path().to_path_buf()];
         let content = resolve_query(&bases, "child", "highlights.scm").unwrap();
         let parent_at = position(&content, "@parent\n");
         let parent_overlay_at = position(&content, "@parent_overlay");

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -172,9 +172,10 @@ impl QueryLoader {
                 ))
             })?;
             let modeline = parse_modeline(&content);
-            // Naming the language itself is Neovim's older way to say
-            // `extends` (`add_included_lang` returns "extension" for it), so
-            // the file is an overlay, not a parent of itself.
+            // Neovim's `get_files` reads a file naming its own language as an
+            // extension (`add_included_lang` reports the self-reference so,
+            // instead of a parent), so the file is an overlay, not a parent
+            // of itself.
             let mut extends = modeline.extends;
             for parent in modeline.inherits {
                 if parent == lang_name {
@@ -1112,9 +1113,8 @@ mod tests {
     }
 
     /// Neovim's `add_included_lang` treats `; inherits: rust` inside rust's
-    /// own query file as the `extends` marker (its `query.set()` docs use that
-    /// idiom), so the file must merge as an overlay rather than trip the
-    /// cycle check and drop the language's query.
+    /// own query file as the `extends` marker, so the file must merge as an
+    /// overlay rather than trip the cycle check and drop the language's query.
     #[test]
     fn a_file_that_inherits_its_own_language_is_an_overlay() {
         let base = tempdir().unwrap();

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -15,7 +15,7 @@ const PARSER_EXTENSIONS: &[&str] = &["so", "dylib", "dll"];
 /// Known limitation: when a query is combined from several files (`inherits`
 /// parents, `extends` overlays), line numbers refer to the **combined** query
 /// string, not the original source file (a pattern on line 5 of a child whose
-/// parent has 100 lines reports about 105).
+/// parent has 100 lines reports 105).
 #[derive(Debug, Clone)]
 pub(crate) struct SkippedPattern {
     /// The pattern text that failed to compile
@@ -245,14 +245,12 @@ impl QueryLoader {
                 }
                 Err(other) => return Err(other),
             };
-            combined.push_str(&resolved.content);
-            combined.push('\n');
+            append_file(&mut combined, &resolved.content);
             file_count += resolved.file_count;
             emitted.insert(parent.clone());
         }
         for content in base.into_iter().chain(overlays) {
-            combined.push_str(&content);
-            combined.push('\n');
+            append_file(&mut combined, &content);
         }
 
         visited.remove(lang_name);
@@ -526,6 +524,17 @@ impl QueryLoader {
 /// stay readable, whereas the write side may be stricter because the name also
 /// becomes a URL segment. Rejection here is a path-shape decision only; it is
 /// not a charset filter and must not be relied on as one.
+/// Append one file's text so the next file starts on a fresh line and no
+/// line is added that the file did not have: a file's line numbers in the
+/// combined text are then its own plus the lines of what precedes it, which
+/// is what a skipped-pattern warning quotes.
+fn append_file(combined: &mut String, content: &str) {
+    combined.push_str(content);
+    if !content.ends_with('\n') {
+        combined.push('\n');
+    }
+}
+
 fn is_single_path_component(value: &str) -> bool {
     let mut components = Path::new(value).components();
     matches!(components.next(), Some(Component::Normal(name)) if name == value)
@@ -1328,6 +1337,34 @@ mod tests {
         for capture in ["@a", "@b", "@child", "@overlay"] {
             assert_eq!(content.matches(capture).count(), 1, "{capture}:\n{content}");
         }
+    }
+
+    /// Files join on a line boundary and nothing else: a file that ends in
+    /// a newline gets no blank line after it, one that does not gets exactly
+    /// the newline it lacks, so every line number in the combined text is the
+    /// file's own offset by the lines before it.
+    #[test]
+    fn files_join_on_a_line_boundary_without_blank_lines() {
+        let base = tempdir().unwrap();
+        let overlay = tempdir().unwrap();
+        write_highlights(base.path(), "parent", "(identifier) @parent\n");
+        write_highlights(
+            base.path(),
+            "child",
+            "; inherits: parent\n(string_literal) @child",
+        );
+        write_highlights(
+            overlay.path(),
+            "child",
+            ";; extends\n(boolean_literal) @overlay\n",
+        );
+
+        let bases = [base.path().to_path_buf(), overlay.path().to_path_buf()];
+        let content = resolve_query(&bases, "child", "highlights.scm").unwrap();
+        assert_eq!(
+            content,
+            "(identifier) @parent\n; inherits: parent\n(string_literal) @child\n;; extends\n(boolean_literal) @overlay\n"
+        );
     }
 
     #[test]

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -1054,6 +1054,30 @@ mod tests {
         );
     }
 
+    /// Neovim reads the modeline of every hit, shadowed ones included, so a
+    /// parent named only by the shadowed file is still prepended. This is
+    /// the one way a shadowed file still matters.
+    #[test]
+    fn a_shadowed_plain_query_still_contributes_its_parents() {
+        let first = tempdir().unwrap();
+        let second = tempdir().unwrap();
+        write_highlights(first.path(), "rust", "(identifier) @first\n");
+        write_highlights(first.path(), "parent", "(boolean_literal) @parent\n");
+        write_highlights(
+            second.path(),
+            "rust",
+            "; inherits: parent\n(string_literal) @second\n",
+        );
+
+        let bases = [first.path().to_path_buf(), second.path().to_path_buf()];
+        let content = resolve_query(&bases, "rust", "highlights.scm").unwrap();
+        assert!(
+            position(&content, "@parent") < position(&content, "@first"),
+            "the shadowed file's parent still comes first:\n{content}"
+        );
+        assert!(!content.contains("@second"), "{content}");
+    }
+
     #[test]
     fn every_extends_overlay_is_appended_in_search_path_order() {
         let base = tempdir().unwrap();

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -133,7 +133,11 @@ impl QueryLoader {
     /// overlays`. Modelines stay in place: tree-sitter reads them as comments,
     /// and keeping them keeps each file's line numbers intact.
     ///
-    /// `visited` guards against circular inheritance.
+    /// `visited` holds the languages on the current inheritance path so a
+    /// cycle is an error; a language leaves it on the way back out so a
+    /// diamond (two parents sharing an ancestor) resolves, as in Neovim. No
+    /// error path removes anything: every error propagates straight to the
+    /// top-level call, which owns the set and drops it.
     fn resolve_query_recursive<P: AsRef<Path>>(
         runtime_bases: &[P],
         lang_name: &str,
@@ -151,7 +155,6 @@ impl QueryLoader {
 
         let paths = Self::find_query_files(runtime_bases, lang_name, file_name);
         if paths.is_empty() {
-            visited.remove(lang_name);
             return Err(QueryLoadError::NotFound);
         }
 
@@ -204,7 +207,6 @@ impl QueryLoader {
             ) {
                 Ok(resolved) => resolved,
                 Err(QueryLoadError::NotFound) => {
-                    visited.remove(lang_name);
                     return Err(LspError::query(format!(
                         "Query file {} not found for language {} (inherited by {} in {}) in search paths: {}",
                         file_name,
@@ -215,10 +217,7 @@ impl QueryLoader {
                     ))
                     .into());
                 }
-                Err(other) => {
-                    visited.remove(lang_name);
-                    return Err(other);
-                }
+                Err(other) => return Err(other),
             };
             combined.push_str(&resolved.content);
             combined.push('\n');

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -1,6 +1,6 @@
 use crate::error::{LspError, LspResult};
 use crate::language::query_modeline::parse_modeline;
-use log::warn;
+use log::{debug, warn};
 use path_clean::PathClean;
 use std::fmt::Write;
 use std::fs;
@@ -12,22 +12,23 @@ const PARSER_EXTENSIONS: &[&str] = &["so", "dylib", "dll"];
 
 /// Information about a pattern that was skipped during tolerant parsing.
 ///
-/// Known limitation: when queries use inheritance (e.g. `; inherits: ecma`),
-/// line numbers refer to the **combined** query string, not the original source
-/// file (a pattern on line 5 of a child whose parent has 100 lines reports 105).
+/// Known limitation: when a query is combined from several files (`inherits`
+/// parents, `extends` overlays), line numbers refer to the **combined** query
+/// string, not the original source file (a pattern on line 5 of a child whose
+/// parent has 100 lines reports 105).
 #[derive(Debug, Clone)]
 pub(crate) struct SkippedPattern {
     /// The pattern text that failed to compile
     pub text: String,
     /// Starting line number (1-indexed for display).
     ///
-    /// **Note**: When query inheritance is used, this refers to the line
-    /// in the combined query string, not the original source file.
+    /// **Note**: When the query is combined from several files, this refers
+    /// to the line in the combined query string, not the original source file.
     pub start_line: usize,
     /// Ending line number (1-indexed for display).
     ///
-    /// **Note**: When query inheritance is used, this refers to the line
-    /// in the combined query string, not the original source file.
+    /// **Note**: When the query is combined from several files, this refers
+    /// to the line in the combined query string, not the original source file.
     pub end_line: usize,
     /// The error message from tree-sitter
     pub error: String,
@@ -61,10 +62,17 @@ pub(crate) struct ParseResult {
     /// If `query` is `None`, this indicates why parsing failed.
     /// When `query` is `Some`, this will be `None`.
     pub failure_reason: Option<ParseFailure>,
-    /// Whether this query used inheritance (e.g., `; inherits: ecma`).
-    /// When true, line numbers in `skipped` refer to the combined query,
-    /// not the original source file.
-    pub used_inheritance: bool,
+    /// Whether more than one file contributed (`inherits` parents, `extends`
+    /// overlays). When true, line numbers in `skipped` refer to the combined
+    /// query, not any one source file.
+    pub combined: bool,
+}
+
+/// The text of a query assembled from every file that contributes to it.
+struct ResolvedQuery {
+    content: String,
+    /// How many files were concatenated, across parents and overlays.
+    file_count: usize,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -115,52 +123,107 @@ impl QueryLoader {
             .clean()
     }
 
-    /// Resolve query inheritance and return the combined query content.
+    /// Resolve every query file that makes up `lang_name`'s `file_name`.
     ///
-    /// Recursively resolves parent queries, concatenating parents-first then
-    /// child. The modeline stays in place: tree-sitter reads it as a comment.
-    /// `preloaded_content` lets the caller skip a re-read when it already has
-    /// the content; `visited` guards against circular inheritance.
+    /// Mirrors Neovim's `vim.treesitter.query.get_files`: across the search
+    /// paths, the first file without an `extends` modeline is the base query
+    /// (a later plain file is shadowed), every file marked `extends` is an
+    /// overlay, and the `inherits` parents named by any of them resolve first
+    /// through this same function. The combined text is `parents, base,
+    /// overlays`. Modelines stay in place: tree-sitter reads them as comments,
+    /// and keeping them keeps each file's line numbers intact.
+    ///
+    /// `visited` guards against circular inheritance.
     fn resolve_query_recursive<P: AsRef<Path>>(
         runtime_bases: &[P],
         lang_name: &str,
         file_name: &str,
-        preloaded_content: Option<String>,
         visited: &mut std::collections::HashSet<String>,
-    ) -> LspResult<String> {
-        // Check for circular inheritance
+    ) -> Result<ResolvedQuery, QueryLoadError> {
         if visited.contains(lang_name) {
             return Err(LspError::query(format!(
                 "Circular inheritance detected for language '{}'",
                 lang_name
-            )));
+            ))
+            .into());
         }
         visited.insert(lang_name.to_string());
 
-        // Use preloaded content or load from disk
-        let content = match preloaded_content {
-            Some(c) => c,
-            None => Self::load_query_file(runtime_bases, lang_name, file_name)?,
-        };
+        let paths = Self::find_query_files(runtime_bases, lang_name, file_name);
+        if paths.is_empty() {
+            visited.remove(lang_name);
+            return Err(QueryLoadError::NotFound);
+        }
 
-        let parents = parse_modeline(&content).inherits;
+        let mut parents: Vec<String> = Vec::new();
+        let mut base: Option<String> = None;
+        let mut overlays: Vec<String> = Vec::new();
+        for path in &paths {
+            let content = fs::read_to_string(path).map_err(|e| {
+                LspError::query(format!(
+                    "Failed to read query file {}: {}",
+                    path.display(),
+                    e
+                ))
+            })?;
+            let modeline = parse_modeline(&content);
+            for parent in modeline.inherits {
+                if !parents.contains(&parent) {
+                    parents.push(parent);
+                }
+            }
+            if modeline.extends {
+                overlays.push(content);
+            } else if base.is_none() {
+                base = Some(content);
+            } else {
+                debug!(
+                    "Query file {} is shadowed by an earlier search path (mark it `;; extends` to merge it)",
+                    path.display()
+                );
+            }
+        }
 
-        // Build combined query: parents first, then child
+        let mut file_count = paths.len();
         let mut combined = String::new();
-
-        // Recursively resolve parent queries (never preloaded)
         for parent in &parents {
-            let parent_content =
-                Self::resolve_query_recursive(runtime_bases, parent, file_name, None, visited)?;
-            combined.push_str(&parent_content);
+            let resolved = match Self::resolve_query_recursive(
+                runtime_bases,
+                parent,
+                file_name,
+                visited,
+            ) {
+                Ok(resolved) => resolved,
+                Err(QueryLoadError::NotFound) => {
+                    visited.remove(lang_name);
+                    return Err(LspError::query(format!(
+                        "Query file {} not found for language {} (inherited by {}) in search paths: {}",
+                        file_name,
+                        parent,
+                        lang_name,
+                        format_search_paths(runtime_bases)
+                    ))
+                    .into());
+                }
+                Err(other) => {
+                    visited.remove(lang_name);
+                    return Err(other);
+                }
+            };
+            combined.push_str(&resolved.content);
+            combined.push('\n');
+            file_count += resolved.file_count;
+        }
+        for content in base.into_iter().chain(overlays) {
+            combined.push_str(&content);
             combined.push('\n');
         }
 
-        combined.push_str(&content);
-
         visited.remove(lang_name);
-
-        Ok(combined)
+        Ok(ResolvedQuery {
+            content: combined,
+            file_count,
+        })
     }
 
     /// Load query content from paths (without parsing).
@@ -186,60 +249,49 @@ impl QueryLoader {
         Ok(combined_query)
     }
 
-    /// Find a query file in search paths.
+    /// Every `<base>/queries/<lang_name>/<file_name>` across the search paths,
+    /// in search-path order.
+    ///
+    /// Returns nothing without touching the filesystem when `lang_name` is not
+    /// a single normal path component, so a document-controlled injection
+    /// language cannot escape `<base>/queries/`.
+    ///
+    /// An entry that exists but cannot be probed (a dangling symlink, an
+    /// unreadable directory) is listed too: presence probing must not
+    /// downgrade a broken asset to an ordinary absence, so the real read
+    /// reports its concrete I/O error.
+    pub(crate) fn find_query_files<P: AsRef<Path>>(
+        runtime_bases: &[P],
+        lang_name: &str,
+        file_name: &str,
+    ) -> Vec<PathBuf> {
+        // Name-only, so it cannot vary per base: reject once, before the search.
+        if !is_single_path_component(lang_name) {
+            return Vec::new();
+        }
+        runtime_bases
+            .iter()
+            .map(|base| Self::query_file_path(base.as_ref(), lang_name, file_name))
+            .filter(|candidate| match fs::symlink_metadata(candidate) {
+                Ok(_) => true,
+                Err(e) => e.kind() != std::io::ErrorKind::NotFound,
+            })
+            .collect()
+    }
+
+    /// The first search-path hit for a query file, if any.
     ///
     /// `pub(crate)` so the captures handler can distinguish "kind file absent"
     /// (expected, debug log) from "file exists but failed to load" (asset
     /// trouble, warn) — captures-protocol §"Null vs. error semantics".
-    ///
-    /// Returns `None` without touching the filesystem when `lang_name` is not a
-    /// single normal path component, so a document-controlled injection language
-    /// cannot escape `<base>/queries/`.
     pub(crate) fn find_query_file<P: AsRef<Path>>(
         runtime_bases: &[P],
         lang_name: &str,
         file_name: &str,
     ) -> Option<PathBuf> {
-        // Name-only, so it cannot vary per base: reject once, before the search.
-        if !is_single_path_component(lang_name) {
-            return None;
-        }
-        for base in runtime_bases {
-            let candidate = Self::query_file_path(base.as_ref(), lang_name, file_name);
-            match fs::symlink_metadata(&candidate) {
-                Ok(_) => return Some(candidate),
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                // Presence probing must not downgrade inaccessible/broken
-                // assets to an ordinary optional-kind absence. Return the
-                // candidate so the real read reports its concrete I/O error.
-                Err(_) => return Some(candidate),
-            }
-        }
-        None
-    }
-
-    /// Load a query file from search paths; `; inherits:` parents resolve
-    /// through this same lookup.
-    fn load_query_file<P: AsRef<Path>>(
-        runtime_bases: &[P],
-        lang_name: &str,
-        file_name: &str,
-    ) -> LspResult<String> {
-        match Self::find_query_file(runtime_bases, lang_name, file_name) {
-            Some(path) => fs::read_to_string(&path).map_err(|e| {
-                LspError::query(format!(
-                    "Failed to read query file {}: {}",
-                    path.display(),
-                    e
-                ))
-            }),
-            None => Err(LspError::query(format!(
-                "Query file {} not found for language {} in search paths: {}",
-                file_name,
-                lang_name,
-                format_search_paths(runtime_bases)
-            ))),
-        }
+        Self::find_query_files(runtime_bases, lang_name, file_name)
+            .into_iter()
+            .next()
     }
 
     /// Parse a query string with fault tolerance.
@@ -247,11 +299,7 @@ impl QueryLoader {
     /// First attempts full compilation (fast path). If that fails, splits the
     /// query into individual patterns, validates each separately, and combines
     /// only the valid ones.
-    pub(crate) fn parse_query(
-        language: &Language,
-        query_str: &str,
-        used_inheritance: bool,
-    ) -> ParseResult {
+    pub(crate) fn parse_query(language: &Language, query_str: &str, combined: bool) -> ParseResult {
         use crate::language::query_pattern_splitter::split_patterns;
 
         // Fast path: try full compilation first.
@@ -264,7 +312,7 @@ impl QueryLoader {
                 query: Some(query),
                 skipped: Vec::new(),
                 failure_reason: None,
-                used_inheritance,
+                combined,
             };
         }
 
@@ -279,7 +327,7 @@ impl QueryLoader {
                     query: None,
                     skipped: Vec::new(),
                     failure_reason: Some(ParseFailure::PatternSplitFailed(reason)),
-                    used_inheritance,
+                    combined,
                 };
             }
         };
@@ -309,17 +357,17 @@ impl QueryLoader {
                 query: None,
                 skipped,
                 failure_reason: Some(ParseFailure::AllPatternsInvalid),
-                used_inheritance,
+                combined,
             };
         }
 
-        let combined = valid_patterns.join("\n");
-        match Query::new(language, &combined) {
+        let valid_query = valid_patterns.join("\n");
+        match Query::new(language, &valid_query) {
             Ok(q) => ParseResult {
                 query: Some(q),
                 skipped,
                 failure_reason: None,
-                used_inheritance,
+                combined,
             },
             Err(e) => {
                 // Defensive: handle the rare case where individually-valid patterns
@@ -333,7 +381,7 @@ impl QueryLoader {
                     query: None,
                     skipped,
                     failure_reason: Some(ParseFailure::CombinationFailed(e.message)),
-                    used_inheritance,
+                    combined,
                 }
             }
         }
@@ -353,38 +401,25 @@ impl QueryLoader {
 
     /// Load and parse a query with inheritance resolution and fault tolerance.
     ///
-    /// Resolves `; inherits:` directives, concatenates parent queries, and skips
-    /// invalid patterns instead of failing the whole query. When inheritance is
-    /// used, line numbers in [`SkippedPattern`] refer to the combined query string,
-    /// not the original source file.
+    /// Resolves `inherits` parents and `extends` overlays across the search
+    /// paths (see [`Self::resolve_query_recursive`]) and skips invalid patterns
+    /// instead of failing the whole query. When more than one file contributes,
+    /// line numbers in [`SkippedPattern`] refer to the combined query string,
+    /// not any one source file.
     pub(crate) fn load_query_with_inheritance<P: AsRef<Path>>(
         language: &Language,
         runtime_bases: &[P],
         lang_name: &str,
         file_name: &str,
     ) -> Result<ParseResult, QueryLoadError> {
-        // Load the original file once and pass to resolver to avoid double-loading
-        let Some(path) = Self::find_query_file(runtime_bases, lang_name, file_name) else {
-            return Err(QueryLoadError::NotFound);
-        };
-        let original_content = fs::read_to_string(&path).map_err(|e| {
-            LspError::query(format!(
-                "Failed to read query file {}: {}",
-                path.display(),
-                e
-            ))
-        })?;
-        let used_inheritance = !parse_modeline(&original_content).inherits.is_empty();
-
         let mut visited = std::collections::HashSet::new();
-        let query_str = Self::resolve_query_recursive(
-            runtime_bases,
-            lang_name,
-            file_name,
-            Some(original_content),
-            &mut visited,
-        )?;
-        Ok(Self::parse_query(language, &query_str, used_inheritance))
+        let resolved =
+            Self::resolve_query_recursive(runtime_bases, lang_name, file_name, &mut visited)?;
+        Ok(Self::parse_query(
+            language,
+            &resolved.content,
+            resolved.file_count > 1,
+        ))
     }
 
     /// Resolve library path for a language.
@@ -465,20 +500,21 @@ mod tests {
 
     const NO_SEARCH_PATHS: &[PathBuf] = &[];
 
-    /// Test helper: resolve query without preloaded content
+    /// Test helper: the combined query text for a language.
     fn resolve_query<P: AsRef<Path>>(
         runtime_bases: &[P],
         lang_name: &str,
         file_name: &str,
     ) -> LspResult<String> {
         let mut visited = std::collections::HashSet::new();
-        QueryLoader::resolve_query_recursive(
-            runtime_bases,
-            lang_name,
-            file_name,
-            None,
-            &mut visited,
-        )
+        QueryLoader::resolve_query_recursive(runtime_bases, lang_name, file_name, &mut visited)
+            .map(|resolved| resolved.content)
+            .map_err(|e| match e {
+                QueryLoadError::Other(e) => e,
+                QueryLoadError::NotFound => LspError::query(format!(
+                    "Query file {file_name} not found for language {lang_name}"
+                )),
+            })
     }
 
     #[test]
@@ -540,7 +576,7 @@ mod tests {
             "a broken configured asset must not be classified as ordinary absence"
         );
 
-        let error = QueryLoader::load_query_file(&[dir.path()], "rust", "highlights.scm")
+        let error = resolve_query(&[dir.path()], "rust", "highlights.scm")
             .expect_err("the present-but-broken asset must surface its read failure");
         let message = error.to_string();
         assert!(message.contains("Failed to read query file"), "{message}");
@@ -859,7 +895,233 @@ mod tests {
         assert!(result.is_ok(), "Should resolve with PathBuf search paths");
         let parsed = result.unwrap();
         assert!(parsed.query.is_some(), "Should produce a valid query");
-        assert!(parsed.used_inheritance, "Should detect inheritance");
+        assert!(parsed.combined, "Should detect inheritance");
+    }
+
+    // Tests for `;; extends` overlays across search paths
+
+    /// Write `<base>/queries/<lang>/highlights.scm` under a fresh base dir.
+    fn write_highlights(base: &Path, lang: &str, content: &str) {
+        let dir = base.join("queries").join(lang);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("highlights.scm"), content).unwrap();
+    }
+
+    fn position(haystack: &str, needle: &str) -> usize {
+        haystack
+            .find(needle)
+            .unwrap_or_else(|| panic!("{needle:?} missing from:\n{haystack}"))
+    }
+
+    #[test]
+    fn find_query_files_lists_every_search_path_hit_in_order() {
+        let first = tempdir().unwrap();
+        let second = tempdir().unwrap();
+        let third = tempdir().unwrap();
+        write_highlights(first.path(), "rust", "(a) @a\n");
+        write_highlights(third.path(), "rust", "(c) @c\n");
+
+        let bases = [
+            first.path().to_path_buf(),
+            second.path().to_path_buf(),
+            third.path().to_path_buf(),
+        ];
+        let found = QueryLoader::find_query_files(&bases, "rust", "highlights.scm");
+        assert_eq!(
+            found,
+            vec![
+                first.path().join("queries/rust/highlights.scm"),
+                third.path().join("queries/rust/highlights.scm"),
+            ]
+        );
+        assert!(QueryLoader::find_query_files(&bases, "../rust", "highlights.scm").is_empty());
+    }
+
+    #[test]
+    fn extends_overlay_in_a_later_search_path_is_appended_to_the_base() {
+        let base = tempdir().unwrap();
+        let overlay = tempdir().unwrap();
+        write_highlights(base.path(), "rust", "(identifier) @base\n");
+        write_highlights(
+            overlay.path(),
+            "rust",
+            ";; extends\n(string_literal) @overlay\n",
+        );
+
+        let bases = [base.path().to_path_buf(), overlay.path().to_path_buf()];
+        let content = resolve_query(&bases, "rust", "highlights.scm").unwrap();
+        assert!(
+            position(&content, "@base") < position(&content, "@overlay"),
+            "the base query comes first, then the overlay:\n{content}"
+        );
+    }
+
+    /// Neovim orders `base, extensions...` regardless of where in the runtime
+    /// path each was found: an overlay stays an overlay even when it sorts
+    /// ahead of the base.
+    #[test]
+    fn extends_overlay_in_an_earlier_search_path_still_follows_the_base() {
+        let overlay = tempdir().unwrap();
+        let base = tempdir().unwrap();
+        write_highlights(
+            overlay.path(),
+            "rust",
+            ";; extends\n(string_literal) @overlay\n",
+        );
+        write_highlights(base.path(), "rust", "(identifier) @base\n");
+
+        let bases = [overlay.path().to_path_buf(), base.path().to_path_buf()];
+        let content = resolve_query(&bases, "rust", "highlights.scm").unwrap();
+        assert!(
+            position(&content, "@base") < position(&content, "@overlay"),
+            "the base query comes first, then the overlay:\n{content}"
+        );
+    }
+
+    #[test]
+    fn a_second_plain_query_is_shadowed_by_the_first() {
+        let first = tempdir().unwrap();
+        let second = tempdir().unwrap();
+        write_highlights(first.path(), "rust", "(identifier) @first\n");
+        write_highlights(second.path(), "rust", "(identifier) @second\n");
+
+        let bases = [first.path().to_path_buf(), second.path().to_path_buf()];
+        let content = resolve_query(&bases, "rust", "highlights.scm").unwrap();
+        assert!(content.contains("@first"));
+        assert!(
+            !content.contains("@second"),
+            "a plain query in a later search path replaces nothing:\n{content}"
+        );
+    }
+
+    #[test]
+    fn every_extends_overlay_is_appended_in_search_path_order() {
+        let base = tempdir().unwrap();
+        let first = tempdir().unwrap();
+        let second = tempdir().unwrap();
+        write_highlights(base.path(), "rust", "(identifier) @base\n");
+        write_highlights(first.path(), "rust", ";; extends\n(a) @first\n");
+        write_highlights(second.path(), "rust", ";; extends\n(b) @second\n");
+
+        let bases = [
+            first.path().to_path_buf(),
+            base.path().to_path_buf(),
+            second.path().to_path_buf(),
+        ];
+        let content = resolve_query(&bases, "rust", "highlights.scm").unwrap();
+        let base_at = position(&content, "@base");
+        let first_at = position(&content, "@first");
+        let second_at = position(&content, "@second");
+        assert!(base_at < first_at && first_at < second_at, "{content}");
+    }
+
+    /// Neovim loads a language whose only query files are overlays (its
+    /// `base_query` stays nil and the extensions load alone); so does kakehashi.
+    #[test]
+    fn extends_overlays_load_without_a_base() {
+        let overlay = tempdir().unwrap();
+        write_highlights(overlay.path(), "rust", ";; extends\n(identifier) @only\n");
+
+        let content =
+            resolve_query(&[overlay.path().to_path_buf()], "rust", "highlights.scm").unwrap();
+        assert!(content.contains("@only"));
+    }
+
+    #[test]
+    fn extends_overlay_may_pull_in_inherits_parents() {
+        let base = tempdir().unwrap();
+        let overlay = tempdir().unwrap();
+        write_highlights(base.path(), "parent", "(identifier) @parent\n");
+        write_highlights(base.path(), "child", "(string_literal) @child\n");
+        write_highlights(
+            overlay.path(),
+            "child",
+            ";; extends\n;; inherits: parent\n(boolean_literal) @overlay\n",
+        );
+
+        let bases = [base.path().to_path_buf(), overlay.path().to_path_buf()];
+        let content = resolve_query(&bases, "child", "highlights.scm").unwrap();
+        let parent_at = position(&content, "@parent");
+        let child_at = position(&content, "@child");
+        let overlay_at = position(&content, "@overlay");
+        assert!(
+            parent_at < child_at && child_at < overlay_at,
+            "parents, then base, then overlays:\n{content}"
+        );
+    }
+
+    #[test]
+    fn an_inherited_parent_brings_its_own_extends_overlays() {
+        let base = tempdir().unwrap();
+        let overlay = tempdir().unwrap();
+        write_highlights(base.path(), "parent", "(identifier) @parent\n");
+        write_highlights(
+            base.path(),
+            "child",
+            "; inherits: parent\n(string_literal) @child\n",
+        );
+        write_highlights(
+            overlay.path(),
+            "parent",
+            ";; extends\n(boolean_literal) @parent_overlay\n",
+        );
+
+        let bases = [base.path().to_path_buf(), overlay.path().to_path_buf()];
+        let content = resolve_query(&bases, "child", "highlights.scm").unwrap();
+        let parent_at = position(&content, "@parent\n");
+        let parent_overlay_at = position(&content, "@parent_overlay");
+        let child_at = position(&content, "@child");
+        assert!(
+            parent_at < parent_overlay_at && parent_overlay_at < child_at,
+            "a parent resolves with its overlays before the child:\n{content}"
+        );
+    }
+
+    #[test]
+    fn combined_flag_reports_any_multi_file_query() {
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let base = tempdir().unwrap();
+        let overlay = tempdir().unwrap();
+        write_highlights(base.path(), "alone", "(identifier) @variable\n");
+        write_highlights(base.path(), "extended", "(identifier) @variable\n");
+        write_highlights(
+            overlay.path(),
+            "extended",
+            ";; extends\n(string_literal) @string\n",
+        );
+
+        let bases = [base.path().to_path_buf(), overlay.path().to_path_buf()];
+        let alone =
+            QueryLoader::load_query_with_inheritance(&language, &bases, "alone", "highlights.scm")
+                .unwrap();
+        assert!(!alone.combined, "one file, line numbers are the file's");
+        let extended = QueryLoader::load_query_with_inheritance(
+            &language,
+            &bases,
+            "extended",
+            "highlights.scm",
+        )
+        .unwrap();
+        assert!(
+            extended.combined,
+            "an overlay shifts line numbers like a parent does"
+        );
+        assert!(extended.query.is_some());
+    }
+
+    #[test]
+    fn missing_query_is_not_found_even_when_the_search_path_holds_other_languages() {
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let base = tempdir().unwrap();
+        write_highlights(base.path(), "other", "(identifier) @variable\n");
+
+        let result = QueryLoader::load_query_with_inheritance(
+            &language,
+            &[base.path().to_path_buf()],
+            "rust",
+            "highlights.scm",
+        );
+        assert!(matches!(result, Err(QueryLoadError::NotFound)));
     }
 
     // Tests for query inheritance

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -1473,9 +1473,6 @@ mod tests {
             content.contains("@keyword.import"),
             "Should contain typescript patterns"
         );
-
-        // The directive stays as a comment, so both languages' lines hold.
-        assert!(content.contains("; inherits:"));
     }
 
     #[test]
@@ -1542,9 +1539,6 @@ mod tests {
             content.contains("@variable.parameter"),
             "Should contain javascript patterns"
         );
-
-        // The directive stays as a comment, so both languages' lines hold.
-        assert!(content.contains("; inherits:"));
     }
 
     // ============================================================

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -1,5 +1,5 @@
 use crate::error::{LspError, LspResult};
-use crate::language::query_modeline::{parse_inherits_directive, starts_with_inherits_directive};
+use crate::language::query_modeline::parse_modeline;
 use log::warn;
 use path_clean::PathClean;
 use std::fmt::Write;
@@ -117,10 +117,10 @@ impl QueryLoader {
 
     /// Resolve query inheritance and return the combined query content.
     ///
-    /// Recursively resolves parent queries, concatenating parents-first then child,
-    /// and removes the `; inherits:` directive. `preloaded_content` lets the caller
-    /// skip a re-read when it already has the content; `visited` guards against
-    /// circular inheritance.
+    /// Recursively resolves parent queries, concatenating parents-first then
+    /// child. The modeline stays in place: tree-sitter reads it as a comment.
+    /// `preloaded_content` lets the caller skip a re-read when it already has
+    /// the content; `visited` guards against circular inheritance.
     fn resolve_query_recursive<P: AsRef<Path>>(
         runtime_bases: &[P],
         lang_name: &str,
@@ -143,8 +143,7 @@ impl QueryLoader {
             None => Self::load_query_file(runtime_bases, lang_name, file_name)?,
         };
 
-        // Parse inheritance directive
-        let parents = parse_inherits_directive(&content);
+        let parents = parse_modeline(&content).inherits;
 
         // Build combined query: parents first, then child
         let mut combined = String::new();
@@ -157,23 +156,11 @@ impl QueryLoader {
             combined.push('\n');
         }
 
-        // Add child content (without the inherits directive line)
-        let child_content = Self::strip_inherits_directive(&content);
-        combined.push_str(&child_content);
+        combined.push_str(&content);
 
         visited.remove(lang_name);
 
         Ok(combined)
-    }
-
-    /// Remove the `; inherits:` line from query content.
-    fn strip_inherits_directive(content: &str) -> String {
-        if starts_with_inherits_directive(content) {
-            // Skip the first line
-            content.lines().skip(1).collect::<Vec<_>>().join("\n")
-        } else {
-            content.to_string()
-        }
     }
 
     /// Load query content from paths (without parsing).
@@ -387,7 +374,7 @@ impl QueryLoader {
                 e
             ))
         })?;
-        let used_inheritance = !parse_inherits_directive(&original_content).is_empty();
+        let used_inheritance = !parse_modeline(&original_content).inherits.is_empty();
 
         let mut visited = std::collections::HashSet::new();
         let query_str = Self::resolve_query_recursive(
@@ -973,29 +960,31 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_query_removes_directive() {
-        // The "; inherits:" line should be removed from output
+    fn test_resolve_query_keeps_the_modeline_as_an_inert_comment() {
+        // Nothing needs to strip the directive: tree-sitter reads a `;` line
+        // as a comment, and leaving it keeps the child's line numbers intact.
         let dir = tempdir().unwrap();
 
-        // Create ecma query
         let ecma_dir = dir.path().join("queries").join("ecma");
         fs::create_dir_all(&ecma_dir).unwrap();
         fs::write(ecma_dir.join("highlights.scm"), "(identifier) @variable\n").unwrap();
 
-        // Create typescript query with inherits
         let ts_dir = dir.path().join("queries").join("typescript");
         fs::create_dir_all(&ts_dir).unwrap();
         fs::write(
             ts_dir.join("highlights.scm"),
-            "; inherits: ecma\n\"require\" @keyword\n",
+            "; inherits: ecma\n(string_literal) @string\n",
         )
         .unwrap();
 
-        let result = resolve_query(&[dir.path().to_path_buf()], "typescript", "highlights.scm");
-        let content = result.unwrap();
-
-        // The inherits directive should not be in the output
-        assert!(!content.contains("; inherits:"));
+        let content =
+            resolve_query(&[dir.path().to_path_buf()], "typescript", "highlights.scm").unwrap();
+        assert!(content.contains("; inherits: ecma"));
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        assert!(
+            tree_sitter::Query::new(&language, &content).is_ok(),
+            "the directive must compile away as a comment"
+        );
     }
 
     #[test]
@@ -1034,11 +1023,8 @@ mod tests {
             "Should contain typescript patterns"
         );
 
-        // Should NOT have the inherits directive
-        assert!(
-            !content.contains("; inherits:"),
-            "Should strip inherits directive"
-        );
+        // The directive stays as a comment, so both languages' lines hold.
+        assert!(content.contains("; inherits:"));
     }
 
     #[test]
@@ -1106,11 +1092,8 @@ mod tests {
             "Should contain javascript patterns"
         );
 
-        // Should NOT have the inherits directive
-        assert!(
-            !content.contains("; inherits:"),
-            "Should strip inherits directive"
-        );
+        // The directive stays as a comment, so both languages' lines hold.
+        assert!(content.contains("; inherits:"));
     }
 
     // ============================================================

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -517,9 +517,7 @@ mod tests {
             .map(|resolved| resolved.content)
             .map_err(|e| match e {
                 QueryLoadError::Other(e) => e,
-                QueryLoadError::NotFound => LspError::query(format!(
-                    "Query file {file_name} not found for language {lang_name}"
-                )),
+                not_found @ QueryLoadError::NotFound => LspError::query(not_found.to_string()),
             })
     }
 

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -167,12 +167,18 @@ impl QueryLoader {
                 ))
             })?;
             let modeline = parse_modeline(&content);
+            // Naming the language itself is Neovim's older way to say
+            // `extends` (`add_included_lang` returns "extension" for it), so
+            // the file is an overlay, not a parent of itself.
+            let mut extends = modeline.extends;
             for parent in modeline.inherits {
-                if !parents.contains(&parent) {
+                if parent == lang_name {
+                    extends = true;
+                } else if !parents.contains(&parent) {
                     parents.push(parent);
                 }
             }
-            if modeline.extends {
+            if extends {
                 overlays.push(content);
             } else if base.is_none() {
                 base = Some(content);
@@ -1029,6 +1035,31 @@ mod tests {
         let content =
             resolve_query(&[overlay.path().to_path_buf()], "rust", "highlights.scm").unwrap();
         assert!(content.contains("@only"));
+    }
+
+    /// Neovim's `add_included_lang` treats `; inherits: rust` inside rust's
+    /// own query file as the `extends` marker (its `query.set()` docs use that
+    /// idiom), so the file must merge as an overlay rather than trip the
+    /// cycle check and drop the language's query.
+    #[test]
+    fn a_file_that_inherits_its_own_language_is_an_overlay() {
+        let base = tempdir().unwrap();
+        let overlay = tempdir().unwrap();
+        write_highlights(base.path(), "rust", "(identifier) @base\n");
+        write_highlights(
+            overlay.path(),
+            "rust",
+            "; inherits: rust\n(string_literal) @overlay\n",
+        );
+
+        // The self-inheriting file sits first, where a plain file would be the
+        // base: it must still follow the real base as an overlay.
+        let bases = [overlay.path().to_path_buf(), base.path().to_path_buf()];
+        let content = resolve_query(&bases, "rust", "highlights.scm").unwrap();
+        assert!(
+            position(&content, "@base") < position(&content, "@overlay"),
+            "the base query comes first, then the self-inheriting overlay:\n{content}"
+        );
     }
 
     #[test]

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -15,7 +15,7 @@ const PARSER_EXTENSIONS: &[&str] = &["so", "dylib", "dll"];
 /// Known limitation: when a query is combined from several files (`inherits`
 /// parents, `extends` overlays), line numbers refer to the **combined** query
 /// string, not the original source file (a pattern on line 5 of a child whose
-/// parent has 100 lines reports 105).
+/// parent has 100 lines reports about 105).
 #[derive(Debug, Clone)]
 pub(crate) struct SkippedPattern {
     /// The pattern text that failed to compile
@@ -1317,7 +1317,7 @@ mod tests {
 
     #[test]
     fn test_resolve_query_no_inheritance() {
-        // ecma has no inheritance - should return content as-is
+        // ecma has no inheritance - the content is the file's own
         let dir = tempdir().unwrap();
 
         // Create ecma query

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -190,11 +190,13 @@ impl QueryLoader {
             // overlay, not a parent of itself.
             let mut extends = modeline.extends;
             for parent in modeline.inherits {
-                if parent.name == lang_name {
-                    extends = true;
-                } else if parent.optional && is_included {
+                if parent.optional && is_included {
                     // `(cpp)`: inherited when this file is loaded for its own
                     // language, not when the file is itself being inherited.
+                    // Neovim skips the entry before looking at it at all, so
+                    // an optional self-name does not mark an overlay either.
+                } else if parent.name == lang_name {
+                    extends = true;
                 } else if !parents.iter().any(|(name, _)| *name == parent.name) {
                     parents.push((parent.name, path));
                 }
@@ -1248,6 +1250,36 @@ mod tests {
         fs::remove_file(base.path().join("queries/cpp/highlights.scm")).unwrap();
         assert!(resolve_query(&bases, "cuda", "highlights.scm").is_ok());
         assert!(resolve_query(&bases, "c", "highlights.scm").is_err());
+    }
+
+    /// Neovim skips a parenthesized entry of an inherited file before
+    /// looking at it, so `; inherits: (c)` in c's own file marks an overlay
+    /// when c is loaded for itself but not when c is reached as a parent —
+    /// there the file is c's base, shadowing a plain c in a later path.
+    #[test]
+    fn an_optional_self_name_marks_an_overlay_only_at_the_top_of_the_chain() {
+        let first = tempdir().unwrap();
+        let second = tempdir().unwrap();
+        write_highlights(first.path(), "c", "; inherits: (c)\n(identifier) @first\n");
+        write_highlights(second.path(), "c", "(string_literal) @second\n");
+        write_highlights(
+            second.path(),
+            "cuda",
+            "; inherits: c\n(boolean_literal) @cuda\n",
+        );
+
+        let bases = [first.path().to_path_buf(), second.path().to_path_buf()];
+        let c = resolve_query(&bases, "c", "highlights.scm").unwrap();
+        assert!(
+            position(&c, "@second") < position(&c, "@first"),
+            "loaded for itself, the self-naming file is an overlay on the plain one:\n{c}"
+        );
+        let cuda = resolve_query(&bases, "cuda", "highlights.scm").unwrap();
+        assert!(cuda.contains("@first"), "{cuda}");
+        assert!(
+            !cuda.contains("@second"),
+            "reached as a parent, the self-naming file is c's base and shadows the other:\n{cuda}"
+        );
     }
 
     #[test]

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -267,10 +267,7 @@ impl QueryLoader {
         for path in paths {
             let normalized_path = path.as_ref().clean();
             match fs::read_to_string(&normalized_path) {
-                Ok(content) => {
-                    combined_query.push_str(&content);
-                    combined_query.push('\n');
-                }
+                Ok(content) => append_file(&mut combined_query, &content),
                 Err(e) => {
                     return Err(LspError::query(format!(
                         "Failed to read query file {}: {e}",
@@ -841,6 +838,21 @@ mod tests {
         assert!(
             layered.multi_file,
             "a second explicit path shifts line numbers like an overlay does"
+        );
+    }
+
+    #[test]
+    fn explicit_paths_join_on_a_line_boundary_without_blank_lines() {
+        let dir = tempdir().unwrap();
+        let one = dir.path().join("one.scm");
+        let two = dir.path().join("two.scm");
+        fs::write(&one, "(identifier) @variable\n").unwrap();
+        fs::write(&two, "(string_literal) @string").unwrap();
+
+        let content = QueryLoader::load_content_from_paths(&[&one, &two]).unwrap();
+        assert_eq!(
+            content,
+            "(identifier) @variable\n(string_literal) @string\n"
         );
     }
 

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -133,6 +133,12 @@ impl QueryLoader {
     /// overlays`. Modelines stay in place: tree-sitter reads them as comments,
     /// and keeping them keeps each file's line numbers intact.
     ///
+    /// One departure from `get_files`, on purpose: a parent named more than
+    /// once — twice on a line, or by the base and an overlay both — is
+    /// concatenated once. Neovim appends it each time, and every pattern in
+    /// it then matches twice; nothing relies on that, and no nvim-treesitter
+    /// query repeats a name.
+    ///
     /// `is_included` says the language is being resolved as a parent of
     /// another rather than for itself; Neovim's `get_files(lang, name,
     /// is_included)` then skips parents written in parentheses, `(cpp)`, and

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -1164,6 +1164,31 @@ mod tests {
     }
 
     #[test]
+    fn a_parent_named_by_both_base_and_overlay_is_concatenated_once() {
+        let base = tempdir().unwrap();
+        let overlay = tempdir().unwrap();
+        write_highlights(base.path(), "parent", "(identifier) @parent\n");
+        write_highlights(
+            base.path(),
+            "child",
+            "; inherits: parent\n(string_literal) @child\n",
+        );
+        write_highlights(
+            overlay.path(),
+            "child",
+            ";; extends\n;; inherits: parent\n(boolean_literal) @overlay\n",
+        );
+
+        let bases = [base.path().to_path_buf(), overlay.path().to_path_buf()];
+        let content = resolve_query(&bases, "child", "highlights.scm").unwrap();
+        assert_eq!(
+            content.matches("@parent").count(),
+            1,
+            "one parent, however many files name it:\n{content}"
+        );
+    }
+
+    #[test]
     fn an_inherited_parent_brings_its_own_extends_overlays() {
         let base = tempdir().unwrap();
         let overlay = tempdir().unwrap();

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -155,7 +155,9 @@ impl QueryLoader {
             return Err(QueryLoadError::NotFound);
         }
 
-        let mut parents: Vec<String> = Vec::new();
+        // Each parent with the file that first named it, so a parent that
+        // cannot be found is reported against the modeline to fix.
+        let mut parents: Vec<(String, &PathBuf)> = Vec::new();
         let mut base: Option<String> = None;
         let mut overlays: Vec<String> = Vec::new();
         for path in &paths {
@@ -174,8 +176,8 @@ impl QueryLoader {
             for parent in modeline.inherits {
                 if parent == lang_name {
                     extends = true;
-                } else if !parents.contains(&parent) {
-                    parents.push(parent);
+                } else if !parents.iter().any(|(name, _)| *name == parent) {
+                    parents.push((parent, path));
                 }
             }
             if extends {
@@ -193,7 +195,7 @@ impl QueryLoader {
         // A shadowed plain file contributed no text, so it does not count.
         let mut file_count = usize::from(base.is_some()) + overlays.len();
         let mut combined = String::new();
-        for parent in &parents {
+        for (parent, declared_in) in &parents {
             let resolved = match Self::resolve_query_recursive(
                 runtime_bases,
                 parent,
@@ -204,10 +206,11 @@ impl QueryLoader {
                 Err(QueryLoadError::NotFound) => {
                     visited.remove(lang_name);
                     return Err(LspError::query(format!(
-                        "Query file {} not found for language {} (inherited by {}) in search paths: {}",
+                        "Query file {} not found for language {} (inherited by {} in {}) in search paths: {}",
                         file_name,
                         parent,
                         lang_name,
+                        declared_in.display(),
                         format_search_paths(runtime_bases)
                     ))
                     .into());
@@ -1192,6 +1195,33 @@ mod tests {
             "an overlay shifts line numbers like a parent does"
         );
         assert!(extended.query.is_some());
+    }
+
+    /// With a base and any number of overlays each allowed to name parents,
+    /// the error for a parent that does not exist must say which file named
+    /// it, or a typo in one overlay sends the reader through every file.
+    #[test]
+    fn a_missing_parent_is_reported_against_the_file_that_named_it() {
+        let base = tempdir().unwrap();
+        let overlay = tempdir().unwrap();
+        write_highlights(base.path(), "rust", "(identifier) @base\n");
+        write_highlights(
+            overlay.path(),
+            "rust",
+            ";; extends\n;; inherits: rsut\n(string_literal) @overlay\n",
+        );
+
+        let bases = [base.path().to_path_buf(), overlay.path().to_path_buf()];
+        let err = resolve_query(&bases, "rust", "highlights.scm").unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("not found for language rsut"), "{message}");
+        assert!(
+            message.contains(&format!(
+                "inherited by rust in {}",
+                overlay.path().join("queries/rust/highlights.scm").display()
+            )),
+            "{message}"
+        );
     }
 
     #[test]

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -524,10 +524,11 @@ impl QueryLoader {
 /// Append one file's text so the next file starts on a fresh line and no
 /// line is added that the file did not have: a file's line numbers in the
 /// combined text are then its own plus the lines of what precedes it, which
-/// is what a skipped-pattern warning quotes.
+/// is what a skipped-pattern warning quotes. An empty file has no lines and
+/// contributes none.
 fn append_file(combined: &mut String, content: &str) {
     combined.push_str(content);
-    if !content.ends_with('\n') {
+    if !content.is_empty() && !content.ends_with('\n') {
         combined.push('\n');
     }
 }
@@ -1376,6 +1377,14 @@ mod tests {
         assert_eq!(
             content,
             "(identifier) @parent\n; inherits: parent\n(string_literal) @child\n;; extends\n(boolean_literal) @overlay\n"
+        );
+
+        // An empty parent has no lines and must not push the child down one.
+        write_highlights(base.path(), "parent", "");
+        let content = resolve_query(&bases, "child", "highlights.scm").unwrap();
+        assert_eq!(
+            content,
+            "; inherits: parent\n(string_literal) @child\n;; extends\n(boolean_literal) @overlay\n"
         );
     }
 

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -133,11 +133,13 @@ impl QueryLoader {
     /// overlays`. Modelines stay in place: tree-sitter reads them as comments,
     /// and keeping them keeps each file's line numbers intact.
     ///
-    /// One departure from `get_files`, on purpose: a parent named more than
-    /// once — twice on a line, or by the base and an overlay both — is
-    /// concatenated once. Neovim appends it each time, and every pattern in
-    /// it then matches twice; nothing relies on that, and no nvim-treesitter
-    /// query repeats a name.
+    /// One departure from `get_files`, on purpose: a language reached more
+    /// than once — named twice on a line, by the base and an overlay both, or
+    /// as the shared ancestor of two parents — is concatenated once. Neovim
+    /// appends it each time, and every pattern in it then matches twice;
+    /// nothing relies on that, and no nvim-treesitter query set has such a
+    /// shape. `emitted` is the set of languages already concatenated in this
+    /// resolution.
     ///
     /// `is_included` says the language is being resolved as a parent of
     /// another rather than for itself; Neovim's `get_files(lang, name,
@@ -146,15 +148,16 @@ impl QueryLoader {
     ///
     /// `visited` holds the languages on the current inheritance path so a
     /// cycle is an error; a language leaves it on the way back out so a
-    /// diamond (two parents sharing an ancestor) resolves, as in Neovim. No
-    /// error path removes anything: every error propagates straight to the
-    /// top-level call, which owns the set and drops it.
+    /// diamond (two parents sharing an ancestor) resolves. No error path
+    /// removes anything: every error propagates straight to the top-level
+    /// call, which owns both sets and drops them.
     fn resolve_query_recursive<P: AsRef<Path>>(
         runtime_bases: &[P],
         lang_name: &str,
         file_name: &str,
         is_included: bool,
         visited: &mut std::collections::HashSet<String>,
+        emitted: &mut std::collections::HashSet<String>,
     ) -> Result<ResolvedQuery, QueryLoadError> {
         if visited.contains(lang_name) {
             return Err(LspError::query(format!(
@@ -217,12 +220,16 @@ impl QueryLoader {
         let mut file_count = usize::from(base.is_some()) + overlays.len();
         let mut combined = String::new();
         for (parent, declared_in) in &parents {
+            if emitted.contains(parent) {
+                continue;
+            }
             let resolved = match Self::resolve_query_recursive(
                 runtime_bases,
                 parent,
                 file_name,
                 true,
                 visited,
+                emitted,
             ) {
                 Ok(resolved) => resolved,
                 Err(QueryLoadError::NotFound) => {
@@ -241,6 +248,7 @@ impl QueryLoader {
             combined.push_str(&resolved.content);
             combined.push('\n');
             file_count += resolved.file_count;
+            emitted.insert(parent.clone());
         }
         for content in base.into_iter().chain(overlays) {
             combined.push_str(&content);
@@ -438,12 +446,14 @@ impl QueryLoader {
         file_name: &str,
     ) -> Result<ParseResult, QueryLoadError> {
         let mut visited = std::collections::HashSet::new();
+        let mut emitted = std::collections::HashSet::new();
         let resolved = Self::resolve_query_recursive(
             runtime_bases,
             lang_name,
             file_name,
             false,
             &mut visited,
+            &mut emitted,
         )?;
         Ok(Self::parse_query(
             language,
@@ -537,12 +547,14 @@ mod tests {
         file_name: &str,
     ) -> LspResult<String> {
         let mut visited = std::collections::HashSet::new();
+        let mut emitted = std::collections::HashSet::new();
         QueryLoader::resolve_query_recursive(
             runtime_bases,
             lang_name,
             file_name,
             false,
             &mut visited,
+            &mut emitted,
         )
         .map(|resolved| resolved.content)
         .map_err(|e| match e {
@@ -1282,6 +1294,42 @@ mod tests {
         );
     }
 
+    /// A base and an overlay may inherit different parents that share an
+    /// ancestor; that ancestor's patterns must not be compiled twice.
+    #[test]
+    fn a_shared_ancestor_of_base_and_overlay_parents_is_concatenated_once() {
+        let base = tempdir().unwrap();
+        let overlay = tempdir().unwrap();
+        write_highlights(base.path(), "shared", "(identifier) @shared\n");
+        write_highlights(
+            base.path(),
+            "a",
+            "; inherits: shared\n(string_literal) @a\n",
+        );
+        write_highlights(
+            base.path(),
+            "b",
+            "; inherits: shared\n(raw_string_literal) @b\n",
+        );
+        write_highlights(
+            base.path(),
+            "child",
+            "; inherits: a\n(boolean_literal) @child\n",
+        );
+        write_highlights(
+            overlay.path(),
+            "child",
+            ";; extends\n;; inherits: b\n(integer_literal) @overlay\n",
+        );
+
+        let bases = [base.path().to_path_buf(), overlay.path().to_path_buf()];
+        let content = resolve_query(&bases, "child", "highlights.scm").unwrap();
+        assert_eq!(content.matches("@shared").count(), 1, "{content}");
+        for capture in ["@a", "@b", "@child", "@overlay"] {
+            assert_eq!(content.matches(capture).count(), 1, "{capture}:\n{content}");
+        }
+    }
+
     #[test]
     fn a_parent_named_by_both_base_and_overlay_is_concatenated_once() {
         let base = tempdir().unwrap();
@@ -1501,7 +1549,11 @@ mod tests {
             result.err()
         );
         let content = result.unwrap();
-        assert!(content.contains("(identifier) @shared"));
+        assert_eq!(
+            content.matches("(identifier) @shared").count(),
+            1,
+            "a shared ancestor is concatenated once, not once per path to it:\n{content}"
+        );
         assert!(content.contains("(string_literal) @parent_a"));
         assert!(content.contains("(raw_string_literal) @parent_b"));
         assert!(content.contains("(boolean_literal) @child"));

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -65,7 +65,7 @@ pub(crate) struct ParseResult {
     /// Whether more than one file contributed (`inherits` parents, `extends`
     /// overlays). When true, line numbers in `skipped` refer to the combined
     /// query, not any one source file.
-    pub combined: bool,
+    pub multi_file: bool,
 }
 
 /// The text of a query assembled from every file that contributes to it.
@@ -306,7 +306,11 @@ impl QueryLoader {
     /// First attempts full compilation (fast path). If that fails, splits the
     /// query into individual patterns, validates each separately, and combines
     /// only the valid ones.
-    pub(crate) fn parse_query(language: &Language, query_str: &str, combined: bool) -> ParseResult {
+    pub(crate) fn parse_query(
+        language: &Language,
+        query_str: &str,
+        multi_file: bool,
+    ) -> ParseResult {
         use crate::language::query_pattern_splitter::split_patterns;
 
         // Fast path: try full compilation first.
@@ -319,7 +323,7 @@ impl QueryLoader {
                 query: Some(query),
                 skipped: Vec::new(),
                 failure_reason: None,
-                combined,
+                multi_file,
             };
         }
 
@@ -334,7 +338,7 @@ impl QueryLoader {
                     query: None,
                     skipped: Vec::new(),
                     failure_reason: Some(ParseFailure::PatternSplitFailed(reason)),
-                    combined,
+                    multi_file,
                 };
             }
         };
@@ -364,7 +368,7 @@ impl QueryLoader {
                 query: None,
                 skipped,
                 failure_reason: Some(ParseFailure::AllPatternsInvalid),
-                combined,
+                multi_file,
             };
         }
 
@@ -374,7 +378,7 @@ impl QueryLoader {
                 query: Some(q),
                 skipped,
                 failure_reason: None,
-                combined,
+                multi_file,
             },
             Err(e) => {
                 // Defensive: handle the rare case where individually-valid patterns
@@ -388,7 +392,7 @@ impl QueryLoader {
                     query: None,
                     skipped,
                     failure_reason: Some(ParseFailure::CombinationFailed(e.message)),
-                    combined,
+                    multi_file,
                 }
             }
         }
@@ -906,7 +910,7 @@ mod tests {
         assert!(result.is_ok(), "Should resolve with PathBuf search paths");
         let parsed = result.unwrap();
         assert!(parsed.query.is_some(), "Should produce a valid query");
-        assert!(parsed.combined, "Should detect inheritance");
+        assert!(parsed.multi_file, "Should detect inheritance");
     }
 
     // Tests for `;; extends` overlays across search paths
@@ -1009,7 +1013,7 @@ mod tests {
             QueryLoader::load_query_with_inheritance(&language, &bases, "rust", "highlights.scm")
                 .unwrap();
         assert!(
-            !parsed.combined,
+            !parsed.multi_file,
             "a shadowed file contributed nothing, so line numbers are the base file's own"
         );
     }
@@ -1123,7 +1127,7 @@ mod tests {
     }
 
     #[test]
-    fn combined_flag_reports_any_multi_file_query() {
+    fn multi_file_flag_reports_any_multi_file_query() {
         let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
         let base = tempdir().unwrap();
         let overlay = tempdir().unwrap();
@@ -1139,7 +1143,7 @@ mod tests {
         let alone =
             QueryLoader::load_query_with_inheritance(&language, &bases, "alone", "highlights.scm")
                 .unwrap();
-        assert!(!alone.combined, "one file, line numbers are the file's");
+        assert!(!alone.multi_file, "one file, line numbers are the file's");
         let extended = QueryLoader::load_query_with_inheritance(
             &language,
             &bases,
@@ -1148,7 +1152,7 @@ mod tests {
         )
         .unwrap();
         assert!(
-            extended.combined,
+            extended.multi_file,
             "an overlay shifts line numbers like a parent does"
         );
         assert!(extended.query.is_some());

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -133,6 +133,11 @@ impl QueryLoader {
     /// overlays`. Modelines stay in place: tree-sitter reads them as comments,
     /// and keeping them keeps each file's line numbers intact.
     ///
+    /// `is_included` says the language is being resolved as a parent of
+    /// another rather than for itself; Neovim's `get_files(lang, name,
+    /// is_included)` then skips parents written in parentheses, `(cpp)`, and
+    /// so does this.
+    ///
     /// `visited` holds the languages on the current inheritance path so a
     /// cycle is an error; a language leaves it on the way back out so a
     /// diamond (two parents sharing an ancestor) resolves, as in Neovim. No
@@ -142,6 +147,7 @@ impl QueryLoader {
         runtime_bases: &[P],
         lang_name: &str,
         file_name: &str,
+        is_included: bool,
         visited: &mut std::collections::HashSet<String>,
     ) -> Result<ResolvedQuery, QueryLoadError> {
         if visited.contains(lang_name) {
@@ -178,10 +184,13 @@ impl QueryLoader {
             // overlay, not a parent of itself.
             let mut extends = modeline.extends;
             for parent in modeline.inherits {
-                if parent == lang_name {
+                if parent.name == lang_name {
                     extends = true;
-                } else if !parents.iter().any(|(name, _)| *name == parent) {
-                    parents.push((parent, path));
+                } else if parent.optional && is_included {
+                    // `(cpp)`: inherited when this file is loaded for its own
+                    // language, not when the file is itself being inherited.
+                } else if !parents.iter().any(|(name, _)| *name == parent.name) {
+                    parents.push((parent.name, path));
                 }
             }
             if extends {
@@ -204,6 +213,7 @@ impl QueryLoader {
                 runtime_bases,
                 parent,
                 file_name,
+                true,
                 visited,
             ) {
                 Ok(resolved) => resolved,
@@ -420,8 +430,13 @@ impl QueryLoader {
         file_name: &str,
     ) -> Result<ParseResult, QueryLoadError> {
         let mut visited = std::collections::HashSet::new();
-        let resolved =
-            Self::resolve_query_recursive(runtime_bases, lang_name, file_name, &mut visited)?;
+        let resolved = Self::resolve_query_recursive(
+            runtime_bases,
+            lang_name,
+            file_name,
+            false,
+            &mut visited,
+        )?;
         Ok(Self::parse_query(
             language,
             &resolved.content,
@@ -514,12 +529,18 @@ mod tests {
         file_name: &str,
     ) -> LspResult<String> {
         let mut visited = std::collections::HashSet::new();
-        QueryLoader::resolve_query_recursive(runtime_bases, lang_name, file_name, &mut visited)
-            .map(|resolved| resolved.content)
-            .map_err(|e| match e {
-                QueryLoadError::Other(e) => e,
-                not_found @ QueryLoadError::NotFound => LspError::query(not_found.to_string()),
-            })
+        QueryLoader::resolve_query_recursive(
+            runtime_bases,
+            lang_name,
+            file_name,
+            false,
+            &mut visited,
+        )
+        .map(|resolved| resolved.content)
+        .map_err(|e| match e {
+            QueryLoadError::Other(e) => e,
+            not_found @ QueryLoadError::NotFound => LspError::query(not_found.to_string()),
+        })
     }
 
     #[test]
@@ -1187,6 +1208,40 @@ mod tests {
             parent_at < child_at && child_at < overlay_at,
             "parents, then base, then overlays:\n{content}"
         );
+    }
+
+    /// Neovim's `get_files` inherits a parenthesized parent, `(cpp)`, only
+    /// when the file is loaded for its own language; a file reached as a
+    /// parent skips its optional parents, so a chain stops there instead of
+    /// pulling in — or failing on — a grandparent the child never asked for.
+    #[test]
+    fn an_optional_parent_is_inherited_only_at_the_top_of_the_chain() {
+        let base = tempdir().unwrap();
+        write_highlights(base.path(), "cpp", "(identifier) @cpp\n");
+        write_highlights(base.path(), "c", "; inherits: (cpp)\n(string_literal) @c\n");
+        write_highlights(
+            base.path(),
+            "cuda",
+            "; inherits: c\n(boolean_literal) @cuda\n",
+        );
+
+        let bases = [base.path().to_path_buf()];
+        let c = resolve_query(&bases, "c", "highlights.scm").unwrap();
+        assert!(
+            position(&c, "@cpp") < position(&c, "@c\n"),
+            "loaded for itself, c inherits (cpp):\n{c}"
+        );
+        let cuda = resolve_query(&bases, "cuda", "highlights.scm").unwrap();
+        assert!(
+            !cuda.contains("@cpp"),
+            "reached as a parent, c skips its optional (cpp):\n{cuda}"
+        );
+        assert!(position(&cuda, "@c\n") < position(&cuda, "@cuda"), "{cuda}");
+
+        // The skipped grandparent need not even exist for the child to load.
+        fs::remove_file(base.path().join("queries/cpp/highlights.scm")).unwrap();
+        assert!(resolve_query(&bases, "cuda", "highlights.scm").is_ok());
+        assert!(resolve_query(&bases, "c", "highlights.scm").is_err());
     }
 
     #[test]

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -1367,6 +1367,41 @@ mod tests {
         );
     }
 
+    /// An entry skipped as optional is never entered into the parent list,
+    /// so a later file naming the same parent bare still has it followed —
+    /// in either file order, and however the language is reached.
+    #[test]
+    fn an_optional_entry_in_one_file_does_not_suppress_a_bare_one_in_another() {
+        let first = tempdir().unwrap();
+        let second = tempdir().unwrap();
+        write_highlights(second.path(), "cpp", "(identifier) @cpp\n");
+        write_highlights(
+            first.path(),
+            "c",
+            ";; extends\n;; inherits: (cpp)\n(string_literal) @overlay\n",
+        );
+        write_highlights(
+            second.path(),
+            "c",
+            "; inherits: cpp\n(boolean_literal) @base\n",
+        );
+        write_highlights(
+            second.path(),
+            "cuda",
+            "; inherits: c\n(integer_literal) @cuda\n",
+        );
+
+        let bases = [first.path().to_path_buf(), second.path().to_path_buf()];
+        for lang in ["c", "cuda"] {
+            let content = resolve_query(&bases, lang, "highlights.scm").unwrap();
+            assert_eq!(
+                content.matches("@cpp").count(),
+                1,
+                "{lang}: the base's bare `cpp` is followed once:\n{content}"
+            );
+        }
+    }
+
     #[test]
     fn a_parent_named_by_both_base_and_overlay_is_concatenated_once() {
         let base = tempdir().unwrap();

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -1112,6 +1112,34 @@ mod tests {
         );
     }
 
+    /// Every hit must be readable: a broken overlay in a later search path
+    /// fails the language rather than silently loading without it, the same
+    /// "present but broken is not absence" rule the single-hit case follows
+    /// (and what Neovim's `get_files` does — `io.open` failure is an error).
+    #[cfg(unix)]
+    #[test]
+    fn an_unreadable_overlay_in_a_later_search_path_fails_the_load() {
+        use std::os::unix::fs::symlink;
+
+        let base = tempdir().unwrap();
+        let overlay = tempdir().unwrap();
+        write_highlights(base.path(), "rust", "(identifier) @base\n");
+        let overlay_dir = overlay.path().join("queries/rust");
+        fs::create_dir_all(&overlay_dir).unwrap();
+        let dangling = overlay_dir.join("highlights.scm");
+        symlink("missing-target.scm", &dangling).unwrap();
+
+        let bases = [base.path().to_path_buf(), overlay.path().to_path_buf()];
+        let err = resolve_query(&bases, "rust", "highlights.scm")
+            .expect_err("a present-but-broken overlay must surface its read failure");
+        let message = err.to_string();
+        assert!(message.contains("Failed to read query file"), "{message}");
+        assert!(
+            message.contains(&dangling.display().to_string()),
+            "{message}"
+        );
+    }
+
     #[test]
     fn extends_overlay_may_pull_in_inherits_parents() {
         let base = tempdir().unwrap();

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -1,4 +1,5 @@
 use crate::error::{LspError, LspResult};
+use crate::language::query_modeline::{parse_inherits_directive, starts_with_inherits_directive};
 use log::warn;
 use path_clean::PathClean;
 use std::fmt::Write;
@@ -8,7 +9,6 @@ use tree_sitter::{Language, Query};
 
 /// Parser library file extensions for different platforms
 const PARSER_EXTENSIONS: &[&str] = &["so", "dylib", "dll"];
-const INHERITS_DIRECTIVE_PREFIX: &str = "; inherits:";
 
 /// Information about a pattern that was skipped during tolerant parsing.
 ///
@@ -144,7 +144,7 @@ impl QueryLoader {
         };
 
         // Parse inheritance directive
-        let parents = Self::parse_inherits_directive(&content);
+        let parents = parse_inherits_directive(&content);
 
         // Build combined query: parents first, then child
         let mut combined = String::new();
@@ -168,28 +168,11 @@ impl QueryLoader {
 
     /// Remove the `; inherits:` line from query content.
     fn strip_inherits_directive(content: &str) -> String {
-        let first_line = content.lines().next().unwrap_or("");
-        if first_line.starts_with(INHERITS_DIRECTIVE_PREFIX) {
+        if starts_with_inherits_directive(content) {
             // Skip the first line
             content.lines().skip(1).collect::<Vec<_>>().join("\n")
         } else {
             content.to_string()
-        }
-    }
-
-    /// Parse the `; inherits: lang1,lang2` directive from query content.
-    ///
-    /// nvim-treesitter queries declare inheritance via this first-line directive;
-    /// returns the parent language names (empty if absent).
-    fn parse_inherits_directive(content: &str) -> Vec<String> {
-        let first_line = content.lines().next().unwrap_or("");
-        if let Some(rest) = first_line.strip_prefix(INHERITS_DIRECTIVE_PREFIX) {
-            rest.split(',')
-                .map(|s| normalize_inherited_language_name(s.trim()))
-                .filter(|s| !s.is_empty())
-                .collect()
-        } else {
-            Vec::new()
         }
     }
 
@@ -404,7 +387,7 @@ impl QueryLoader {
                 e
             ))
         })?;
-        let used_inheritance = !Self::parse_inherits_directive(&original_content).is_empty();
+        let used_inheritance = !parse_inherits_directive(&original_content).is_empty();
 
         let mut visited = std::collections::HashSet::new();
         let query_str = Self::resolve_query_recursive(
@@ -485,14 +468,6 @@ fn is_single_path_component(value: &str) -> bool {
     let mut components = Path::new(value).components();
     matches!(components.next(), Some(Component::Normal(name)) if name == value)
         && components.next().is_none()
-}
-
-fn normalize_inherited_language_name(name: &str) -> String {
-    name.strip_prefix('(')
-        .and_then(|name| name.strip_suffix(')'))
-        .unwrap_or(name)
-        .trim()
-        .to_string()
 }
 
 #[cfg(test)]
@@ -784,13 +759,6 @@ mod tests {
         assert!(result.contains("(string) @string"));
     }
 
-    #[test]
-    fn parse_inherits_directive_strips_parenthesized_language_names() {
-        let parents = QueryLoader::parse_inherits_directive("; inherits: c, (cpp), (cuda)\n");
-
-        assert_eq!(parents, vec!["c", "cpp", "cuda"]);
-    }
-
     /// Create a directory with non-UTF-8 bytes in its name under the given temp dir.
     #[cfg(unix)]
     fn create_non_utf8_base(dir: &tempfile::TempDir) -> PathBuf {
@@ -908,38 +876,6 @@ mod tests {
     }
 
     // Tests for query inheritance
-
-    #[test]
-    fn test_parse_inherits_directive_single() {
-        // TypeScript inherits from ecma
-        let content = "; inherits: ecma\n\n\"require\" @keyword.import\n";
-        let result = QueryLoader::parse_inherits_directive(content);
-        assert_eq!(result, vec!["ecma"]);
-    }
-
-    #[test]
-    fn test_parse_inherits_directive_multiple() {
-        // JavaScript inherits from ecma and jsx
-        let content = "; inherits: ecma,jsx\n\n(identifier) @variable\n";
-        let result = QueryLoader::parse_inherits_directive(content);
-        assert_eq!(result, vec!["ecma", "jsx"]);
-    }
-
-    #[test]
-    fn test_parse_inherits_directive_none() {
-        // ecma has no inheritance
-        let content = "(identifier) @variable\n";
-        let result = QueryLoader::parse_inherits_directive(content);
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn test_parse_inherits_directive_with_spaces() {
-        // Handle spaces around language names
-        let content = "; inherits: ecma , jsx\n";
-        let result = QueryLoader::parse_inherits_directive(content);
-        assert_eq!(result, vec!["ecma", "jsx"]);
-    }
 
     #[test]
     fn test_resolve_query_no_inheritance() {

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -257,7 +257,9 @@ impl QueryLoader {
     }
 
     /// Every `<base>/queries/<lang_name>/<file_name>` across the search paths,
-    /// in search-path order.
+    /// in search-path order, each path once: Neovim dedupes its runtime hits
+    /// the same way, so a directory listed twice in `searchPaths` does not
+    /// append its overlays twice.
     ///
     /// Returns nothing without touching the filesystem when `lang_name` is not
     /// a single normal path component, so a document-controlled injection
@@ -276,14 +278,19 @@ impl QueryLoader {
         if !is_single_path_component(lang_name) {
             return Vec::new();
         }
-        runtime_bases
-            .iter()
-            .map(|base| Self::query_file_path(base.as_ref(), lang_name, file_name))
-            .filter(|candidate| match fs::symlink_metadata(candidate) {
-                Ok(_) => true,
-                Err(e) => e.kind() != std::io::ErrorKind::NotFound,
-            })
-            .collect()
+        let mut found: Vec<PathBuf> = Vec::new();
+        for base in runtime_bases {
+            let candidate = Self::query_file_path(base.as_ref(), lang_name, file_name);
+            if found.contains(&candidate) {
+                continue;
+            }
+            match fs::symlink_metadata(&candidate) {
+                Ok(_) => found.push(candidate),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(_) => found.push(candidate),
+            }
+        }
+        found
     }
 
     /// Parse a query string with fault tolerance.
@@ -953,6 +960,32 @@ mod tests {
             ]
         );
         assert!(QueryLoader::find_query_files(&bases, "../rust", "highlights.scm").is_empty());
+    }
+
+    /// Neovim runs its runtime hits through `dedupe_files`; without the same,
+    /// a search path listed twice would append every overlay in it twice.
+    #[test]
+    fn a_search_path_listed_twice_contributes_its_overlay_once() {
+        let base = tempdir().unwrap();
+        let overlay = tempdir().unwrap();
+        write_highlights(base.path(), "rust", "(identifier) @base\n");
+        write_highlights(
+            overlay.path(),
+            "rust",
+            ";; extends\n(string_literal) @overlay\n",
+        );
+
+        let bases = [
+            base.path().to_path_buf(),
+            overlay.path().to_path_buf(),
+            overlay.path().join("."),
+        ];
+        let content = resolve_query(&bases, "rust", "highlights.scm").unwrap();
+        assert_eq!(
+            content.matches("@overlay").count(),
+            1,
+            "the same file must not be concatenated twice:\n{content}"
+        );
     }
 
     #[test]

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -525,8 +525,9 @@ impl QueryLoader {
 /// line is added that the file did not have: a file's line numbers in the
 /// combined text are then its own plus the lines of what precedes it, which
 /// is what a skipped-pattern warning quotes. An empty file has no lines and
-/// contributes none.
-fn append_file(combined: &mut String, content: &str) {
+/// contributes none. `pub(crate)` so the asset tests join sources the same
+/// way and count lines the loader would.
+pub(crate) fn append_file(combined: &mut String, content: &str) {
     combined.push_str(content);
     if !content.is_empty() && !content.ends_with('\n') {
         combined.push('\n');

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -401,13 +401,14 @@ impl QueryLoader {
     /// Load and parse a query from explicit paths with fault tolerance.
     ///
     /// Tolerant parsing skips invalid patterns instead of failing the whole query;
-    /// errors only on a missing/unreadable file.
+    /// errors only on a missing/unreadable file. Several paths concatenate in
+    /// the order given, and the result then says so through `multi_file`.
     pub(crate) fn load_query_from_paths<P: AsRef<Path>>(
         language: &Language,
         paths: &[P],
     ) -> LspResult<ParseResult> {
         let query_str = Self::load_content_from_paths(paths)?;
-        Ok(Self::parse_query(language, &query_str, false))
+        Ok(Self::parse_query(language, &query_str, paths.len() > 1))
     }
 
     /// Load and parse a query with inheritance resolution and fault tolerance.
@@ -780,6 +781,24 @@ mod tests {
                 .unwrap()
                 .to_string_lossy()
                 .ends_with("parser/rust.so")
+        );
+    }
+
+    #[test]
+    fn explicit_paths_report_multi_file_only_when_several_are_given() {
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let dir = tempdir().unwrap();
+        let one = dir.path().join("one.scm");
+        let two = dir.path().join("two.scm");
+        fs::write(&one, "(identifier) @variable\n").unwrap();
+        fs::write(&two, "(string_literal) @string\n").unwrap();
+
+        let single = QueryLoader::load_query_from_paths(&language, &[&one]).unwrap();
+        assert!(!single.multi_file, "one file, line numbers are its own");
+        let layered = QueryLoader::load_query_from_paths(&language, &[&one, &two]).unwrap();
+        assert!(
+            layered.multi_file,
+            "a second explicit path shifts line numbers like an overlay does"
         );
     }
 

--- a/src/language/query_modeline.rs
+++ b/src/language/query_modeline.rs
@@ -20,15 +20,18 @@
 //! directives may repeat; the first line that does not start with `;` — a
 //! blank line included — ends the block.
 //!
-//! Neovim matches `inherits` against `^;+%s*inherits%s*:?%s*([a-z_,()]+)%s*$`:
-//! the keyword needs no separator before the list, the list is one run of
-//! names with no whitespace inside it, and a line whose operand holds anything
-//! else — `; inherits the ecma queries` — is prose, not a directive. The
-//! parser here reads exactly that, so a comment that mentions inheritance
-//! never becomes a parent that cannot be found. The one widening is digits in
-//! a name: nvim-treesitter ships languages such as `m68k` and `t32` that
-//! Neovim's own character class cannot name. A name in this class is also
-//! what the installer needs of a path and URL segment, so
+//! Neovim matches `inherits` against `^;+%s*inherits%s*:?%s*([a-z_,()]+)%s*$`
+//! and then splits the list on commas: the keyword needs no separator before
+//! the list, the list is one run of list characters with no whitespace inside
+//! it, and a line whose operand holds anything else — `; inherits the ecma
+//! queries` — is prose, not a directive. Within a line that matches, each
+//! name stands alone: `; inherits: ecma,` still inherits `ecma`, the empty
+//! name after the comma finding nothing. The parser here reads exactly that,
+//! so a comment that mentions inheritance never becomes a parent that cannot
+//! be found, and a stray comma never loses the parents beside it. The one
+//! widening is digits in a name: nvim-treesitter ships languages such as
+//! `m68k` and `t32` that Neovim's own character class cannot name. A name in
+//! this class is also what the installer needs of a path and URL segment, so
 //! [`is_safe_language_name`] is the one definition both sides use.
 
 /// What the modeline block at the top of a query file declares.
@@ -67,21 +70,35 @@ pub(crate) fn parse_modeline(content: &str) -> QueryModeline {
 /// The languages named by an `inherits` directive, or `None` when `directive`
 /// is not one.
 ///
-/// Mirrors Neovim's `inherits%s*:?%s*([a-z_,()]+)%s*$`: after the keyword,
-/// optional whitespace, an optional colon, and optional whitespace, the rest
-/// of the line must be a comma-separated run of names with no whitespace in
-/// it. Any other operand makes the line a comment, as it is in Neovim.
+/// Mirrors Neovim's `inherits%s*:?%s*([a-z_,()]+)%s*$` followed by a split on
+/// commas: after the keyword, optional whitespace, an optional colon, and
+/// optional whitespace, the rest of the line must be one run of list
+/// characters — any other operand makes the line a comment, as it is in
+/// Neovim. Within a matching line each comma-separated entry is a name on
+/// its own: one that is not a name after all (empty, or `(cpp` with its
+/// parenthesis unmatched) is skipped, and the parents beside it stand.
+/// Neovim would look such an entry up and find nothing; skipping it here
+/// keeps a parent that cannot exist from failing the whole query.
 fn inherits_operand(directive: &str) -> Option<Vec<String>> {
     let rest = directive.strip_prefix("inherits")?.trim_start();
     let operand = rest.strip_prefix(':').unwrap_or(rest).trim_start();
-    if operand.is_empty() {
+    let is_list_char = |b: u8| b.is_ascii_lowercase() || b.is_ascii_digit() || b"_,()".contains(&b);
+    if operand.is_empty() || !operand.bytes().all(is_list_char) {
         return None;
     }
-    operand
-        .split(',')
-        .map(normalize_inherited_language_name)
-        .map(|name| is_safe_language_name(&name).then_some(name))
-        .collect()
+    Some(
+        operand
+            .split(',')
+            .map(normalize_inherited_language_name)
+            .filter(|name| {
+                let is_name = is_safe_language_name(name);
+                if !is_name {
+                    log::debug!("Ignoring `{name}` in an inherits modeline: not a language name");
+                }
+                is_name
+            })
+            .collect(),
+    )
 }
 
 /// The character class of a language name: `[a-z0-9_]+`.
@@ -101,7 +118,7 @@ pub fn is_safe_language_name(name: &str) -> bool {
 
 /// Strip the parentheses of an optional name, `(cpp)`, leaving the bare name.
 /// Only a *matched* pair is a wrapper: `(cpp` is not a name at all, and the
-/// caller then reads the whole line as a comment rather than guessing `cpp`.
+/// caller then skips it rather than guessing `cpp`.
 fn normalize_inherited_language_name(name: &str) -> String {
     name.strip_prefix('(')
         .and_then(|name| name.strip_suffix(')'))
@@ -150,6 +167,34 @@ mod tests {
             inherits("; inherits: c,(cpp),(cuda)\n(identifier) @variable\n"),
             vec!["c", "cpp", "cuda"]
         );
+        assert_eq!(inherits("; inherits: (cpp)\n"), vec!["cpp"]);
+        assert_eq!(inherits("; inherits:(cpp),c\n"), vec!["cpp", "c"]);
+    }
+
+    /// Neovim splits a matching list on commas and looks each entry up on its
+    /// own, so an entry that is no name finds nothing while its neighbours
+    /// are still inherited. Reading the whole line as a comment instead would
+    /// lose real parents to a stray comma, silently.
+    #[test]
+    fn an_entry_that_is_not_a_name_is_skipped_and_its_neighbours_kept() {
+        assert_eq!(inherits("; inherits: ecma,\n"), vec!["ecma"]);
+        assert_eq!(inherits("; inherits: ecma,,jsx\n"), vec!["ecma", "jsx"]);
+        assert_eq!(inherits("; inherits: c,(cpp\n"), vec!["c"]);
+        assert_eq!(inherits("; inherits: ecma,jsx)\n"), vec!["ecma"]);
+        assert_eq!(inherits("; inherits: ()\n"), Vec::<String>::new());
+    }
+
+    /// `str::lines` strips `\r\n`; a file checked out with CRLF must not lose
+    /// its parents to a `\r` that fails the name class.
+    #[test]
+    fn crlf_line_endings_do_not_reach_the_names() {
+        assert_eq!(
+            parse_modeline("; inherits: ecma,jsx\r\n;; extends\r\n(identifier) @variable\r\n"),
+            QueryModeline {
+                inherits: vec!["ecma".into(), "jsx".into()],
+                extends: true,
+            }
+        );
     }
 
     /// Neovim matches `^;+%s*inherits%s*:?%s*`: any run of semicolons, any
@@ -180,9 +225,6 @@ mod tests {
         assert!(inherits("; inherits: Ecma\n").is_empty());
         assert!(inherits("; inherits: with-dash\n").is_empty());
         assert!(inherits("; inherits: ../../evil\n").is_empty());
-        assert!(inherits("; inherits: (cpp\n").is_empty());
-        assert!(inherits("; inherits: cpp)\n").is_empty());
-        assert!(inherits("; inherits: ecma,\n").is_empty());
         assert!(inherits("; inherits:\n").is_empty());
         assert!(inherits("; inherits\n").is_empty());
         assert!(!parse_modeline("; extendsfoo\n").extends);

--- a/src/language/query_modeline.rs
+++ b/src/language/query_modeline.rs
@@ -53,9 +53,7 @@ pub(crate) struct QueryModeline {
 pub(crate) fn parse_modeline(content: &str) -> QueryModeline {
     let mut modeline = QueryModeline::default();
     for line in content.lines().take_while(|line| line.starts_with(';')) {
-        let directive = line
-            .trim_start_matches(';')
-            .trim_matches(|c: char| c.is_ascii_whitespace());
+        let directive = line.trim_start_matches(';').trim_matches(is_lua_space);
         if directive == "extends" {
             modeline.extends = true;
         } else if let Some(names) = inherits_operand(directive) {
@@ -82,16 +80,13 @@ pub(crate) fn parse_modeline(content: &str) -> QueryModeline {
 /// Neovim would look such an entry up and find nothing; skipping it here
 /// keeps a parent that cannot exist from failing the whole query.
 fn inherits_operand(directive: &str) -> Option<Vec<String>> {
-    // Lua's `%s` is ASCII whitespace; a U+3000 before the keyword keeps the
-    // line a comment in Neovim, so it does here.
-    let ascii_space = |c: char| c.is_ascii_whitespace();
     let rest = directive
         .strip_prefix("inherits")?
-        .trim_start_matches(ascii_space);
+        .trim_start_matches(is_lua_space);
     let operand = rest
         .strip_prefix(':')
         .unwrap_or(rest)
-        .trim_start_matches(ascii_space);
+        .trim_start_matches(is_lua_space);
     let is_list_char = |b: u8| b.is_ascii_lowercase() || b.is_ascii_digit() || b"_,()".contains(&b);
     if operand.is_empty() || !operand.bytes().all(is_list_char) {
         return None;
@@ -109,6 +104,14 @@ fn inherits_operand(directive: &str) -> Option<Vec<String>> {
             })
             .collect(),
     )
+}
+
+/// What Lua's `%s` matches in Neovim's modeline patterns: C `isspace`, that
+/// is ASCII whitespace plus the vertical tab `char::is_ascii_whitespace`
+/// leaves out. A U+3000 or a no-break space before the keyword keeps the
+/// line a comment in Neovim, so it does here.
+fn is_lua_space(c: char) -> bool {
+    c.is_ascii_whitespace() || c == '\x0B'
 }
 
 /// The character class of a language name: `[a-z0-9_]+`.
@@ -240,7 +243,10 @@ mod tests {
         assert!(inherits("; inherits\n").is_empty());
         assert!(!parse_modeline("; extendsfoo\n").extends);
         assert!(!parse_modeline("; extends foo\n").extends);
-        // Lua's `%s` is ASCII: ideographic space and NBSP are not spacing.
+        // Lua's `%s` is C `isspace`: a vertical tab is spacing, an
+        // ideographic space or an NBSP is not.
+        assert_eq!(inherits("; inherits:\x0Becma\n"), vec!["ecma"]);
+        assert!(parse_modeline(";\x0Bextends\x0B\n").extends);
         assert!(inherits(";\u{3000}inherits: ecma\n").is_empty());
         assert!(inherits("; inherits:\u{a0}ecma\n").is_empty());
         assert!(!parse_modeline(";\u{3000}extends\n").extends);

--- a/src/language/query_modeline.rs
+++ b/src/language/query_modeline.rs
@@ -25,11 +25,12 @@
 //! the list, the list is one run of list characters with no whitespace inside
 //! it, and a line whose operand holds anything else — `; inherits the ecma
 //! queries` — is prose, not a directive. Within a line that matches, each
-//! name stands alone: `; inherits: ecma,` still inherits `ecma`, the empty
-//! name after the comma finding nothing. The parser here reads exactly that,
-//! so a comment that mentions inheritance never becomes a parent that cannot
-//! be found, and a stray comma never loses the parents beside it. The one
-//! widening is digits in a name: nvim-treesitter ships languages such as
+//! entry stands alone: `; inherits: ecma,` still inherits `ecma`, and the
+//! empty entry after the comma is skipped (see [`inherits_operand`] for why
+//! it is skipped rather than looked up). So a comment that mentions
+//! inheritance never becomes a parent that cannot be found, and a stray
+//! comma never loses the parents beside it. The one widening of Neovim's
+//! grammar is digits in a name: nvim-treesitter ships languages such as
 //! `m68k` and `t32` that Neovim's own character class cannot name. A name in
 //! this class is also what the installer needs of a path and URL segment, so
 //! [`is_safe_language_name`] is the one definition both sides use.

--- a/src/language/query_modeline.rs
+++ b/src/language/query_modeline.rs
@@ -32,7 +32,7 @@
 //! [`is_safe_language_name`] is the one definition both sides use.
 
 /// What the modeline block at the top of a query file declares.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct QueryModeline {
     /// Parent languages named by `inherits` directives, in declaration order,
     /// each at most once.

--- a/src/language/query_modeline.rs
+++ b/src/language/query_modeline.rs
@@ -117,8 +117,9 @@ fn inherits_operand(directive: &str) -> Option<Vec<String>> {
 /// module doc for why digits are added) and what the installer accepts as a
 /// language to fetch: such a name is one normal path component and a safe
 /// URL segment, so it can never escape `queries/` on disk or the query
-/// source's URL. `pub` because the `kakehashi` binary validates CLI language
-/// arguments through the installer's re-export of it.
+/// source's URL. `pub` because the `kakehashi` binary validates language
+/// names — CLI arguments and on-disk entries alike — through the installer's
+/// re-export of it.
 pub fn is_safe_language_name(name: &str) -> bool {
     !name.is_empty()
         && name

--- a/src/language/query_modeline.rs
+++ b/src/language/query_modeline.rs
@@ -1,43 +1,79 @@
 //! The `;` comment modelines Neovim reads at the top of a query file.
 //!
 //! nvim-treesitter queries declare what they build on through comments such
-//! as `; inherits: ecma`; kakehashi reads the same modelines so those query
-//! files load unchanged. This module is the one parser for them: the loader,
-//! the installer, and the in-repo asset tests all resolve a query's parents
-//! through it, so a form accepted in one place is accepted everywhere.
+//! as `; inherits: ecma`, and user overlays mark themselves `;; extends`;
+//! kakehashi reads the same modelines so those query files load unchanged.
+//! This module is the one parser for them: the loader, the installer, and the
+//! in-repo asset tests all read a query's modelines through it, so a form
+//! accepted in one place is accepted everywhere.
+//!
+//! The grammar is Neovim's (`runtime/lua/vim/treesitter/query.lua`): the
+//! modeline block is the run of lines at the top of the file that start with
+//! `;`, and within it
+//!
+//! ```text
+//! ;+ inherits: lang1,lang2    ; the colon is optional
+//! ;+ extends
+//! ```
+//!
+//! are directives while every other `;` line is an ordinary comment. Both
+//! directives may repeat; the first line that does not start with `;` — a
+//! blank line included — ends the block.
 
-const INHERITS_DIRECTIVE_PREFIX: &str = "; inherits:";
-
-/// The parent languages named by the `; inherits: lang1,lang2` directive on
-/// the first line of `content`, in declaration order. Empty without one.
-///
-/// A parenthesized name (`(cpp)`) is read as the bare name: Neovim uses the
-/// parentheses to stop recursion when the file is itself being inherited,
-/// which kakehashi does not distinguish.
-pub(crate) fn parse_inherits_directive(content: &str) -> Vec<String> {
-    let first_line = content.lines().next().unwrap_or("");
-    if let Some(rest) = first_line.strip_prefix(INHERITS_DIRECTIVE_PREFIX) {
-        rest.split(',')
-            .map(|s| normalize_inherited_language_name(s.trim()))
-            .filter(|s| !s.is_empty())
-            .collect()
-    } else {
-        Vec::new()
-    }
+/// What the modeline block at the top of a query file declares.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct QueryModeline {
+    /// Parent languages named by `inherits` directives, in declaration order,
+    /// each at most once.
+    ///
+    /// A parenthesized name (`(cpp)`) is read as the bare name: Neovim uses the
+    /// parentheses to stop recursion when the file is itself being inherited,
+    /// which kakehashi does not distinguish.
+    pub inherits: Vec<String>,
+    /// Whether an `extends` directive marks the file as an overlay to merge
+    /// onto the language's base query instead of replacing it.
+    pub extends: bool,
 }
 
-/// Whether the first line of `content` is the `; inherits:` directive.
-pub(crate) fn starts_with_inherits_directive(content: &str) -> bool {
-    content
-        .lines()
-        .next()
-        .is_some_and(|first_line| first_line.starts_with(INHERITS_DIRECTIVE_PREFIX))
+/// Read the modeline block at the top of `content`.
+pub(crate) fn parse_modeline(content: &str) -> QueryModeline {
+    let mut modeline = QueryModeline::default();
+    for line in content.lines().take_while(|line| line.starts_with(';')) {
+        let directive = line.trim_start_matches(';').trim();
+        if directive == "extends" {
+            modeline.extends = true;
+        } else if let Some(names) = inherits_operand(directive) {
+            for name in names.split(',') {
+                let name = normalize_inherited_language_name(name);
+                if !name.is_empty() && !modeline.inherits.contains(&name) {
+                    modeline.inherits.push(name);
+                }
+            }
+        }
+    }
+    modeline
+}
+
+/// The language list of an `inherits` directive, or `None` when `directive`
+/// is not one. The keyword must end with the colon or whitespace, so a
+/// comment that merely begins with the word (`inheritsfoo`) is not read as it.
+fn inherits_operand(directive: &str) -> Option<&str> {
+    let rest = directive.strip_prefix("inherits")?;
+    match rest.chars().next() {
+        Some(':') => Some(&rest[1..]),
+        Some(c) if c.is_whitespace() => {
+            let rest = rest.trim_start();
+            Some(rest.strip_prefix(':').unwrap_or(rest))
+        }
+        _ => None,
+    }
 }
 
 /// Strip only a *matched* pair of parentheses: on `(cpp` the loader looks for
 /// a language literally called `(cpp`, and an installer that helpfully
 /// fetched `cpp` would report success over a language it still cannot load.
 fn normalize_inherited_language_name(name: &str) -> String {
+    let name = name.trim();
     name.strip_prefix('(')
         .and_then(|name| name.strip_suffix(')'))
         .unwrap_or(name)
@@ -49,55 +85,121 @@ fn normalize_inherited_language_name(name: &str) -> String {
 mod tests {
     use super::*;
 
+    fn inherits(content: &str) -> Vec<String> {
+        parse_modeline(content).inherits
+    }
+
     #[test]
     fn single_parent() {
         // TypeScript inherits from ecma
         let content = "; inherits: ecma\n\n\"require\" @keyword.import\n";
-        assert_eq!(parse_inherits_directive(content), vec!["ecma"]);
+        assert_eq!(inherits(content), vec!["ecma"]);
     }
 
     #[test]
     fn multiple_parents_in_declaration_order() {
         // JavaScript inherits from ecma and jsx
         let content = "; inherits: ecma,jsx\n\n(identifier) @variable\n";
-        assert_eq!(parse_inherits_directive(content), vec!["ecma", "jsx"]);
+        assert_eq!(inherits(content), vec!["ecma", "jsx"]);
     }
 
     #[test]
     fn no_directive() {
-        assert!(parse_inherits_directive("(identifier) @variable\n").is_empty());
-        assert!(parse_inherits_directive("").is_empty());
+        assert_eq!(
+            parse_modeline("(identifier) @variable\n"),
+            QueryModeline::default()
+        );
+        assert_eq!(parse_modeline(""), QueryModeline::default());
+        assert_eq!(
+            parse_modeline(";; just a comment\n(identifier) @variable\n"),
+            QueryModeline::default()
+        );
     }
 
     #[test]
     fn spaces_around_names() {
-        assert_eq!(
-            parse_inherits_directive("; inherits: ecma , jsx\n"),
-            vec!["ecma", "jsx"]
-        );
+        assert_eq!(inherits("; inherits: ecma , jsx\n"), vec!["ecma", "jsx"]);
     }
 
     #[test]
     fn parenthesized_names_read_as_bare_names() {
         assert_eq!(
-            parse_inherits_directive("; inherits: c, (cpp), ( cuda )\n(identifier) @variable\n"),
+            inherits("; inherits: c, (cpp), ( cuda )\n(identifier) @variable\n"),
             vec!["c", "cpp", "cuda"]
         );
     }
 
     #[test]
     fn unmatched_parentheses_are_kept_verbatim() {
-        assert_eq!(parse_inherits_directive("; inherits: (cpp\n"), vec!["(cpp"]);
-        assert_eq!(parse_inherits_directive("; inherits: cpp)\n"), vec!["cpp)"]);
+        assert_eq!(inherits("; inherits: (cpp\n"), vec!["(cpp"]);
+        assert_eq!(inherits("; inherits: cpp)\n"), vec!["cpp)"]);
+    }
+
+    /// Neovim matches `^;+%s*inherits%s*:?%s*`: any run of semicolons, any
+    /// spacing, and the colon is optional.
+    #[test]
+    fn any_number_of_semicolons_and_an_optional_colon() {
+        assert_eq!(inherits(";; inherits: ecma\n"), vec!["ecma"]);
+        assert_eq!(inherits(";;; inherits: ecma\n"), vec!["ecma"]);
+        assert_eq!(inherits(";inherits:ecma\n"), vec!["ecma"]);
+        assert_eq!(inherits("; inherits ecma\n"), vec!["ecma"]);
+        assert_eq!(inherits(";  inherits  :  ecma  \n"), vec!["ecma"]);
+        assert_eq!(inherits("; inherits ecma, jsx\n"), vec!["ecma", "jsx"]);
     }
 
     #[test]
-    fn directive_is_recognized_on_the_first_line_only() {
-        assert!(parse_inherits_directive("(identifier) @variable\n; inherits: ecma\n").is_empty());
-        assert!(starts_with_inherits_directive("; inherits: ecma\n"));
-        assert!(!starts_with_inherits_directive(
-            "(identifier) @variable\n; inherits: ecma\n"
-        ));
-        assert!(!starts_with_inherits_directive(""));
+    fn a_comment_that_merely_begins_with_the_keyword_is_not_a_directive() {
+        assert!(inherits("; inheritsecma\n").is_empty());
+        assert!(inherits("; inherits\n").is_empty());
+        assert!(!parse_modeline("; extendsfoo\n").extends);
+        assert!(!parse_modeline("; extends foo\n").extends);
+    }
+
+    #[test]
+    fn extends_directive() {
+        assert!(parse_modeline(";; extends\n(identifier) @variable\n").extends);
+        assert!(parse_modeline("; extends\n").extends);
+        assert!(parse_modeline(";extends\n").extends);
+        assert!(parse_modeline(";;   extends   \n").extends);
+        assert!(!parse_modeline("(identifier) @variable\n").extends);
+    }
+
+    /// Both orders from `:h treesitter-query-modeline` are valid, and plain
+    /// comment lines inside the block are skipped over.
+    #[test]
+    fn modeline_block_may_span_several_lines() {
+        assert_eq!(
+            parse_modeline(";; inherits: typescript,jsx\n;; extends\n"),
+            QueryModeline {
+                inherits: vec!["typescript".into(), "jsx".into()],
+                extends: true,
+            }
+        );
+        assert_eq!(
+            parse_modeline(";; extends\n;;\n;; inherits: css\n(identifier) @variable\n"),
+            QueryModeline {
+                inherits: vec!["css".into()],
+                extends: true,
+            }
+        );
+        assert_eq!(
+            inherits("; inherits: c\n; inherits: cpp, c\n"),
+            vec!["c", "cpp"],
+            "repeated directives accumulate, each parent once"
+        );
+    }
+
+    /// The block is the leading run of `;` lines: a blank line or a pattern
+    /// ends it, and a directive after that is an ordinary comment.
+    #[test]
+    fn modeline_block_ends_at_the_first_non_comment_line() {
+        assert!(inherits("(identifier) @variable\n; inherits: ecma\n").is_empty());
+        assert_eq!(
+            parse_modeline(";; extends\n\n; inherits: ecma\n"),
+            QueryModeline {
+                inherits: vec![],
+                extends: true,
+            }
+        );
     }
 }

--- a/src/language/query_modeline.rs
+++ b/src/language/query_modeline.rs
@@ -39,15 +39,21 @@
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct QueryModeline {
     /// Parent languages named by `inherits` directives, in declaration order,
-    /// each at most once.
-    ///
-    /// A parenthesized name (`(cpp)`) is read as the bare name: Neovim uses the
-    /// parentheses to stop recursion when the file is itself being inherited,
-    /// which kakehashi does not distinguish.
-    pub inherits: Vec<String>,
+    /// each name at most once.
+    pub inherits: Vec<InheritedLanguage>,
     /// Whether an `extends` directive marks the file as an overlay to merge
     /// onto the language's base query instead of replacing it.
     pub extends: bool,
+}
+
+/// One entry of an `inherits` list.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct InheritedLanguage {
+    pub name: String,
+    /// Written in parentheses, `(cpp)`: Neovim's `get_files` inherits such a
+    /// parent only when the file is loaded for its own language, not when
+    /// the file is itself being inherited, so a chain stops there.
+    pub optional: bool,
 }
 
 /// Read the modeline block at the top of `content`.
@@ -57,10 +63,10 @@ pub(crate) fn parse_modeline(content: &str) -> QueryModeline {
         let directive = line.trim_start_matches(';').trim_matches(is_lua_space);
         if directive == "extends" {
             modeline.extends = true;
-        } else if let Some(names) = inherits_operand(directive) {
-            for name in names {
-                if !modeline.inherits.contains(&name) {
-                    modeline.inherits.push(name);
+        } else if let Some(parents) = inherits_operand(directive) {
+            for parent in parents {
+                if !modeline.inherits.iter().any(|p| p.name == parent.name) {
+                    modeline.inherits.push(parent);
                 }
             }
         }
@@ -80,7 +86,7 @@ pub(crate) fn parse_modeline(content: &str) -> QueryModeline {
 /// parenthesis unmatched) is skipped, and the parents beside it stand.
 /// Neovim would look such an entry up and find nothing; skipping it here
 /// keeps a parent that cannot exist from failing the whole query.
-fn inherits_operand(directive: &str) -> Option<Vec<String>> {
+fn inherits_operand(directive: &str) -> Option<Vec<InheritedLanguage>> {
     let rest = directive
         .strip_prefix("inherits")?
         .trim_start_matches(is_lua_space);
@@ -95,11 +101,20 @@ fn inherits_operand(directive: &str) -> Option<Vec<String>> {
     Some(
         operand
             .split(',')
-            .map(normalize_inherited_language_name)
-            .filter(|name| {
-                let is_name = is_safe_language_name(name);
+            .map(|entry| {
+                let (name, optional) = strip_optional_parentheses(entry);
+                InheritedLanguage {
+                    name: name.to_string(),
+                    optional,
+                }
+            })
+            .filter(|parent| {
+                let is_name = is_safe_language_name(&parent.name);
                 if !is_name {
-                    log::debug!("Ignoring `{name}` in an inherits modeline: not a language name");
+                    log::debug!(
+                        "Ignoring `{}` in an inherits modeline: not a language name",
+                        parent.name
+                    );
                 }
                 is_name
             })
@@ -131,14 +146,17 @@ pub fn is_safe_language_name(name: &str) -> bool {
             .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_')
 }
 
-/// Strip the parentheses of an optional name, `(cpp)`, leaving the bare name.
-/// Only a *matched* pair is a wrapper: `(cpp` is not a name at all, and the
-/// caller then skips it rather than guessing `cpp`.
-fn normalize_inherited_language_name(name: &str) -> String {
-    name.strip_prefix('(')
+/// Split an entry into its bare name and whether it was parenthesized.
+/// Only a *matched* pair marks an optional name: `(cpp` is not a name at
+/// all, and the caller then skips it rather than guessing `cpp`.
+fn strip_optional_parentheses(entry: &str) -> (&str, bool) {
+    match entry
+        .strip_prefix('(')
         .and_then(|name| name.strip_suffix(')'))
-        .unwrap_or(name)
-        .to_string()
+    {
+        Some(name) => (name, true),
+        None => (entry, false),
+    }
 }
 
 #[cfg(test)]
@@ -146,7 +164,18 @@ mod tests {
     use super::*;
 
     fn inherits(content: &str) -> Vec<String> {
-        parse_modeline(content).inherits
+        parse_modeline(content)
+            .inherits
+            .into_iter()
+            .map(|parent| parent.name)
+            .collect()
+    }
+
+    fn parent(name: &str, optional: bool) -> InheritedLanguage {
+        InheritedLanguage {
+            name: name.to_string(),
+            optional,
+        }
     }
 
     #[test]
@@ -177,13 +206,22 @@ mod tests {
     }
 
     #[test]
-    fn parenthesized_names_read_as_bare_names() {
+    fn parenthesized_names_are_optional_parents() {
         assert_eq!(
-            inherits("; inherits: c,(cpp),(cuda)\n(identifier) @variable\n"),
-            vec!["c", "cpp", "cuda"]
+            parse_modeline("; inherits: c,(cpp),(cuda)\n(identifier) @variable\n").inherits,
+            vec![
+                parent("c", false),
+                parent("cpp", true),
+                parent("cuda", true)
+            ]
         );
         assert_eq!(inherits("; inherits: (cpp)\n"), vec!["cpp"]);
         assert_eq!(inherits("; inherits:(cpp),c\n"), vec!["cpp", "c"]);
+        assert_eq!(
+            parse_modeline("; inherits: c,(c)\n").inherits,
+            vec![parent("c", false)],
+            "a name keeps its first spelling"
+        );
     }
 
     /// Neovim splits a matching list on commas and looks each entry up on its
@@ -206,7 +244,7 @@ mod tests {
         assert_eq!(
             parse_modeline("; inherits: ecma,jsx\r\n;; extends\r\n(identifier) @variable\r\n"),
             QueryModeline {
-                inherits: vec!["ecma".into(), "jsx".into()],
+                inherits: vec![parent("ecma", false), parent("jsx", false)],
                 extends: true,
             }
         );
@@ -269,14 +307,14 @@ mod tests {
         assert_eq!(
             parse_modeline(";; inherits: typescript,jsx\n;; extends\n"),
             QueryModeline {
-                inherits: vec!["typescript".into(), "jsx".into()],
+                inherits: vec![parent("typescript", false), parent("jsx", false)],
                 extends: true,
             }
         );
         assert_eq!(
             parse_modeline(";; extends\n;;\n;; inherits: css\n(identifier) @variable\n"),
             QueryModeline {
-                inherits: vec!["css".into()],
+                inherits: vec![parent("css", false)],
                 extends: true,
             }
         );

--- a/src/language/query_modeline.rs
+++ b/src/language/query_modeline.rs
@@ -39,7 +39,8 @@
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct QueryModeline {
     /// Parent languages named by `inherits` directives, in declaration order,
-    /// each name at most once.
+    /// each name at most once; a name written both with and without
+    /// parentheses is required.
     pub inherits: Vec<InheritedLanguage>,
     /// Whether an `extends` directive marks the file as an overlay to merge
     /// onto the language's base query instead of replacing it.
@@ -65,8 +66,12 @@ pub(crate) fn parse_modeline(content: &str) -> QueryModeline {
             modeline.extends = true;
         } else if let Some(parents) = inherits_operand(directive) {
             for parent in parents {
-                if !modeline.inherits.iter().any(|p| p.name == parent.name) {
-                    modeline.inherits.push(parent);
+                match modeline.inherits.iter_mut().find(|p| p.name == parent.name) {
+                    // Named again without parentheses, a parent is required:
+                    // Neovim would follow that occurrence wherever the file
+                    // is reached, so one entry must say the same.
+                    Some(known) => known.optional &= parent.optional,
+                    None => modeline.inherits.push(parent),
                 }
             }
         }
@@ -217,10 +222,24 @@ mod tests {
         );
         assert_eq!(inherits("; inherits: (cpp)\n"), vec!["cpp"]);
         assert_eq!(inherits("; inherits:(cpp),c\n"), vec!["cpp", "c"]);
+        // Named again without parentheses, a parent is required, in either
+        // order: Neovim would follow the bare occurrence wherever the file is
+        // reached, and one entry must say the same.
         assert_eq!(
             parse_modeline("; inherits: c,(c)\n").inherits,
-            vec![parent("c", false)],
-            "a name keeps its first spelling"
+            vec![parent("c", false)]
+        );
+        assert_eq!(
+            parse_modeline("; inherits: (c),c\n").inherits,
+            vec![parent("c", false)]
+        );
+        assert_eq!(
+            parse_modeline("; inherits: (c)\n; inherits: c\n").inherits,
+            vec![parent("c", false)]
+        );
+        assert_eq!(
+            parse_modeline("; inherits: (c),(c)\n").inherits,
+            vec![parent("c", true)]
         );
     }
 

--- a/src/language/query_modeline.rs
+++ b/src/language/query_modeline.rs
@@ -53,7 +53,9 @@ pub(crate) struct QueryModeline {
 pub(crate) fn parse_modeline(content: &str) -> QueryModeline {
     let mut modeline = QueryModeline::default();
     for line in content.lines().take_while(|line| line.starts_with(';')) {
-        let directive = line.trim_start_matches(';').trim();
+        let directive = line
+            .trim_start_matches(';')
+            .trim_matches(|c: char| c.is_ascii_whitespace());
         if directive == "extends" {
             modeline.extends = true;
         } else if let Some(names) = inherits_operand(directive) {
@@ -80,8 +82,16 @@ pub(crate) fn parse_modeline(content: &str) -> QueryModeline {
 /// Neovim would look such an entry up and find nothing; skipping it here
 /// keeps a parent that cannot exist from failing the whole query.
 fn inherits_operand(directive: &str) -> Option<Vec<String>> {
-    let rest = directive.strip_prefix("inherits")?.trim_start();
-    let operand = rest.strip_prefix(':').unwrap_or(rest).trim_start();
+    // Lua's `%s` is ASCII whitespace; a U+3000 before the keyword keeps the
+    // line a comment in Neovim, so it does here.
+    let ascii_space = |c: char| c.is_ascii_whitespace();
+    let rest = directive
+        .strip_prefix("inherits")?
+        .trim_start_matches(ascii_space);
+    let operand = rest
+        .strip_prefix(':')
+        .unwrap_or(rest)
+        .trim_start_matches(ascii_space);
     let is_list_char = |b: u8| b.is_ascii_lowercase() || b.is_ascii_digit() || b"_,()".contains(&b);
     if operand.is_empty() || !operand.bytes().all(is_list_char) {
         return None;
@@ -229,6 +239,10 @@ mod tests {
         assert!(inherits("; inherits\n").is_empty());
         assert!(!parse_modeline("; extendsfoo\n").extends);
         assert!(!parse_modeline("; extends foo\n").extends);
+        // Lua's `%s` is ASCII: ideographic space and NBSP are not spacing.
+        assert!(inherits(";\u{3000}inherits: ecma\n").is_empty());
+        assert!(inherits("; inherits:\u{a0}ecma\n").is_empty());
+        assert!(!parse_modeline(";\u{3000}extends\n").extends);
     }
 
     #[test]

--- a/src/language/query_modeline.rs
+++ b/src/language/query_modeline.rs
@@ -199,8 +199,8 @@ mod tests {
         assert_eq!(inherits("; inherits: ()\n"), Vec::<String>::new());
     }
 
-    /// `str::lines` strips `\r\n`; a file checked out with CRLF must not lose
-    /// its parents to a `\r` that fails the name class.
+    /// A CRLF file yields the same modeline as an LF file: `lines` and the
+    /// spacing trim each drop the `\r` before it can fail the name class.
     #[test]
     fn crlf_line_endings_do_not_reach_the_names() {
         assert_eq!(

--- a/src/language/query_modeline.rs
+++ b/src/language/query_modeline.rs
@@ -19,6 +19,17 @@
 //! are directives while every other `;` line is an ordinary comment. Both
 //! directives may repeat; the first line that does not start with `;` — a
 //! blank line included — ends the block.
+//!
+//! Neovim matches `inherits` against `^;+%s*inherits%s*:?%s*([a-z_,()]+)%s*$`:
+//! the keyword needs no separator before the list, the list is one run of
+//! names with no whitespace inside it, and a line whose operand holds anything
+//! else — `; inherits the ecma queries` — is prose, not a directive. The
+//! parser here reads exactly that, so a comment that mentions inheritance
+//! never becomes a parent that cannot be found. The one widening is digits in
+//! a name: nvim-treesitter ships languages such as `m68k` and `t32` that
+//! Neovim's own character class cannot name. A name in this class is also
+//! what the installer needs of a path and URL segment, so
+//! [`is_safe_language_name`] is the one definition both sides use.
 
 /// What the modeline block at the top of a query file declares.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -43,9 +54,8 @@ pub(crate) fn parse_modeline(content: &str) -> QueryModeline {
         if directive == "extends" {
             modeline.extends = true;
         } else if let Some(names) = inherits_operand(directive) {
-            for name in names.split(',') {
-                let name = normalize_inherited_language_name(name);
-                if !name.is_empty() && !modeline.inherits.contains(&name) {
+            for name in names {
+                if !modeline.inherits.contains(&name) {
                     modeline.inherits.push(name);
                 }
             }
@@ -54,30 +64,48 @@ pub(crate) fn parse_modeline(content: &str) -> QueryModeline {
     modeline
 }
 
-/// The language list of an `inherits` directive, or `None` when `directive`
-/// is not one. The keyword must end with the colon or whitespace, so a
-/// comment that merely begins with the word (`inheritsfoo`) is not read as it.
-fn inherits_operand(directive: &str) -> Option<&str> {
-    let rest = directive.strip_prefix("inherits")?;
-    match rest.chars().next() {
-        Some(':') => Some(&rest[1..]),
-        Some(c) if c.is_whitespace() => {
-            let rest = rest.trim_start();
-            Some(rest.strip_prefix(':').unwrap_or(rest))
-        }
-        _ => None,
+/// The languages named by an `inherits` directive, or `None` when `directive`
+/// is not one.
+///
+/// Mirrors Neovim's `inherits%s*:?%s*([a-z_,()]+)%s*$`: after the keyword,
+/// optional whitespace, an optional colon, and optional whitespace, the rest
+/// of the line must be a comma-separated run of names with no whitespace in
+/// it. Any other operand makes the line a comment, as it is in Neovim.
+fn inherits_operand(directive: &str) -> Option<Vec<String>> {
+    let rest = directive.strip_prefix("inherits")?.trim_start();
+    let operand = rest.strip_prefix(':').unwrap_or(rest).trim_start();
+    if operand.is_empty() {
+        return None;
     }
+    operand
+        .split(',')
+        .map(normalize_inherited_language_name)
+        .map(|name| is_safe_language_name(&name).then_some(name))
+        .collect()
 }
 
-/// Strip only a *matched* pair of parentheses: on `(cpp` the loader looks for
-/// a language literally called `(cpp`, and an installer that helpfully
-/// fetched `cpp` would report success over a language it still cannot load.
+/// The character class of a language name: `[a-z0-9_]+`.
+///
+/// This is what a modeline may name (Neovim's class is `[a-z_]`; see the
+/// module doc for why digits are added) and what the installer accepts as a
+/// language to fetch: such a name is one normal path component and a safe
+/// URL segment, so it can never escape `queries/` on disk or the query
+/// source's URL. `pub` because the `kakehashi` binary validates CLI language
+/// arguments through the installer's re-export of it.
+pub fn is_safe_language_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_')
+}
+
+/// Strip the parentheses of an optional name, `(cpp)`, leaving the bare name.
+/// Only a *matched* pair is a wrapper: `(cpp` is not a name at all, and the
+/// caller then reads the whole line as a comment rather than guessing `cpp`.
 fn normalize_inherited_language_name(name: &str) -> String {
-    let name = name.trim();
     name.strip_prefix('(')
         .and_then(|name| name.strip_suffix(')'))
         .unwrap_or(name)
-        .trim()
         .to_string()
 }
 
@@ -117,39 +145,45 @@ mod tests {
     }
 
     #[test]
-    fn spaces_around_names() {
-        assert_eq!(inherits("; inherits: ecma , jsx\n"), vec!["ecma", "jsx"]);
-    }
-
-    #[test]
     fn parenthesized_names_read_as_bare_names() {
         assert_eq!(
-            inherits("; inherits: c, (cpp), ( cuda )\n(identifier) @variable\n"),
+            inherits("; inherits: c,(cpp),(cuda)\n(identifier) @variable\n"),
             vec!["c", "cpp", "cuda"]
         );
     }
 
-    #[test]
-    fn unmatched_parentheses_are_kept_verbatim() {
-        assert_eq!(inherits("; inherits: (cpp\n"), vec!["(cpp"]);
-        assert_eq!(inherits("; inherits: cpp)\n"), vec!["cpp)"]);
-    }
-
     /// Neovim matches `^;+%s*inherits%s*:?%s*`: any run of semicolons, any
-    /// spacing, and the colon is optional.
+    /// spacing, the colon optional, and no separator needed after the keyword.
     #[test]
     fn any_number_of_semicolons_and_an_optional_colon() {
         assert_eq!(inherits(";; inherits: ecma\n"), vec!["ecma"]);
         assert_eq!(inherits(";;; inherits: ecma\n"), vec!["ecma"]);
         assert_eq!(inherits(";inherits:ecma\n"), vec!["ecma"]);
         assert_eq!(inherits("; inherits ecma\n"), vec!["ecma"]);
-        assert_eq!(inherits(";  inherits  :  ecma  \n"), vec!["ecma"]);
-        assert_eq!(inherits("; inherits ecma, jsx\n"), vec!["ecma", "jsx"]);
+        assert_eq!(inherits("; inheritsecma\n"), vec!["ecma"]);
+        assert_eq!(
+            inherits(";  inherits  :  ecma,jsx  \n"),
+            vec!["ecma", "jsx"]
+        );
+        assert_eq!(inherits("; inherits: m68k,t32\n"), vec!["m68k", "t32"]);
     }
 
+    /// Neovim's operand is one run of `[a-z_,()]`: a line whose operand holds
+    /// anything else is prose. Reading it as a directive would name a parent
+    /// that cannot exist and fail the whole query for a comment.
     #[test]
-    fn a_comment_that_merely_begins_with_the_keyword_is_not_a_directive() {
-        assert!(inherits("; inheritsecma\n").is_empty());
+    fn a_line_whose_operand_is_not_a_name_list_is_a_comment() {
+        assert!(inherits("; inherits the ecma queries\n").is_empty());
+        assert!(inherits("; inherits: ecma (see ecma/highlights.scm)\n").is_empty());
+        assert!(inherits("; inherits: ecma , jsx\n").is_empty());
+        assert!(inherits("; inherits: ecma jsx\n").is_empty());
+        assert!(inherits("; inherits: Ecma\n").is_empty());
+        assert!(inherits("; inherits: with-dash\n").is_empty());
+        assert!(inherits("; inherits: ../../evil\n").is_empty());
+        assert!(inherits("; inherits: (cpp\n").is_empty());
+        assert!(inherits("; inherits: cpp)\n").is_empty());
+        assert!(inherits("; inherits: ecma,\n").is_empty());
+        assert!(inherits("; inherits:\n").is_empty());
         assert!(inherits("; inherits\n").is_empty());
         assert!(!parse_modeline("; extendsfoo\n").extends);
         assert!(!parse_modeline("; extends foo\n").extends);
@@ -183,7 +217,7 @@ mod tests {
             }
         );
         assert_eq!(
-            inherits("; inherits: c\n; inherits: cpp, c\n"),
+            inherits("; inherits: c\n; inherits: cpp,c\n"),
             vec!["c", "cpp"],
             "repeated directives accumulate, each parent once"
         );

--- a/src/language/query_modeline.rs
+++ b/src/language/query_modeline.rs
@@ -1,0 +1,103 @@
+//! The `;` comment modelines Neovim reads at the top of a query file.
+//!
+//! nvim-treesitter queries declare what they build on through comments such
+//! as `; inherits: ecma`; kakehashi reads the same modelines so those query
+//! files load unchanged. This module is the one parser for them: the loader,
+//! the installer, and the in-repo asset tests all resolve a query's parents
+//! through it, so a form accepted in one place is accepted everywhere.
+
+const INHERITS_DIRECTIVE_PREFIX: &str = "; inherits:";
+
+/// The parent languages named by the `; inherits: lang1,lang2` directive on
+/// the first line of `content`, in declaration order. Empty without one.
+///
+/// A parenthesized name (`(cpp)`) is read as the bare name: Neovim uses the
+/// parentheses to stop recursion when the file is itself being inherited,
+/// which kakehashi does not distinguish.
+pub(crate) fn parse_inherits_directive(content: &str) -> Vec<String> {
+    let first_line = content.lines().next().unwrap_or("");
+    if let Some(rest) = first_line.strip_prefix(INHERITS_DIRECTIVE_PREFIX) {
+        rest.split(',')
+            .map(|s| normalize_inherited_language_name(s.trim()))
+            .filter(|s| !s.is_empty())
+            .collect()
+    } else {
+        Vec::new()
+    }
+}
+
+/// Whether the first line of `content` is the `; inherits:` directive.
+pub(crate) fn starts_with_inherits_directive(content: &str) -> bool {
+    content
+        .lines()
+        .next()
+        .is_some_and(|first_line| first_line.starts_with(INHERITS_DIRECTIVE_PREFIX))
+}
+
+/// Strip only a *matched* pair of parentheses: on `(cpp` the loader looks for
+/// a language literally called `(cpp`, and an installer that helpfully
+/// fetched `cpp` would report success over a language it still cannot load.
+fn normalize_inherited_language_name(name: &str) -> String {
+    name.strip_prefix('(')
+        .and_then(|name| name.strip_suffix(')'))
+        .unwrap_or(name)
+        .trim()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_parent() {
+        // TypeScript inherits from ecma
+        let content = "; inherits: ecma\n\n\"require\" @keyword.import\n";
+        assert_eq!(parse_inherits_directive(content), vec!["ecma"]);
+    }
+
+    #[test]
+    fn multiple_parents_in_declaration_order() {
+        // JavaScript inherits from ecma and jsx
+        let content = "; inherits: ecma,jsx\n\n(identifier) @variable\n";
+        assert_eq!(parse_inherits_directive(content), vec!["ecma", "jsx"]);
+    }
+
+    #[test]
+    fn no_directive() {
+        assert!(parse_inherits_directive("(identifier) @variable\n").is_empty());
+        assert!(parse_inherits_directive("").is_empty());
+    }
+
+    #[test]
+    fn spaces_around_names() {
+        assert_eq!(
+            parse_inherits_directive("; inherits: ecma , jsx\n"),
+            vec!["ecma", "jsx"]
+        );
+    }
+
+    #[test]
+    fn parenthesized_names_read_as_bare_names() {
+        assert_eq!(
+            parse_inherits_directive("; inherits: c, (cpp), ( cuda )\n(identifier) @variable\n"),
+            vec!["c", "cpp", "cuda"]
+        );
+    }
+
+    #[test]
+    fn unmatched_parentheses_are_kept_verbatim() {
+        assert_eq!(parse_inherits_directive("; inherits: (cpp\n"), vec!["(cpp"]);
+        assert_eq!(parse_inherits_directive("; inherits: cpp)\n"), vec!["cpp)"]);
+    }
+
+    #[test]
+    fn directive_is_recognized_on_the_first_line_only() {
+        assert!(parse_inherits_directive("(identifier) @variable\n; inherits: ecma\n").is_empty());
+        assert!(starts_with_inherits_directive("; inherits: ecma\n"));
+        assert!(!starts_with_inherits_directive(
+            "(identifier) @variable\n; inherits: ecma\n"
+        ));
+        assert!(!starts_with_inherits_directive(""));
+    }
+}

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -9,8 +9,8 @@
 //!
 //! The query itself is not sent by the client: `kind` names a per-language
 //! asset resolved as `queries/<lang>/<kind>.scm` across the configured
-//! `searchPaths`, through the same loader (`; inherits:`, tolerant
-//! per-pattern compilation) used for highlights. Kinds are therefore
+//! `searchPaths`, through the same loader (`inherits`/`extends` modelines,
+//! tolerant per-pattern compilation) used for highlights. Kinds are therefore
 //! open-ended — defined by what files exist, not by an enum.
 //!
 //! `#set!` directives in the kind file ride along as `metadata` objects —
@@ -48,7 +48,7 @@ use url::Url;
 
 use crate::analysis::next_result_id;
 use crate::language::query_exec::execute_query;
-use crate::language::query_loader::QueryLoader;
+use crate::language::query_loader::{QueryLoadError, QueryLoader};
 use crate::language::registry::LanguageRegistry;
 use crate::lsp::lsp_impl::kakehashi::node::injection_stack::walk_document_layers;
 use crate::lsp::lsp_impl::{Kakehashi, uri_to_url};
@@ -424,18 +424,18 @@ fn load_kind_query(
         file_name,
     ) {
         Ok(parsed) => parsed,
+        Err(QueryLoadError::NotFound) => {
+            log::debug!(
+                target: "kakehashi::captures",
+                "no {file_name} for {language_id}"
+            );
+            return KindQueryLoad::Unavailable;
+        }
         Err(err) => {
-            if QueryLoader::find_query_file(search_paths, language_id, file_name).is_none() {
-                log::debug!(
-                    target: "kakehashi::captures",
-                    "no {file_name} for {language_id}: {err}"
-                );
-            } else {
-                log::warn!(
-                    target: "kakehashi::captures",
-                    "failed to load {file_name} for {language_id}: {err}"
-                );
-            }
+            log::warn!(
+                target: "kakehashi::captures",
+                "failed to load {file_name} for {language_id}: {err}"
+            );
             return KindQueryLoad::Unavailable;
         }
     };


### PR DESCRIPTION
## Summary

kakehashi now reads Neovim's query modelines the way Neovim does and merges `;; extends` overlay files across `searchPaths` onto a language's base query, instead of taking the first search-path hit and recognizing only the literal first line `; inherits: a,b`.

## What changes

**Modeline grammar** (`src/language/query_modeline.rs`, one shared parser for the loader, the installer, and the asset tests)
- The modeline block is the leading run of `;` lines; `;+ inherits[:] list` and `;+ extends` are directives, everything else in the block is a comment. Any run of `;`, any spacing, the colon optional, no separator needed after the keyword, directives may repeat — Neovim's `MODELINE_FORMAT`/`EXTENDS_FORMAT`.
- The `inherits` operand must be one run of `[a-z0-9_,()]` (Neovim's class plus digits, for languages such as `m68k`); a line with anything else after the keyword is prose, not a parent that fails to load. Within a matching line each entry stands alone: an empty or unmatched-paren entry is skipped, its neighbours kept.
- A parenthesized name, `(cpp)`, is an optional parent: inherited when the file is loaded for its own language, skipped when the file is reached as another language's parent (Neovim's `is_included`). A name written both ways is required.
- Lua's `%s` (C `isspace`) is the spacing class, vertical tab included, Unicode spaces excluded.

**Loader** (`src/language/query_loader.rs`)
- Every search-path hit is listed (deduped by cleaned path, like Neovim's `dedupe_files`). The first file without `extends` is the base; a later plain file is shadowed (debug log); every `extends` file is an overlay; a file naming its own language is an overlay. Combined text is `inherits parents (recursively), base, overlays`.
- Modelines are no longer stripped from the combined text; they are comments, and leaving them keeps each file's line numbers intact. Files join on a line boundary with no blank line added, so a line number in a combined-query warning is the file's own offset by exactly the lines before it.
- `ParseResult::used_inheritance` → `multi_file`: true when more than one file was concatenated (parents or overlays, and now also several explicit `languages[*].queries` paths), which is when the "(in combined query)" note on a skipped-pattern warning is right. A shadowed file does not count.
- A parent that cannot be found is reported with the file that named it.

**Installer / auto-install** (`src/install/queries.rs`)
- Parents are discovered through the shared parser, so every modeline form the loader honors is installed for; `is_safe_language_name` moves to the modeline module (the installer re-exports it) and is the one definition of a language name.
- The installer asks "which parents are needed" the way the loader does: only the requested language is loaded for itself, so an optional parent of an inherited language is neither fetched nor required (`StageRole`, `required_parents`). A dangling query symlink is present-but-broken, not absent.

**Captures handler** (`src/lsp/lsp_impl/kakehashi/captures.rs`)
- "no such kind" vs "kind present but broken" now comes from the loader's `QueryLoadError::NotFound` instead of a second filesystem probe.

**Docs**: new "Query modelines" section in `docs/README.md` (grammar, merge order, the overlay-in-your-own-search-path recipe, the strict rules); sibling ADR/feature docs updated.

## Deliberate decisions (recorded, not bugs)
- An unreadable hit in any search path fails the language's query (Neovim's `get_files` errors on `io.open` failure too); a present-but-broken asset is never read as absent.
- A parent named only by an overlay outside the data dir is not auto-installed; the README says so and the error names the overlay. Cross-search-path staging is a separate feature (trust/network policy).
- A language reached more than once — a parent named twice, or the shared ancestor of two parents — is concatenated once (Neovim appends it each time and doubles its matches).
- The installer works per language on the union of its kinds (pre-existing contract); the loader resolves each kind on its own. The union is a superset of any kind's need.
- The installer accepts an on-disk cycle the loader rejects (pre-existing: refusing would loop auto-install on an unrepairable state).

## Testing
- `make check`; `cargo test --lib` 3670 passed; `make test_e2e` 430 + 79 passed.
- One unrelated lib test, `lsp::bridge::text_document::code_lens::tests::virt_dispatch_fails_soft_..._case_3`, fails in ~half of full-suite runs and passes in isolation; this branch does not touch `src/lsp/bridge`. Worth a look on `main` (last touched by #1047).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RTVhP28Xg9BHrsw4cvRNn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Neovim-style query modelines, including `inherits` parent queries and `extends` overlays.
  - Query files can combine across search paths with consistent ordering, deduplication, optional parents, and cycle handling.
  - Combined queries preserve source line information and indicate when multiple files contributed.

- **Bug Fixes**
  - Improved handling of missing, unsafe, or unreadable query files.
  - Updated skipped-pattern warnings to identify only genuinely combined queries.

- **Documentation**
  - Documented query modelines, inheritance, overlays, search paths, and automatic parent loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->