### PR TITLE
fix(lsp): publish a language's queries before its parser and read the injection state as tri-state

### DIFF
--- a/docs/architecture-decisions/respawn-reopen-derives-its-targets.md
+++ b/docs/architecture-decisions/respawn-reopen-derives-its-targets.md
@@ -275,14 +275,14 @@ rather than implied.
 **An invalidation placeholder reads as a current parse.** `invalidate_parse`
 publishes a tree-less snapshot whose `parsed_version` equals the content
 version, so both the parse wait and the currency re-check classify it as
-settled. The sweep then resolves no injections — because there is no tree, not
-because the host has no regions — and reports success. This matters most on the
-settings-reload path, which invalidates every parse and purges connections in
-the same pass. Distinguishing a placeholder from a legitimately tree-less parse
-(no parser loaded, parse produced nothing) needs a discriminator the snapshot
-does not currently carry, and rejecting every tree-less snapshot instead would
-wedge the barrier shut while a parser is still being installed. Same root cause
-as the reload-placeholder issue (#923).
+settled. The injection resolution answers "could not look" for a tree-less
+document (and for a language whose parser is not published, or a reload in
+progress), so the sweep reports the connection incomplete rather than
+repaired: the command that waits on it fails soft once, the reparse that
+follows re-opens eagerly. Reporting incomplete is the fail-soft direction; the
+cost is that one command, also for a document that stays tree-less (no parser
+will ever come), which has no regions to route anyway. Same root cause as the
+reload-placeholder issue (#923).
 
 **An empty resolution can be confirmed against a NEWER version.** If a
 `didChange` clears the tree and its reparse publishes before the currency

--- a/docs/architecture-decisions/respawn-reopen-derives-its-targets.md
+++ b/docs/architecture-decisions/respawn-reopen-derives-its-targets.md
@@ -79,11 +79,16 @@ connection is a `(server, root)` pair, so a document that bridges to the right
 server but sits under a different root is not its document.
 
 So each candidate host is screened in stages, cheapest first, and the ordering
-is a correctness property rather than a micro-optimization: the re-open runs
-inside a fixed budget that `done` must signal within, so work done per candidate
-is work charged against every command on that connection. Screening after the
-expensive steps would make that budget scale with workspace size instead of
-with the work that belongs to the connection.
+is a correctness property rather than a micro-optimization. Three bounds are
+in play and none is the sweep's lifetime: the sweep WAITS for pending parses
+against one shared deadline (`REOPEN_WAIT`), each command waiting on `done`
+applies its own `REOPEN_WAIT` and fails soft when it passes, and the sweep
+itself keeps walking — without waiting — until every candidate has been
+looked at, however long that takes. Work done per candidate before the
+cheap screen is therefore work charged against every command on that
+connection while the sweep runs; screening after the expensive steps would
+make a command's wait scale with workspace size instead of with the work
+that belongs to the connection.
 
 1. Could a document in this HOST language bridge to this server at all? Pure
    configuration, answered from the per-snapshot memo — no parse, no tree, no
@@ -253,9 +258,10 @@ anyway, incorrectly, since it cannot include documents opened since the purge.
   configuration question is answered first and from a memo, so the cost is a
   map lookup per open document, but it does scale with the workspace rather
   than with what one connection held. The ordering above is what keeps that
-  cost off the barrier's budget; a future change that moves work ahead of the
-  stage-1 screen re-couples them, and the symptom is every command on a
-  respawned connection failing soft on a large workspace.
+  cost off the commands' wait (the sweep itself may outlive it); a future
+  change that moves work ahead of the stage-1 screen re-couples them, and
+  the symptom is every command on a respawned connection failing soft on a
+  large workspace.
 - Marker resolution now runs during the re-open for the server entries that
   lack a route binding record; bound entries answer from the binding
   instead (per exact (document, server) entry — one host's units can

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -581,11 +581,6 @@ impl LanguageCoordinator {
         language: &tree_sitter::Language,
     ) -> LanguageLoadResult {
         self.query_store.remove_queries(derived_name);
-        self.register_configured_language(derived_name, language.clone());
-        self.derived_languages
-            .write()
-            .recover_poison("LanguageCoordinator::register_derived_from_base(derived_languages)")
-            .insert(derived_name.to_string());
 
         let mut events = Vec::new();
         let should_load_derived_queries = config.queries.is_some()
@@ -605,6 +600,14 @@ impl LanguageCoordinator {
                 }
             }
         }
+
+        // Queries BEFORE the parser, as on every other publication path: a
+        // reader that finds the derived parser must find its queries.
+        self.register_configured_language(derived_name, language.clone());
+        self.derived_languages
+            .write()
+            .recover_poison("LanguageCoordinator::register_derived_from_base(derived_languages)")
+            .insert(derived_name.to_string());
 
         events.push(LanguageEvent::log(
             LanguageLogLevel::Info,

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -580,6 +580,13 @@ impl LanguageCoordinator {
         search_paths: &[PathBuf],
         language: &tree_sitter::Language,
     ) -> LanguageLoadResult {
+        // One registration section from query removal through registration,
+        // like the configured and dynamic paths, so a same-generation dynamic
+        // load of this name cannot slip its queries in between.
+        let _registration = self
+            .registration_lock
+            .lock()
+            .recover_poison("LanguageCoordinator::register_derived_from_base");
         self.query_store.remove_queries(derived_name);
 
         let mut events = Vec::new();
@@ -888,6 +895,12 @@ impl LanguageCoordinator {
             || self.configured_load_failed(language_id, expected_generation)
         {
             return false;
+        }
+        // A duplicate of a load that already published (concurrent first
+        // loads are admitted): the language is in place, and clearing its
+        // queries again would reopen the parser-without-queries window.
+        if self.has_current_parser_registration(language_id, expected_generation) {
+            return true;
         }
         // Queries BEFORE the parser: `has_parser_available` reads the registry
         // without this lock, so a parse admitted the instant the parser lands
@@ -1631,7 +1644,7 @@ impl LanguageCoordinator {
         // its queries.
         let mut events = self.load_queries_for_language(lang_name, config, search_paths, &language);
         if !pre_registered_is_builtin {
-            self.register_configured_language_locked(lang_name, language.clone());
+            self.register_configured_language(lang_name, language.clone());
         }
         events.push(LanguageEvent::log(
             LanguageLogLevel::Info,
@@ -1640,17 +1653,10 @@ impl LanguageCoordinator {
         LanguageLoadResult::success_with(events)
     }
 
+    /// Register a configured (or derived) language's parser. The caller holds
+    /// `registration_lock`: every publication path runs as one section from
+    /// query removal through this registration.
     fn register_configured_language(&self, language_id: &str, language: Language) {
-        let _registration = self
-            .registration_lock
-            .lock()
-            .recover_poison("LanguageCoordinator::register_configured_language");
-        self.register_configured_language_locked(language_id, language);
-    }
-
-    /// [`register_configured_language`](Self::register_configured_language)
-    /// for a caller already holding `registration_lock`.
-    fn register_configured_language_locked(&self, language_id: &str, language: Language) {
         self.language_registry
             .register(language_id.to_string(), language);
         self.configured_load_failures.remove(language_id);

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -3601,6 +3601,35 @@ mod tests {
         assert!(coordinator.configured_load_failed("racing", generation));
     }
 
+    /// A reader that finds the parser registered must also find its queries:
+    /// `has_parser_available` does not take the registration lock, so a parse
+    /// admitted between the two publishes would run its injection query pass
+    /// against an empty store and record the document as injection-free.
+    #[test]
+    fn dynamic_publication_registers_the_parser_after_its_queries() {
+        let coordinator = LanguageCoordinator::new();
+        coordinator.load_settings(&WorkspaceSettings::default());
+        let generation = coordinator
+            .load_generation
+            .load(std::sync::atomic::Ordering::Acquire);
+        let parser_seen_while_publishing_queries = std::cell::Cell::new(None);
+        assert!(coordinator.publish_dynamic_language(
+            "ordered",
+            tree_sitter_rust::LANGUAGE.into(),
+            generation,
+            || {
+                parser_seen_while_publishing_queries
+                    .set(Some(coordinator.has_parser_available("ordered")));
+            },
+        ));
+        assert_eq!(
+            parser_seen_while_publishing_queries.get(),
+            Some(false),
+            "the queries must be published before the parser becomes visible"
+        );
+        assert!(coordinator.has_parser_available("ordered"));
+    }
+
     #[test]
     fn reload_without_override_preserves_builtin_queries() {
         let coordinator = LanguageCoordinator::new();

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -886,12 +886,16 @@ impl LanguageCoordinator {
         {
             return false;
         }
+        // Queries BEFORE the parser: `has_parser_available` reads the registry
+        // without this lock, so a parse admitted the instant the parser lands
+        // would otherwise run its injection pass against a store the queries
+        // have not reached yet and record the document as injection-free.
+        self.query_store.remove_queries(language_id);
+        publish_queries();
         self.language_registry
             .register(language_id.to_string(), language);
         self.reload_scoped_registrations
             .insert(language_id.to_string(), expected_generation);
-        self.query_store.remove_queries(language_id);
-        publish_queries();
         true
     }
 
@@ -1610,11 +1614,13 @@ impl LanguageCoordinator {
                 }
             }
         };
+        // Queries BEFORE the parser, for the same reason as
+        // `publish_dynamic_language`: a reader that finds the parser must find
+        // its queries.
+        let mut events = self.load_queries_for_language(lang_name, config, search_paths, &language);
         if !pre_registered_is_builtin {
             self.register_configured_language(lang_name, language.clone());
         }
-
-        let mut events = self.load_queries_for_language(lang_name, config, search_paths, &language);
         events.push(LanguageEvent::log(
             LanguageLogLevel::Info,
             format!("Language {lang_name} loaded."),

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -3653,6 +3653,46 @@ mod tests {
         assert!(coordinator.has_parser_available("ordered"));
     }
 
+    /// Duplicate loads of one language are admitted concurrently; once the
+    /// first has published, a second must not clear the queries again while
+    /// the parser it published stays visible.
+    #[test]
+    fn duplicate_dynamic_publication_keeps_the_published_queries() {
+        let coordinator = LanguageCoordinator::new();
+        coordinator.load_settings(&WorkspaceSettings::default());
+        let generation = coordinator
+            .load_generation
+            .load(std::sync::atomic::Ordering::Acquire);
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let query = tree_sitter::Query::new(&language, "(identifier) @injection.content")
+            .expect("valid query");
+        assert!(coordinator.publish_dynamic_language(
+            "twice",
+            language.clone(),
+            generation,
+            || {
+                coordinator
+                    .query_store
+                    .insert_injection_query("twice".to_string(), std::sync::Arc::new(query));
+            },
+        ));
+        let second_published_queries = std::cell::Cell::new(false);
+        assert!(
+            coordinator.publish_dynamic_language("twice", language, generation, || {
+                second_published_queries.set(true);
+            }),
+            "a duplicate load of a published language is a success"
+        );
+        assert!(
+            !second_published_queries.get(),
+            "the duplicate must not republish (and so not clear) the queries"
+        );
+        assert!(
+            coordinator.query_store.injection_query("twice").is_some(),
+            "the first publication's queries must survive the duplicate"
+        );
+    }
+
     #[test]
     fn reload_without_override_preserves_builtin_queries() {
         let coordinator = LanguageCoordinator::new();

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1620,7 +1620,7 @@ impl LanguageCoordinator {
             ) {
                 Ok(lang) => lang,
                 Err(result) => {
-                    self.record_configured_load_failure_locked(lang_name, generation);
+                    self.record_configured_load_failure(lang_name, generation);
                     self.record_failed_load(lang_name, generation);
                     return result;
                 }
@@ -1661,17 +1661,10 @@ impl LanguageCoordinator {
             .insert(language_id.to_string(), generation);
     }
 
+    /// Record that `language_id`'s configured parser failed to load under
+    /// `generation`. The caller holds `registration_lock` (the configured load
+    /// runs as one registration section).
     fn record_configured_load_failure(&self, language_id: &str, generation: u64) {
-        let _registration = self
-            .registration_lock
-            .lock()
-            .recover_poison("LanguageCoordinator::record_configured_load_failure");
-        self.record_configured_load_failure_locked(language_id, generation);
-    }
-
-    /// [`record_configured_load_failure`](Self::record_configured_load_failure)
-    /// for a caller already holding `registration_lock`.
-    fn record_configured_load_failure_locked(&self, language_id: &str, generation: u64) {
         self.configured_load_failures
             .insert(language_id.to_string(), generation);
         self.language_registry.unregister(language_id);

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1550,6 +1550,15 @@ impl LanguageCoordinator {
         config: &LanguageSettings,
         search_paths: &[PathBuf],
     ) -> LanguageLoadResult {
+        // One critical section from query removal through parser
+        // registration, like `publish_dynamic_language`: a same-generation
+        // dynamic load of this language would otherwise slip its queries in
+        // between the configured queries and the configured parser, leaving
+        // the registry with a configured parser over dynamic queries.
+        let _registration = self
+            .registration_lock
+            .lock()
+            .recover_poison("LanguageCoordinator::load_single_language");
         let generation = self
             .load_generation
             .load(std::sync::atomic::Ordering::Acquire);
@@ -1611,7 +1620,7 @@ impl LanguageCoordinator {
             ) {
                 Ok(lang) => lang,
                 Err(result) => {
-                    self.record_configured_load_failure(lang_name, generation);
+                    self.record_configured_load_failure_locked(lang_name, generation);
                     self.record_failed_load(lang_name, generation);
                     return result;
                 }
@@ -1622,7 +1631,7 @@ impl LanguageCoordinator {
         // its queries.
         let mut events = self.load_queries_for_language(lang_name, config, search_paths, &language);
         if !pre_registered_is_builtin {
-            self.register_configured_language(lang_name, language.clone());
+            self.register_configured_language_locked(lang_name, language.clone());
         }
         events.push(LanguageEvent::log(
             LanguageLogLevel::Info,
@@ -1636,6 +1645,12 @@ impl LanguageCoordinator {
             .registration_lock
             .lock()
             .recover_poison("LanguageCoordinator::register_configured_language");
+        self.register_configured_language_locked(language_id, language);
+    }
+
+    /// [`register_configured_language`](Self::register_configured_language)
+    /// for a caller already holding `registration_lock`.
+    fn register_configured_language_locked(&self, language_id: &str, language: Language) {
         self.language_registry
             .register(language_id.to_string(), language);
         self.configured_load_failures.remove(language_id);
@@ -1651,6 +1666,12 @@ impl LanguageCoordinator {
             .registration_lock
             .lock()
             .recover_poison("LanguageCoordinator::record_configured_load_failure");
+        self.record_configured_load_failure_locked(language_id, generation);
+    }
+
+    /// [`record_configured_load_failure`](Self::record_configured_load_failure)
+    /// for a caller already holding `registration_lock`.
+    fn record_configured_load_failure_locked(&self, language_id: &str, generation: u64) {
         self.configured_load_failures
             .insert(language_id.to_string(), generation);
         self.language_registry.unregister(language_id);

--- a/src/language/parser_pool.rs
+++ b/src/language/parser_pool.rs
@@ -64,6 +64,13 @@ impl DocumentParserPool {
         self.reload_depth = self.reload_depth.saturating_sub(1);
     }
 
+    /// Whether a settings reload is swapping parsers and queries right now.
+    /// Readers that combine a parser check with a query read must not trust
+    /// the pair while this holds: the two can come from different generations.
+    pub(crate) fn reload_in_progress(&self) -> bool {
+        self.reload_depth != 0
+    }
+
     pub(crate) fn acquire_versioned(&mut self, language_id: &str) -> ParserCheckout {
         if self.reload_depth != 0 {
             return ParserCheckout::Reloading;

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -1286,9 +1286,16 @@ mod tests {
                 assert!(result.command.is_none(), "lens stays unresolved");
             });
         });
+        // The capture is process-wide while it is armed, so another test's
+        // warning can land in it; only this resolve's own lines prove
+        // whether the gate fired before the handle was consulted.
+        let own: Vec<&String> = warnings
+            .iter()
+            .filter(|w| w.contains("codeLens/resolve"))
+            .collect();
         assert!(
-            warnings.is_empty(),
-            "an unbound or mismatched envelope must fail soft before any connection is consulted: {warnings:?}"
+            own.is_empty(),
+            "an unbound or mismatched envelope must fail soft before any connection is consulted: {own:?}"
         );
     }
 }

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -80,13 +80,29 @@ pub(crate) struct PopulatedInjections {
 }
 
 impl PopulatedInjections {
-    /// No regions (no injection query, or none matched): the downstream skips
-    /// its work, exactly as the inline resolution's empty result did.
+    /// No regions (the query ran and none matched): the downstream skips its
+    /// work, exactly as the inline resolution's empty result did.
     pub(crate) fn empty(generation: u64) -> Self {
         Self {
             discovery: None,
             bridge_regions: Some(Vec::new()),
             resolved_regions: Some(Vec::new()),
+            generation,
+        }
+    }
+
+    /// The pass could not look: the host language's injection query was not
+    /// in the store (a lazy load or a reload still swapping queries in).
+    /// Distinct from [`Self::empty`] on purpose — a definitive empty set
+    /// would be consumed by every reader until the next edit, skipping
+    /// documents that do have injections once the query is loaded. Riding
+    /// without regions makes readers fall back to inline resolution, which
+    /// finds the query as soon as it is there.
+    pub(crate) fn undetermined(generation: u64) -> Self {
+        Self {
+            discovery: None,
+            bridge_regions: None,
+            resolved_regions: None,
             generation,
         }
     }
@@ -269,18 +285,20 @@ impl CacheCoordinator {
         let injection_query = match language.injection_query(language_name) {
             Some(q) => q,
             None => {
-                // No injection query = no injections to track. Clear any
-                // stale injection caches — but only when no edit landed
-                // during this pass (a stale pass must not clobber state the
-                // newer text's own populate maintains). A refused clear
-                // aborts the pass (`None`): reporting ran-and-empty while
-                // the old entries survive would leave them unreclaimed
-                // until another parse.
+                // No injection query in the store = nothing this pass can
+                // track. Clear any stale injection caches — but only when
+                // no edit landed during this pass (a stale pass must not
+                // clobber state the newer text's own populate maintains). A
+                // refused clear aborts the pass (`None`): reporting a result
+                // while the old entries survive would leave them unreclaimed
+                // until another parse. The result is UNDETERMINED, not
+                // empty: the query may simply not be loaded yet, and a
+                // definitive empty set would stand until the next edit.
                 tracker.commit_if_unshifted(uri, entry_mint_epoch, incarnation, || {
                     self.injection_map.clear(uri);
                     self.injection_token_cache.clear_document(uri);
                 })?;
-                return Some(PopulatedInjections::empty(generation));
+                return Some(PopulatedInjections::undetermined(generation));
             }
         };
 

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -291,14 +291,22 @@ impl CacheCoordinator {
                 // clobber state the newer text's own populate maintains). A
                 // refused clear aborts the pass (`None`): reporting a result
                 // while the old entries survive would leave them unreclaimed
-                // until another parse. The result is UNDETERMINED, not
-                // empty: the query may simply not be loaded yet, and a
-                // definitive empty set would stand until the next edit.
+                // until another parse.
                 tracker.commit_if_unshifted(uri, entry_mint_epoch, incarnation, || {
                     self.injection_map.clear(uri);
                     self.injection_token_cache.clear_document(uri);
                 })?;
-                return Some(PopulatedInjections::undetermined(generation));
+                // Queries are published before their parser, so a visible
+                // parser with no injection query is a language that has
+                // none: a definitive empty set, which keeps the fast paths
+                // for it. Without the parser the load is still publishing
+                // and the result is UNDETERMINED — a definitive empty set
+                // would stand until the next edit.
+                return Some(if language.has_parser_available(language_name) {
+                    PopulatedInjections::empty(generation)
+                } else {
+                    PopulatedInjections::undetermined(generation)
+                });
             }
         };
 
@@ -978,6 +986,34 @@ mod tests {
         );
         assert!(populated.resolved_regions.is_none());
         assert!(populated.discovery.is_none());
+
+        // Once the parser is visible its queries are too (they are published
+        // first), so the absence is definitive and the fast paths keep their
+        // empty set.
+        coordinator
+            .language_registry_for_parallel()
+            .register("markdown".to_string(), language);
+        let populated = cache
+            .populate_injections(
+                &uri,
+                text,
+                &tree,
+                "markdown",
+                &coordinator,
+                &tracker,
+                tracker.mint_epoch(&uri),
+                1,
+                true,
+                true,
+            )
+            .expect("the pass ran");
+        assert!(
+            populated
+                .bridge_regions
+                .as_ref()
+                .is_some_and(|regions| regions.is_empty()),
+            "a settled language without an injection query publishes a definitive empty set"
+        );
     }
 
     #[test]

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -918,6 +918,50 @@ mod tests {
         assert!(!cache.is_request_active(&uri, req));
     }
 
+    /// A populate pass that runs before the host language's injection query
+    /// is in the store — a lazy query load or a settings reload still
+    /// swapping queries in — cannot tell "no injections" from "could not
+    /// look". Publishing a definitive empty set would be consumed by every
+    /// reader until the next edit; the snapshot must ride without regions so
+    /// readers fall back to inline resolution, which finds the query once it
+    /// is loaded.
+    #[test]
+    fn populate_without_the_injection_query_leaves_the_regions_undetermined() {
+        use tree_sitter::Parser;
+
+        let cache = CacheCoordinator::new();
+        let tracker = NodeTracker::new();
+        let coordinator = LanguageCoordinator::new();
+        let uri = create_test_uri("no-query-yet.md");
+        let language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let text = "```lua\nprint(1)\n```\n";
+        let mut parser = Parser::new();
+        parser.set_language(&language).unwrap();
+        let tree = parser.parse(text, None).unwrap();
+
+        let populated = cache
+            .populate_injections(
+                &uri,
+                text,
+                &tree,
+                "markdown",
+                &coordinator,
+                &tracker,
+                tracker.mint_epoch(&uri),
+                1,
+                true,
+                true,
+            )
+            .expect("the pass ran");
+
+        assert!(
+            populated.bridge_regions.is_none(),
+            "no query available must not publish a definitive empty region set"
+        );
+        assert!(populated.resolved_regions.is_none());
+        assert!(populated.discovery.is_none());
+    }
+
     #[test]
     fn cancelled_populate_commits_no_injection_state() {
         use tree_sitter::{Parser, Query};

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -281,6 +281,12 @@ impl CacheCoordinator {
         // mint and the commit), so a stale pass mints nothing and clobbers
         // nothing — identity defers to the next current pass.
 
+        // The parser BEFORE the query: a lazy publication lands queries then
+        // parser, so reading the query first could see none, then find the
+        // parser published — and publish a definitive empty set although the
+        // language has an injection query by now. Seen the other way round, a
+        // visible parser makes a missing query definitive.
+        let parser_published = language.has_parser_available(language_name);
         // Get the injection query for this language
         let injection_query = match language.injection_query(language_name) {
             Some(q) => q,
@@ -302,7 +308,7 @@ impl CacheCoordinator {
                 // for it. Without the parser the load is still publishing
                 // and the result is UNDETERMINED — a definitive empty set
                 // would stand until the next edit.
-                return Some(if language.has_parser_available(language_name) {
+                return Some(if parser_published {
                     PopulatedInjections::empty(generation)
                 } else {
                     PopulatedInjections::undetermined(generation)

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -2,6 +2,7 @@ mod apply_edit_translation;
 pub(crate) mod bridge_context;
 mod cli;
 mod coordinator;
+mod settle_retry;
 pub(crate) use coordinator::DiagnosticPublisher;
 pub(crate) mod kakehashi;
 mod lifecycle;
@@ -368,6 +369,9 @@ pub struct Kakehashi {
     /// dropped. Cancelling the token gives deterministic shutdown: `shutdown()`
     /// cancels → task exits immediately → no waiting for channel drainage.
     shutdown_token: tokio_util::sync::CancellationToken,
+    /// One settle-retry waiter per (kind, host) across the injection pass
+    /// and the diagnostic republish.
+    settle_retry_waiters: settle_retry::SettleRetryWaiters,
     /// Whether a `workspace/configuration` pull is already in flight, and
     /// whether a trigger arrived while one was; see
     /// `pull_client_configuration`.
@@ -510,6 +514,7 @@ impl Kakehashi {
                 crate::lsp::diagnostic_cache::DiagnosticAggregator::new(),
             ),
             shutdown_token: tokio_util::sync::CancellationToken::new(),
+            settle_retry_waiters: settle_retry::SettleRetryWaiters::default(),
             configuration_pull_in_flight: std::sync::atomic::AtomicBool::new(false),
             configuration_pull_pending: std::sync::atomic::AtomicBool::new(false),
             home_dir: dirs::home_dir().map(|p| p.to_string_lossy().into_owned()),

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -200,18 +200,21 @@ pub(super) async fn apply_shared_settings_locked(
     } else {
         Vec::new()
     };
+    // Second bump IMMEDIATELY after the query swap, before any await and
+    // BEFORE the reload guard is released: a request that started after the
+    // transitional bump above but before the swap computed against the OLD
+    // queries yet stamped the new generation — without this bump those
+    // products would be accepted as current for the whole awaited propagate
+    // below, and a publish landing between the guard's release and the bump
+    // would be accepted by readers that treat "no reload in progress" plus a
+    // current stamp as settled. (The final bump after apply_settings covers
+    // the settings-side inputs the apply swaps.)
+    cache.bump_semantic_token_generation();
     // Invalidate again after the synchronous swap: the first bump rejects
     // pre-reload checkouts, while this one rejects parsers acquired while the
     // registry and query stores were being replaced.
     drop(parser_reload);
     crate::analysis::semantic::invalidate_thread_local_parser_caches();
-    // Second bump IMMEDIATELY after the query swap, before any await: a
-    // request that started after the transitional bump above but before the
-    // swap computed against the OLD queries yet stamped the new generation —
-    // without this bump those products would be accepted as current for the
-    // whole awaited propagate below. (The final bump after apply_settings
-    // covers the settings-side inputs the apply swaps.)
-    cache.bump_semantic_token_generation();
     // Publish the settings snapshot before invalidating downstream connections:
     // once propagation exposes a pool miss, a concurrent request must resolve
     // the NEW launch config rather than respawn from the old snapshot (#587).

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1109,10 +1109,11 @@ impl DiagnosticPublisher {
                     // language's auto-install reload. Retry once it settles;
                     // a document whose language stays unsettled (a load that
                     // failed for good) ends the retry at its deadline.
-                    let host_language = self.documents.get(host).and_then(|doc| {
-                        doc.snapshot()?;
-                        doc.language_id().map(str::to_string)
-                    });
+                    let host_language = self
+                        .documents
+                        .get(host)
+                        .and_then(|doc| doc.snapshot().map(|_| ()))
+                        .and_then(|()| self.settled_host_language(host));
                     if let Some(host_language) = host_language {
                         self.retry_republish_when_settled(host, host_language);
                     }
@@ -1629,6 +1630,27 @@ impl DiagnosticPublisher {
         });
     }
 
+    /// The host's language as the settled parse names it (a current snapshot
+    /// with a tree; a reload that re-detects the document publishes the new
+    /// language there only), else the id the document was opened under.
+    /// Shared by the geometry computation and the deferral retry, so the
+    /// retry waits for — and re-publishes — the language the geometry will
+    /// use, not a removed one.
+    fn settled_host_language(&self, host: &Url) -> Option<String> {
+        let settled = self.documents.latest_snapshot(host).and_then(|view| {
+            view.slot.snapshot.as_ref().and_then(|current| {
+                (current.parsed_version == view.content_version && current.tree.is_some())
+                    .then(|| current.language.clone())
+                    .flatten()
+            })
+        });
+        settled.or_else(|| {
+            self.documents
+                .get(host)
+                .and_then(|doc| doc.language_id().map(str::to_string))
+        })
+    }
+
     fn current_region_offsets(&self, host: &Url) -> Option<HashMap<String, RegionOffset>> {
         let mut offsets = HashMap::new();
 
@@ -1647,20 +1669,10 @@ impl DiagnosticPublisher {
         // snapshot only); then the stored id; parser-aware detection last —
         // it answers "none" (or another loaded language) while the declared
         // language is still publishing, and that is not "no regions".
-        let settled_language = self.documents.latest_snapshot(host).and_then(|view| {
-            view.slot.snapshot.as_ref().and_then(|current| {
-                (current.parsed_version == view.content_version && current.tree.is_some())
-                    .then(|| current.language.clone())
-                    .flatten()
-            })
-        });
-        let Some(language_name) = settled_language
-            .or_else(|| doc.language_id().map(str::to_string))
-            .or_else(|| {
-                self.language
-                    .detect_language_trace(host.path(), snapshot.text(), None, None)
-            })
-        else {
+        let Some(language_name) = self.settled_host_language(host).or_else(|| {
+            self.language
+                .detect_language_trace(host.path(), snapshot.text(), None, None)
+        }) else {
             return Some(offsets);
         };
         // A language still publishing (queries land before the parser) has

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1104,13 +1104,15 @@ impl DiagnosticPublisher {
                     // A deferral with a parse snapshot present is the
                     // language still publishing or a reload in progress, not
                     // a pending tree — and no reparse follows an injected
-                    // language's auto-install reload. Retry once it settles.
-                    if self
-                        .documents
-                        .get(host)
-                        .is_some_and(|doc| doc.snapshot().is_some())
-                    {
-                        self.retry_republish_when_settled(host);
+                    // language's auto-install reload. Retry once it settles;
+                    // a document whose language stays unsettled (a load that
+                    // failed for good) ends the retry at its deadline.
+                    let host_language = self.documents.get(host).and_then(|doc| {
+                        doc.snapshot()?;
+                        doc.language_id().map(str::to_string)
+                    });
+                    if let Some(host_language) = host_language {
+                        self.retry_republish_when_settled(host, host_language);
                     }
                     return RepublishOutcome::Deferred;
                 }
@@ -1572,7 +1574,7 @@ impl DiagnosticPublisher {
     /// Re-run `republish` for `host` once no reload is in progress, bounded:
     /// the deferral otherwise relies on the reparse loop, which an injected
     /// language's auto-install reload never triggers for the host.
-    fn retry_republish_when_settled(&self, host: &Url) {
+    fn retry_republish_when_settled(&self, host: &Url, host_language: String) {
         const REPUBLISH_RETRY_BUDGET: std::time::Duration = std::time::Duration::from_secs(10);
         const REPUBLISH_RETRY_POLL: std::time::Duration = std::time::Duration::from_millis(50);
         let this = self.clone();
@@ -1589,7 +1591,7 @@ impl DiagnosticPublisher {
                     .lock()
                     .recover_poison("DiagnosticPublisher::retry_republish_when_settled")
                     .reload_in_progress();
-                if !reloading {
+                if !reloading && this.language.has_parser_available(&host_language) {
                     log::debug!(
                         target: LOG_TARGET,
                         "retry republish for {host}: reload settled"

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1588,7 +1588,7 @@ impl DiagnosticPublisher {
         let this = self.clone();
         let host = host.clone();
         tokio::spawn(async move {
-            let _claim = claim;
+            let claim = claim;
             let deadline = tokio::time::Instant::now() + REPUBLISH_RETRY_BUDGET;
             loop {
                 tokio::select! {
@@ -1615,6 +1615,10 @@ impl DiagnosticPublisher {
                         target: LOG_TARGET,
                         "retry republish for {host}: reload settled"
                     );
+                    // Release the slot BEFORE republishing: a reload
+                    // starting right now makes it defer again, and that
+                    // deferral must be able to claim the slot this waiter held.
+                    drop(claim);
                     let _ = this.republish(&host).await;
                     return;
                 }
@@ -1638,13 +1642,25 @@ impl DiagnosticPublisher {
         // region slots are present (every keystroke settle during a typing
         // burst) — the debug variant would re-grow the per-event
         // `language_detection` log volume PR #677 moved off hot paths.
-        // Stored language first: parser-aware detection answers "none" (or
-        // another loaded language) while the declared language is still
-        // publishing, and that is not "no regions".
-        let Some(language_name) = doc.language_id().map(str::to_string).or_else(|| {
-            self.language
-                .detect_language_trace(host.path(), snapshot.text(), None, None)
-        }) else {
+        // The settled parse names the language authoritatively (a reload
+        // that re-detects the document publishes the new language on the
+        // snapshot only); then the stored id; parser-aware detection last —
+        // it answers "none" (or another loaded language) while the declared
+        // language is still publishing, and that is not "no regions".
+        let settled_language = self.documents.latest_snapshot(host).and_then(|view| {
+            view.slot.snapshot.as_ref().and_then(|current| {
+                (current.parsed_version == view.content_version && current.tree.is_some())
+                    .then(|| current.language.clone())
+                    .flatten()
+            })
+        });
+        let Some(language_name) = settled_language
+            .or_else(|| doc.language_id().map(str::to_string))
+            .or_else(|| {
+                self.language
+                    .detect_language_trace(host.path(), snapshot.text(), None, None)
+            })
+        else {
             return Some(offsets);
         };
         // A language still publishing (queries land before the parser) has

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use url::Url;
 
 use crate::document::DocumentStore;
+use crate::error::LockResultExt;
 use crate::language::{InjectionResolver, LanguageCoordinator};
 use crate::lsp::bridge::{
     BridgeCoordinator, ProgressConnectionId, RegionOffset, VirtualDocumentUri,
@@ -148,6 +149,7 @@ pub(crate) struct DiagnosticPublisher {
     bridge: Arc<BridgeCoordinator>,
     settings_manager: Arc<SettingsManager>,
     cache: Arc<crate::lsp::cache::CacheCoordinator>,
+    parser_pool: Arc<std::sync::Mutex<crate::language::DocumentParserPool>>,
     snapshot_preparer: DiagnosticSnapshotPreparer,
     aggregator: Arc<DiagnosticAggregator>,
     shutdown: tokio_util::sync::CancellationToken,
@@ -162,6 +164,7 @@ impl DiagnosticPublisher {
             bridge: Arc::clone(&server.bridge),
             settings_manager: Arc::clone(&server.settings_manager),
             cache: Arc::clone(&server.cache),
+            parser_pool: Arc::clone(&server.parser_pool),
             snapshot_preparer: DiagnosticSnapshotPreparer::new(server),
             aggregator: Arc::clone(&server.diagnostics),
             shutdown: server.shutdown_token.clone(),
@@ -1578,9 +1581,16 @@ impl DiagnosticPublisher {
             return Some(offsets);
         };
         // A language still publishing (queries land before the parser) has
-        // unknown geometry: defer, like a pending tree. A visible parser
-        // with no injection query is definitive.
-        if !self.language.has_parser_available(&language_name) {
+        // unknown geometry: defer, like a pending tree. So does a settings
+        // reload in progress, during which an already-visible parser keeps
+        // its registration while its queries are cleared and republished. A
+        // visible parser with no injection query is otherwise definitive.
+        let reload_in_progress = self
+            .parser_pool
+            .lock()
+            .recover_poison("DiagnosticPublisher::current_region_offsets")
+            .reload_in_progress();
+        if reload_in_progress || !self.language.has_parser_available(&language_name) {
             return None;
         }
         let Some(injection_query) = self.language.injection_query(&language_name) else {
@@ -3391,6 +3401,25 @@ mod tests {
             publisher.current_region_offsets(&publishing).is_none(),
             "a language whose parser is not published has unknown geometry"
         );
+        // Parser published, but a reload is swapping its queries: unknown too.
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("markdown".to_string(), language);
+        server
+            .parser_pool
+            .lock()
+            .expect("parser pool lock")
+            .begin_reload();
+        assert!(
+            publisher.current_region_offsets(&publishing).is_none(),
+            "a reload in progress has unknown geometry"
+        );
+        server
+            .parser_pool
+            .lock()
+            .expect("parser pool lock")
+            .finish_reload();
 
         // Closed (never-opened) document: geometry ABSENT → Some(empty) (stale
         // region slots legitimately drop; didClose's clearing publish proceeds).

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1663,7 +1663,9 @@ impl DiagnosticPublisher {
             return None;
         }
         let Some(injection_query) = injection_query else {
-            return Some(offsets);
+            // Definitive only while still settled: a reload beginning right
+            // here removes queries, and "no query" would read as no regions.
+            return settled().then_some(offsets);
         };
 
         let resolved_regions = match self

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1772,7 +1772,16 @@ impl DiagnosticPublisher {
                 ),
             );
         }
-        settled().then_some(offsets)
+        // The offsets describe the captured snapshot; an edit (or reopen)
+        // landing since makes them stale positions for the text the editor
+        // now holds, and edits do not move the generation `settled` watches.
+        // Defer instead; the pending parse's republish carries the new
+        // geometry.
+        let document_unchanged = self.documents.latest_snapshot(host).is_some_and(|now| {
+            now.content_version == view.content_version
+                && now.slot.current_incarnation == view.slot.current_incarnation
+        });
+        (settled() && document_unchanged).then_some(offsets)
     }
 }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1591,6 +1591,16 @@ impl DiagnosticPublisher {
                     .lock()
                     .recover_poison("DiagnosticPublisher::retry_republish_when_settled")
                     .reload_in_progress();
+                // A host parser discovered from `searchPaths` loses its
+                // registration to any reload's generation bump and is only
+                // re-published on request; ask for it, or the wait would
+                // only expire.
+                if !reloading && !this.language.has_parser_available(&host_language) {
+                    let _ = this
+                        .language
+                        .ensure_language_loaded_async(&host_language)
+                        .await;
+                }
                 if !reloading && this.language.has_parser_available(&host_language) {
                     log::debug!(
                         target: LOG_TARGET,

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1585,15 +1585,26 @@ impl DiagnosticPublisher {
         // reload in progress, during which an already-visible parser keeps
         // its registration while its queries are cleared and republished. A
         // visible parser with no injection query is otherwise definitive.
-        let reload_in_progress = self
-            .parser_pool
-            .lock()
-            .recover_poison("DiagnosticPublisher::current_region_offsets")
-            .reload_in_progress();
-        if reload_in_progress || !self.language.has_parser_available(&language_name) {
+        // Re-asked before every definitive answer, with the generation read
+        // around the parser and query reads: a reload starting in between
+        // would otherwise turn a query removed mid-swap into "no regions".
+        let generation_before = self.cache.semantic_token_generation();
+        let settled = || {
+            let reload_in_progress = self
+                .parser_pool
+                .lock()
+                .recover_poison("DiagnosticPublisher::current_region_offsets")
+                .reload_in_progress();
+            !reload_in_progress && self.cache.semantic_token_generation() == generation_before
+        };
+        if !settled() || !self.language.has_parser_available(&language_name) {
             return None;
         }
-        let Some(injection_query) = self.language.injection_query(&language_name) else {
+        let injection_query = self.language.injection_query(&language_name);
+        if !settled() {
+            return None;
+        }
+        let Some(injection_query) = injection_query else {
             return Some(offsets);
         };
 
@@ -1621,7 +1632,7 @@ impl DiagnosticPublisher {
                 ),
             );
         }
-        Some(offsets)
+        settled().then_some(offsets)
     }
 }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1568,14 +1568,21 @@ impl DiagnosticPublisher {
         // region slots are present (every keystroke settle during a typing
         // burst) — the debug variant would re-grow the per-event
         // `language_detection` log volume PR #677 moved off hot paths.
-        let Some(language_name) = self.language.detect_language_trace(
-            host.path(),
-            snapshot.text(),
-            None,
-            doc.language_id(),
-        ) else {
+        // Stored language first: parser-aware detection answers "none" (or
+        // another loaded language) while the declared language is still
+        // publishing, and that is not "no regions".
+        let Some(language_name) = doc.language_id().map(str::to_string).or_else(|| {
+            self.language
+                .detect_language_trace(host.path(), snapshot.text(), None, None)
+        }) else {
             return Some(offsets);
         };
+        // A language still publishing (queries land before the parser) has
+        // unknown geometry: defer, like a pending tree. A visible parser
+        // with no injection query is definitive.
+        if !self.language.has_parser_available(&language_name) {
+            return None;
+        }
         let Some(injection_query) = self.language.injection_query(&language_name) else {
             return Some(offsets);
         };
@@ -3341,6 +3348,48 @@ mod tests {
         assert!(
             publisher.current_region_offsets(&pending).is_none(),
             "an open document with no parse snapshot has unknown geometry"
+        );
+
+        // Parsed, but its language's parser is not published (still loading
+        // or scoped out by a reload): geometry UNKNOWN → None, not "no
+        // regions" — a republish would otherwise drop every injected
+        // diagnostic until another parse.
+        let publishing = Url::parse("file:///test/publishing.md").unwrap();
+        let text = "```lua\nprint(1)\n```\n";
+        let language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&language).unwrap();
+        let tree = parser.parse(text, None).unwrap();
+        let incarnation = server.documents.insert(
+            publishing.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let content_version = server.documents.get(&publishing).unwrap().content_version();
+        let landed = server
+            .documents
+            .get(&publishing)
+            .map(|doc| {
+                doc.publish_snapshot(std::sync::Arc::new(
+                    crate::document::snapshot::ParseSnapshot {
+                        text: std::sync::Arc::from(text),
+                        tree: Some(tree),
+                        language: Some("markdown".to_string()),
+                        parsed_version: content_version,
+                        incarnation,
+                        injection_regions: None,
+                        bridge_regions: None,
+                        resolved_regions: None,
+                        layer_trees: std::sync::OnceLock::new(),
+                    },
+                ))
+            })
+            .unwrap_or(false);
+        assert!(landed, "test publish must land");
+        assert!(
+            publisher.current_region_offsets(&publishing).is_none(),
+            "a language whose parser is not published has unknown geometry"
         );
 
         // Closed (never-opened) document: geometry ABSENT → Some(empty) (stale

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1681,16 +1681,30 @@ impl DiagnosticPublisher {
         // guard is dropped before any further store lookup: a second lookup
         // under a held guard could queue behind a writer on the same shard
         // that is itself waiting for this guard.
-        let settled_language = self.settled_snapshot_language(host);
-        let (snapshot, stored_language) = {
-            let Some(doc) = self.documents.get(host) else {
-                return Some(offsets); // closed host: nothing to anchor against
-            };
-            let Some(snapshot) = doc.snapshot() else {
-                return None; // open but tree pending: geometry unknown, defer
-            };
-            (snapshot, doc.language_id().map(str::to_string))
+        // Language, tree, text and lifetime from ONE current snapshot: a
+        // replacement parse of a re-detected document attaches its tree to
+        // the legacy document before it publishes, and the old query over
+        // the new tree would anchor region diagnostics wrongly. The view is
+        // an owned clone; no store guard is held across the lookups below.
+        let Some(view) = self.documents.latest_snapshot(host) else {
+            return Some(offsets); // closed host: nothing to anchor against
         };
+        let Some(current) = view
+            .slot
+            .snapshot
+            .as_ref()
+            .filter(|snapshot| snapshot.parsed_version == view.content_version)
+        else {
+            return None; // open but tree pending: geometry unknown, defer
+        };
+        let Some(tree) = current.tree.as_ref() else {
+            return None; // reload placeholder / parse without a tree: defer
+        };
+        let settled_language = current.language.clone();
+        let stored_language = self
+            .documents
+            .get(host)
+            .and_then(|doc| doc.language_id().map(str::to_string));
         // Trace-level detection: this runs on the republish path whenever
         // region slots are present (every keystroke settle during a typing
         // burst) — the debug variant would re-grow the per-event
@@ -1700,7 +1714,7 @@ impl DiagnosticPublisher {
         // is still publishing, and that is not "no regions".
         let Some(language_name) = settled_language.or(stored_language).or_else(|| {
             self.language
-                .detect_language_trace(host.path(), snapshot.text(), None, None)
+                .detect_language_trace(host.path(), &current.text, None, None)
         }) else {
             return Some(offsets);
         };
@@ -1743,10 +1757,10 @@ impl DiagnosticPublisher {
                 &self.language,
                 self.bridge.node_tracker(),
                 host,
-                snapshot.tree(),
-                snapshot.text(),
+                tree,
+                &current.text,
                 injection_query.as_ref(),
-                snapshot.incarnation(),
+                current.incarnation,
             )),
         };
         for resolved in resolved_regions.iter() {

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1101,6 +1101,17 @@ impl DiagnosticPublisher {
                         target: LOG_TARGET,
                         "defer republish for {host}: tree pending, region geometry unknown"
                     );
+                    // A deferral with a parse snapshot present is the
+                    // language still publishing or a reload in progress, not
+                    // a pending tree — and no reparse follows an injected
+                    // language's auto-install reload. Retry once it settles.
+                    if self
+                        .documents
+                        .get(host)
+                        .is_some_and(|doc| doc.snapshot().is_some())
+                    {
+                        self.retry_republish_when_settled(host);
+                    }
                     return RepublishOutcome::Deferred;
                 }
             }
@@ -1558,6 +1569,41 @@ impl DiagnosticPublisher {
     /// regions as gone. `Some(empty)` means there legitimately are no regions to
     /// anchor: the document is closed, or its language resolves to no injection
     /// query — stale region slots drop from the merge.
+    /// Re-run `republish` for `host` once no reload is in progress, bounded:
+    /// the deferral otherwise relies on the reparse loop, which an injected
+    /// language's auto-install reload never triggers for the host.
+    fn retry_republish_when_settled(&self, host: &Url) {
+        const REPUBLISH_RETRY_BUDGET: std::time::Duration = std::time::Duration::from_secs(10);
+        const REPUBLISH_RETRY_POLL: std::time::Duration = std::time::Duration::from_millis(50);
+        let this = self.clone();
+        let host = host.clone();
+        tokio::spawn(async move {
+            let deadline = tokio::time::Instant::now() + REPUBLISH_RETRY_BUDGET;
+            loop {
+                tokio::select! {
+                    _ = this.shutdown.cancelled() => return,
+                    _ = tokio::time::sleep(REPUBLISH_RETRY_POLL) => {}
+                }
+                let reloading = this
+                    .parser_pool
+                    .lock()
+                    .recover_poison("DiagnosticPublisher::retry_republish_when_settled")
+                    .reload_in_progress();
+                if !reloading {
+                    log::debug!(
+                        target: LOG_TARGET,
+                        "retry republish for {host}: reload settled"
+                    );
+                    let _ = this.republish(&host).await;
+                    return;
+                }
+                if tokio::time::Instant::now() >= deadline {
+                    return;
+                }
+            }
+        });
+    }
+
     fn current_region_offsets(&self, host: &Url) -> Option<HashMap<String, RegionOffset>> {
         let mut offsets = HashMap::new();
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1653,39 +1653,52 @@ impl DiagnosticPublisher {
     /// retry waits for — and re-publishes — the language the geometry will
     /// use, not a removed one.
     fn settled_host_language(&self, host: &Url) -> Option<String> {
-        let settled = self.documents.latest_snapshot(host).and_then(|view| {
-            view.slot.snapshot.as_ref().and_then(|current| {
-                (current.parsed_version == view.content_version && current.tree.is_some())
-                    .then(|| current.language.clone())
-                    .flatten()
-            })
-        });
-        settled.or_else(|| {
+        self.settled_snapshot_language(host).or_else(|| {
             self.documents
                 .get(host)
                 .and_then(|doc| doc.language_id().map(str::to_string))
         })
     }
 
+    /// The language of the current snapshot when it carries a tree. One
+    /// store lookup, released on return.
+    fn settled_snapshot_language(&self, host: &Url) -> Option<String> {
+        self.documents.latest_snapshot(host).and_then(|view| {
+            view.slot.snapshot.as_ref().and_then(|current| {
+                (current.parsed_version == view.content_version && current.tree.is_some())
+                    .then(|| current.language.clone())
+                    .flatten()
+            })
+        })
+    }
+
     fn current_region_offsets(&self, host: &Url) -> Option<HashMap<String, RegionOffset>> {
         let mut offsets = HashMap::new();
 
-        let Some(doc) = self.documents.get(host) else {
-            return Some(offsets); // closed host: nothing to anchor against
-        };
-        let Some(snapshot) = doc.snapshot() else {
-            return None; // open but tree pending: geometry unknown, defer
+        // The settled parse names the language authoritatively (a reload
+        // that re-detects the document publishes the new language on the
+        // snapshot only); read BEFORE the document guard below, and the
+        // guard is dropped before any further store lookup: a second lookup
+        // under a held guard could queue behind a writer on the same shard
+        // that is itself waiting for this guard.
+        let settled_language = self.settled_snapshot_language(host);
+        let (snapshot, stored_language) = {
+            let Some(doc) = self.documents.get(host) else {
+                return Some(offsets); // closed host: nothing to anchor against
+            };
+            let Some(snapshot) = doc.snapshot() else {
+                return None; // open but tree pending: geometry unknown, defer
+            };
+            (snapshot, doc.language_id().map(str::to_string))
         };
         // Trace-level detection: this runs on the republish path whenever
         // region slots are present (every keystroke settle during a typing
         // burst) — the debug variant would re-grow the per-event
         // `language_detection` log volume PR #677 moved off hot paths.
-        // The settled parse names the language authoritatively (a reload
-        // that re-detects the document publishes the new language on the
-        // snapshot only); then the stored id; parser-aware detection last —
-        // it answers "none" (or another loaded language) while the declared
-        // language is still publishing, and that is not "no regions".
-        let Some(language_name) = self.settled_host_language(host).or_else(|| {
+        // Then the stored id; parser-aware detection last — it answers
+        // "none" (or another loaded language) while the declared language
+        // is still publishing, and that is not "no regions".
+        let Some(language_name) = settled_language.or(stored_language).or_else(|| {
             self.language
                 .detect_language_trace(host.path(), snapshot.text(), None, None)
         }) else {

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1582,7 +1582,7 @@ impl DiagnosticPublisher {
         // One waiter per host: every deferral of the same window would
         // otherwise spawn its own poller, and all of them would then
         // serialize through the host's republish lock once settled.
-        let Some(claim) = self.settle_retry_waiters.claim("republish", host) else {
+        let Some(claim) = self.settle_retry_waiters.claim("republish", host, None) else {
             return;
         };
         let this = self.clone();

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -150,6 +150,7 @@ pub(crate) struct DiagnosticPublisher {
     settings_manager: Arc<SettingsManager>,
     cache: Arc<crate::lsp::cache::CacheCoordinator>,
     parser_pool: Arc<std::sync::Mutex<crate::language::DocumentParserPool>>,
+    settle_retry_waiters: crate::lsp::lsp_impl::settle_retry::SettleRetryWaiters,
     snapshot_preparer: DiagnosticSnapshotPreparer,
     aggregator: Arc<DiagnosticAggregator>,
     shutdown: tokio_util::sync::CancellationToken,
@@ -165,6 +166,7 @@ impl DiagnosticPublisher {
             settings_manager: Arc::clone(&server.settings_manager),
             cache: Arc::clone(&server.cache),
             parser_pool: Arc::clone(&server.parser_pool),
+            settle_retry_waiters: server.settle_retry_waiters.clone(),
             snapshot_preparer: DiagnosticSnapshotPreparer::new(server),
             aggregator: Arc::clone(&server.diagnostics),
             shutdown: server.shutdown_token.clone(),
@@ -1577,9 +1579,16 @@ impl DiagnosticPublisher {
     fn retry_republish_when_settled(&self, host: &Url, host_language: String) {
         const REPUBLISH_RETRY_BUDGET: std::time::Duration = std::time::Duration::from_secs(10);
         const REPUBLISH_RETRY_POLL: std::time::Duration = std::time::Duration::from_millis(50);
+        // One waiter per host: every deferral of the same window would
+        // otherwise spawn its own poller, and all of them would then
+        // serialize through the host's republish lock once settled.
+        let Some(claim) = self.settle_retry_waiters.claim("republish", host) else {
+            return;
+        };
         let this = self.clone();
         let host = host.clone();
         tokio::spawn(async move {
+            let _claim = claim;
             let deadline = tokio::time::Instant::now() + REPUBLISH_RETRY_BUDGET;
             loop {
                 tokio::select! {

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1109,13 +1109,12 @@ impl DiagnosticPublisher {
                     // language's auto-install reload. Retry once it settles;
                     // a document whose language stays unsettled (a load that
                     // failed for good) ends the retry at its deadline.
-                    let host_language = self
-                        .documents
-                        .get(host)
-                        .and_then(|doc| doc.snapshot().map(|_| ()))
-                        .and_then(|()| self.settled_host_language(host));
-                    if let Some(host_language) = host_language {
-                        self.retry_republish_when_settled(host, host_language);
+                    let lifetime = self.documents.get(host).and_then(|doc| {
+                        doc.snapshot()?;
+                        Some(doc.incarnation())
+                    });
+                    if let Some(lifetime) = lifetime {
+                        self.retry_republish_when_settled(host, lifetime);
                     }
                     return RepublishOutcome::Deferred;
                 }
@@ -1577,13 +1576,21 @@ impl DiagnosticPublisher {
     /// Re-run `republish` for `host` once no reload is in progress, bounded:
     /// the deferral otherwise relies on the reparse loop, which an injected
     /// language's auto-install reload never triggers for the host.
-    fn retry_republish_when_settled(&self, host: &Url, host_language: String) {
+    ///
+    /// Bound to the document lifetime that deferred: a close and reopen at
+    /// the same URI gets its own waiter, and this one exits when its
+    /// lifetime is gone. The language is re-read on every poll, so a
+    /// re-detection under the same lifetime is followed too.
+    fn retry_republish_when_settled(&self, host: &Url, lifetime: u64) {
         const REPUBLISH_RETRY_BUDGET: std::time::Duration = std::time::Duration::from_secs(10);
         const REPUBLISH_RETRY_POLL: std::time::Duration = std::time::Duration::from_millis(50);
         // One waiter per host: every deferral of the same window would
         // otherwise spawn its own poller, and all of them would then
         // serialize through the host's republish lock once settled.
-        let Some(claim) = self.settle_retry_waiters.claim("republish", host, None) else {
+        let Some(claim) = self
+            .settle_retry_waiters
+            .claim("republish", host, Some(lifetime))
+        else {
             return;
         };
         let this = self.clone();
@@ -1596,6 +1603,15 @@ impl DiagnosticPublisher {
                     _ = this.shutdown.cancelled() => return,
                     _ = tokio::time::sleep(REPUBLISH_RETRY_POLL) => {}
                 }
+                // The lifetime that deferred must still be current, and the
+                // language is whatever the settled parse names NOW.
+                let current = this.documents.get(&host).map(|doc| doc.incarnation());
+                if current != Some(lifetime) {
+                    return;
+                }
+                let Some(host_language) = this.settled_host_language(&host) else {
+                    return;
+                };
                 let reloading = this
                     .parser_pool
                     .lock()

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -546,9 +546,10 @@ impl InjectionCoordinator {
     /// landing right after an edit would resolve ZERO injections and silently
     /// open nothing — the same reason every request path waits for a fresh tree
     /// (execute-command-routing-token). This NARROWS that window rather than
-    /// closing it: the wait is bounded, and on expiry the re-open proceeds and
-    /// may still open nothing. Degrading to the pre-existing lazy heal (the next
-    /// parse re-opens) is preferred over stalling the barrier.
+    /// closing it: the wait is bounded, and on expiry the caller reads
+    /// `Unsettled`, skips the document and reports its sweep incomplete, leaving
+    /// the document to its own pending parse's eager open. Degrading to that
+    /// lazy heal is preferred over stalling the barrier.
     /// Returns which of the three outcomes a caller must distinguish. They are
     /// not interchangeable: `Gone` is nothing to do, `Unsettled` is something
     /// this pass could not determine, and collapsing them makes a closed buffer

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -560,15 +560,17 @@ impl InjectionCoordinator {
     fn get_language_for_document(&self, uri: &Url) -> Option<String> {
         detect_document_language(&self.language, &self.documents, uri)
     }
+    fn reload_in_progress(&self) -> bool {
+        self.parser_pool
+            .lock()
+            .recover_poison("InjectionCoordinator::reload_in_progress")
+            .reload_in_progress()
+    }
+
     /// Whether `language`'s parser is not published yet or a reload is in
     /// progress — the two transient reasons a resolution cannot look.
     fn language_is_unsettled(&self, language: &str) -> bool {
-        let reloading = self
-            .parser_pool
-            .lock()
-            .recover_poison("InjectionCoordinator::language_is_unsettled")
-            .reload_in_progress();
-        reloading || !self.language.has_parser_available(language)
+        self.reload_in_progress() || !self.language.has_parser_available(language)
     }
 
     /// Re-run the tree-derived downstream pass for `uri` once the language's
@@ -593,6 +595,19 @@ impl InjectionCoordinator {
             let deadline = tokio::time::Instant::now() + INJECTION_RETRY_BUDGET;
             loop {
                 tokio::time::sleep(INJECTION_RETRY_POLL).await;
+                // A host parser discovered from `searchPaths` (not declared)
+                // loses its registration to the generation bump of any
+                // reload — including an injected language's auto-install,
+                // which re-ensures only the installed language — and nothing
+                // re-publishes it without a request. Ask for it here, or the
+                // wait below would only expire.
+                if !this.reload_in_progress() && !this.language.has_parser_available(&host_language)
+                {
+                    let _ = this
+                        .language
+                        .ensure_language_loaded_async(&host_language)
+                        .await;
+                }
                 if !this.language_is_unsettled(&host_language) {
                     log::debug!(
                         target: "kakehashi::bridge",

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -545,8 +545,18 @@ impl InjectionCoordinator {
     /// The cheap half of what [`Self::bridge_injections`] returns, so a caller
     /// screening many candidate documents can ask the configuration question
     /// before paying for a parse wait and an injection resolution.
+    ///
+    /// Parser-aware detection answers `None` until the language's parser is
+    /// published, which a language load in progress makes true for a moment
+    /// (queries land first); the language the document was opened or parsed
+    /// under is then the answer, so the caller reads "could not look" from
+    /// the resolution instead of "no language" from here.
     pub(crate) fn document_language(&self, uri: &Url) -> Option<String> {
-        self.get_language_for_document(uri)
+        self.get_language_for_document(uri).or_else(|| {
+            self.documents
+                .get(uri)
+                .and_then(|document| document.language_id().map(str::to_string))
+        })
     }
 
     /// `uri`'s reopen generation, which scopes a downstream `didOpen` to the
@@ -568,7 +578,7 @@ impl InjectionCoordinator {
         &self,
         uri: &Url,
     ) -> Option<(String, Option<Vec<BridgeInjection>>)> {
-        let host_language = self.get_language_for_document(uri)?;
+        let host_language = self.document_language(uri)?;
         let injections = self.resolve_injection_data(uri, &host_language);
         Some((host_language, injections))
     }

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -598,8 +598,16 @@ impl InjectionCoordinator {
             // user simply closed.
             Ok(SnapshotWait::Gone) => ParseWait::Gone,
             // Trailing, never parsed, or out of budget: whatever the injection
-            // resolution says next is not evidence about this document.
-            Ok(SnapshotWait::Stale | SnapshotWait::Unparsed) | Err(_) => ParseWait::Unsettled,
+            // resolution says next is not evidence about this document — unless
+            // the parse landed between the check above and the timeout, which
+            // a zero budget makes likely enough to look once more.
+            Ok(SnapshotWait::Stale | SnapshotWait::Unparsed) | Err(_) => {
+                if self.snapshot_is_current(uri) {
+                    ParseWait::Current
+                } else {
+                    ParseWait::Unsettled
+                }
+            }
         }
     }
 

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -143,13 +143,25 @@ impl InjectionCoordinator {
             );
         }
 
-        let injection_query = self.language.injection_query(host_language)?;
+        // `None` below means "could not be looked at", which the re-open sweep
+        // must tell apart from "has nothing" — the latter releases commands.
+        let parser_published = self.language.has_parser_available(host_language);
+        let Some(injection_query) = self.language.injection_query(host_language) else {
+            // Queries are published before the parser, so a visible parser
+            // with no injection query is definitive. Without the parser the
+            // load is still publishing (or failed, and nothing will parse).
+            return parser_published.then(Vec::new);
+        };
 
         let Some(doc) = self.documents.get(uri) else {
             return Some(Vec::new());
         };
         let Some(tree) = doc.tree().cloned() else {
-            return Some(Vec::new());
+            // No tree although a parser is published: a reload placeholder
+            // (`Document::invalidate_parse`, version-current and tree-less) or
+            // a parse that yielded nothing — either way the document could not
+            // be looked at. No parser: nothing will ever be parsed here.
+            return (!parser_published).then(Vec::new);
         };
         let text = doc.text_arc();
         let incarnation = doc.incarnation();
@@ -527,9 +539,9 @@ impl InjectionCoordinator {
     /// when the document has no detectable language. Lets a caller re-derive the
     /// injected regions on demand (the respawn re-open), mirroring the
     /// didOpen/didChange discovery.
-    /// The inner `None` means the host language's injection query is not in
-    /// the store right now: the document could not be looked at, which is
-    /// not the same as having no injections.
+    /// The inner `None` means the document could not be looked at — its
+    /// language is still publishing, or it has no tree although a parser is
+    /// published — which is not the same as having no injections.
     pub(crate) fn bridge_injections(
         &self,
         uri: &Url,

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -175,11 +175,12 @@ impl InjectionCoordinator {
             return Some(Vec::new());
         };
         let Some(tree) = doc.tree().cloned() else {
-            // No tree although a parser is published: a reload placeholder
+            // No tree: with the parser published, a reload placeholder
             // (`Document::invalidate_parse`, version-current and tree-less) or
-            // a parse that yielded nothing — either way the document could not
-            // be looked at. No parser: nothing will ever be parsed here.
-            return (!parser_published).then(Vec::new);
+            // a parse that yielded nothing; without it, a publication still
+            // in progress (the query above arrived first). Either way the
+            // document could not be looked at.
+            return None;
         };
         let text = doc.text_arc();
         let incarnation = doc.incarnation();
@@ -993,11 +994,11 @@ mod tests {
     }
 
     /// A reload publishes a version-current placeholder with no tree while
-    /// the replacement parse is still queued. With a parser published, such a
-    /// document could not be looked at; without one no tree will ever come,
-    /// and the reading is genuinely empty.
+    /// the replacement parse is still queued, and a language publishes its
+    /// queries before its parser. A tree-less document could not be looked
+    /// at in either state.
     #[tokio::test]
-    async fn tree_less_document_is_undeterminable_only_while_a_parser_exists() {
+    async fn tree_less_document_is_undeterminable() {
         let (service, _socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
         let server = service.inner();
         let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
@@ -1022,10 +1023,8 @@ mod tests {
         let injection = server.injection_coordinator();
 
         assert!(
-            injection
-                .resolve_injection_data(&uri, "rust")
-                .is_some_and(|regions| regions.is_empty()),
-            "without a parser nothing will ever be parsed: read as empty"
+            injection.resolve_injection_data(&uri, "rust").is_none(),
+            "query published, parser not yet: the publication is in progress"
         );
 
         server

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -306,14 +306,20 @@ impl InjectionCoordinator {
         // lands once the language is in place run this pass for real.
         let Some(injections) = self.resolve_injection_data(uri, &host_language) else {
             // Nothing else re-runs this pass for a document whose sole parse
-            // overlapped the window (an injected language's auto-install
-            // reload does not reparse hosts), so arrange the retry here.
-            self.retry_injection_pass_when_settled(
-                uri,
-                &host_language,
-                forward_did_change,
-                incarnation,
-            );
+            // overlapped a publication or reload window (an injected
+            // language's auto-install reload does not reparse hosts), so
+            // arrange the retry here — for THAT cause only. A document that
+            // is tree-less under a settled language gets a tree from its own
+            // next parse or never; retrying it would re-schedule itself on
+            // every attempt.
+            if self.language_is_unsettled(&host_language) {
+                self.retry_injection_pass_when_settled(
+                    uri,
+                    &host_language,
+                    forward_did_change,
+                    incarnation,
+                );
+            }
             self.documents.remove_edit_lock_if_unshared(uri, &edit_lock);
             return true;
         };
@@ -554,6 +560,17 @@ impl InjectionCoordinator {
     fn get_language_for_document(&self, uri: &Url) -> Option<String> {
         detect_document_language(&self.language, &self.documents, uri)
     }
+    /// Whether `language`'s parser is not published yet or a reload is in
+    /// progress — the two transient reasons a resolution cannot look.
+    fn language_is_unsettled(&self, language: &str) -> bool {
+        let reloading = self
+            .parser_pool
+            .lock()
+            .recover_poison("InjectionCoordinator::language_is_unsettled")
+            .reload_in_progress();
+        reloading || !self.language.has_parser_available(language)
+    }
+
     /// Re-run the tree-derived downstream pass for `uri` once the language's
     /// publication or reload has settled, bounded (`INJECTION_RETRY_BUDGET`):
     /// a pass that answered "could not look" opened nothing, and without an
@@ -576,12 +593,7 @@ impl InjectionCoordinator {
             let deadline = tokio::time::Instant::now() + INJECTION_RETRY_BUDGET;
             loop {
                 tokio::time::sleep(INJECTION_RETRY_POLL).await;
-                let reloading = this
-                    .parser_pool
-                    .lock()
-                    .recover_poison("InjectionCoordinator::retry_injection_pass_when_settled")
-                    .reload_in_progress();
-                if !reloading && this.language.has_parser_available(&host_language) {
+                if !this.language_is_unsettled(&host_language) {
                     log::debug!(
                         target: "kakehashi::bridge",
                         "Re-running the injection pass for {uri}: {host_language} has settled"

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -128,6 +128,16 @@ impl InjectionCoordinator {
         if reload_in_progress() {
             return None;
         }
+        // Nor is anything evidence before the language's parser is published
+        // (queries land first): regions a prior lifetime's parser derived, or
+        // an inline run of a query the published parser may not pair with,
+        // would let the sweep report a document repaired from unsettled
+        // state. The generation is read around the parser and query reads so
+        // a reload starting in between shows.
+        let generation_before = self.cache.semantic_token_generation();
+        if !self.language.has_parser_available(host_language) {
+            return None;
+        }
         // Fast path (parse-snapshot ADR §3, never discover twice): the parse
         // pass that scheduled this downstream already derived the bridge
         // regions from its single injection-query run and published them on
@@ -160,34 +170,30 @@ impl InjectionCoordinator {
         // `None` below means "could not be looked at", which the re-open sweep
         // must tell apart from "has nothing" — the latter releases commands.
         //
-        // The parser check and the query read are two reads of state a
+        // The parser check above and the query read are two reads of state a
         // settings reload swaps in place (registry, then query store, under
         // the reload guard). A pair straddling that swap could combine the old
         // parser with a not-yet-published query and read as definitive, so a
         // reload in progress — or one that started between the reads, which
         // the generation bump reveals — makes the whole answer undeterminable.
-        let generation_before = self.cache.semantic_token_generation();
-        let parser_published = self.language.has_parser_available(host_language);
         let injection_query = self.language.injection_query(host_language);
         if reload_in_progress() || self.cache.semantic_token_generation() != generation_before {
             return None;
         }
         let Some(injection_query) = injection_query else {
             // Queries are published before the parser, so a visible parser
-            // with no injection query is definitive. Without the parser the
-            // load is still publishing (or failed, and nothing will parse).
-            return parser_published.then(Vec::new);
+            // with no injection query is definitive.
+            return Some(Vec::new());
         };
 
         let Some(doc) = self.documents.get(uri) else {
             return Some(Vec::new());
         };
         let Some(tree) = doc.tree().cloned() else {
-            // No tree: with the parser published, a reload placeholder
+            // No tree under a published parser: a reload placeholder
             // (`Document::invalidate_parse`, version-current and tree-less) or
-            // a parse that yielded nothing; without it, a publication still
-            // in progress (the query above arrived first). Either way the
-            // document could not be looked at.
+            // a parse that yielded nothing. The document could not be looked
+            // at.
             return None;
         };
         let text = doc.text_arc();
@@ -944,6 +950,11 @@ mod tests {
             .language
             .query_store()
             .insert_injection_query("rust".to_string(), std::sync::Arc::new(query));
+        // The resolution answers only for a published parser.
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".to_string(), language.clone());
         let text = r#"fn main() { let open = "<div>"; let close = "</div>"; }"#;
         let mut parser = tree_sitter::Parser::new();
         parser.set_language(&language).expect("load rust grammar");
@@ -1104,7 +1115,7 @@ mod tests {
 
         assert!(
             injection.resolve_injection_data(&uri, "rust").is_none(),
-            "no parser published: the load may still be publishing its queries"
+            "no parser published: the load is still publishing"
         );
 
         server

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -633,6 +633,13 @@ impl InjectionCoordinator {
         if self.snapshot_is_current(uri) {
             return ParseWait::Current;
         }
+        // Likewise a document closed since it was enumerated: with a zero
+        // budget the timeout can fire before the wait future looks, which
+        // would misreport a buffer the user closed as unsettled and hold the
+        // barrier shut over it.
+        if self.documents.get(uri).is_none() {
+            return ParseWait::Gone;
+        }
         use crate::lsp::lsp_impl::snapshot_read::SnapshotWait;
         match tokio::time::timeout(
             budget,
@@ -657,6 +664,8 @@ impl InjectionCoordinator {
             Ok(SnapshotWait::Stale | SnapshotWait::Unparsed) | Err(_) => {
                 if self.snapshot_is_current(uri) {
                     ParseWait::Current
+                } else if self.documents.get(uri).is_none() {
+                    ParseWait::Gone
                 } else {
                     ParseWait::Unsettled
                 }
@@ -733,6 +742,23 @@ mod tests {
                 .ensure_document_parsed(&pending, std::time::Duration::ZERO)
                 .await,
             super::ParseWait::Unsettled
+        ));
+
+        // A document closed since the sweep enumerated it is nothing to
+        // repair, whatever the budget.
+        let closed = Url::parse("file:///zero-budget-closed.md").unwrap();
+        server.documents.insert(
+            closed.clone(),
+            "# closed".to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        server.documents.remove(&closed);
+        assert!(matches!(
+            injection
+                .ensure_document_parsed(&closed, std::time::Duration::ZERO)
+                .await,
+            super::ParseWait::Gone
         ));
 
         let current = Url::parse("file:///zero-budget-current.md").unwrap();

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -590,9 +590,14 @@ impl InjectionCoordinator {
     ) {
         const INJECTION_RETRY_BUDGET: std::time::Duration = std::time::Duration::from_secs(10);
         const INJECTION_RETRY_POLL: std::time::Duration = std::time::Duration::from_millis(50);
-        // One waiter per document: a burst of passes deferred by the same
-        // window re-runs the pass once, when the language settles.
-        let Some(claim) = self.settle_retry_waiters.claim("injection", uri) else {
+        // One waiter per document LIFETIME: a burst of passes deferred by the
+        // same window re-runs the pass once, when the language settles; a
+        // close and reopen in the meantime gets its own waiter, since this
+        // one exits at its lifetime check.
+        let Some(claim) = self
+            .settle_retry_waiters
+            .claim("injection", uri, Some(incarnation))
+        else {
             return;
         };
         let this = self.clone();

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -115,6 +115,19 @@ impl InjectionCoordinator {
         uri: &Url,
         host_language: &str,
     ) -> Option<Vec<BridgeInjection>> {
+        // A reload in progress makes nothing below evidence — not even the
+        // snapshot fast path: a parse that checked its parser out just before
+        // the reload began can publish regions derived from the OLD query
+        // under the transitional generation, which the stamp check accepts.
+        let reload_in_progress = || {
+            self.parser_pool
+                .lock()
+                .recover_poison("InjectionCoordinator::resolve_injection_data")
+                .reload_in_progress()
+        };
+        if reload_in_progress() {
+            return None;
+        }
         // Fast path (parse-snapshot ADR §3, never discover twice): the parse
         // pass that scheduled this downstream already derived the bridge
         // regions from its single injection-query run and published them on
@@ -156,12 +169,7 @@ impl InjectionCoordinator {
         let generation_before = self.cache.semantic_token_generation();
         let parser_published = self.language.has_parser_available(host_language);
         let injection_query = self.language.injection_query(host_language);
-        let reload_in_progress = self
-            .parser_pool
-            .lock()
-            .recover_poison("InjectionCoordinator::resolve_injection_data")
-            .reload_in_progress();
-        if reload_in_progress || self.cache.semantic_token_generation() != generation_before {
+        if reload_in_progress() || self.cache.semantic_token_generation() != generation_before {
             return None;
         }
         let Some(injection_query) = injection_query else {
@@ -1148,6 +1156,71 @@ mod tests {
                 .is_some_and(|regions| regions.len() == 1),
             "settled again: the region resolves"
         );
+
+        // The snapshot fast path too: regions a parse published under the
+        // current generation are not evidence while a reload is swapping
+        // the query they were derived from.
+        let populated = server
+            .cache
+            .populate_injections(
+                &uri,
+                text,
+                &parser.parse(text, None).expect("parse rust"),
+                "rust",
+                &server.language,
+                &server.bridge.node_tracker_arc(),
+                server.bridge.node_tracker_arc().mint_epoch(&uri),
+                server.documents.get(&uri).unwrap().incarnation(),
+                true,
+                true,
+            )
+            .expect("current pass populates");
+        let bridge_regions = populated.bridge_regions.expect("gate was true");
+        let content_version = server.documents.get(&uri).unwrap().content_version();
+        let incarnation = server.documents.get(&uri).unwrap().incarnation();
+        let landed = server
+            .documents
+            .get(&uri)
+            .map(|doc| {
+                doc.publish_snapshot(std::sync::Arc::new(
+                    crate::document::snapshot::ParseSnapshot {
+                        text: std::sync::Arc::from(text),
+                        tree: None,
+                        language: Some("rust".to_string()),
+                        parsed_version: content_version,
+                        incarnation,
+                        injection_regions: None,
+                        bridge_regions: Some((
+                            populated.generation,
+                            std::sync::Arc::new(bridge_regions),
+                        )),
+                        resolved_regions: None,
+                        layer_trees: std::sync::OnceLock::new(),
+                    },
+                ))
+            })
+            .unwrap_or(false);
+        assert!(landed, "test publish must land");
+        assert!(
+            injection
+                .resolve_injection_data(&uri, "rust")
+                .is_some_and(|regions| regions.len() == 1),
+            "settled: the fast path serves the published regions"
+        );
+        server
+            .parser_pool
+            .lock()
+            .expect("parser pool lock")
+            .begin_reload();
+        assert!(
+            injection.resolve_injection_data(&uri, "rust").is_none(),
+            "mid-reload, published regions are not evidence either"
+        );
+        server
+            .parser_pool
+            .lock()
+            .expect("parser pool lock")
+            .finish_reload();
     }
 
     /// The re-open sweep screens hosts by language before a parser is

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -1057,4 +1057,69 @@ mod tests {
             "parser published and no injection query: genuinely no injections"
         );
     }
+
+    /// A settings reload swaps parsers and queries in place while the reload
+    /// guard is held; a parser and a query read in that window may come from
+    /// different generations, so nothing read then is evidence. The inline
+    /// resolution must answer "could not look" for its duration.
+    #[tokio::test]
+    async fn inline_resolution_is_undeterminable_while_a_reload_is_in_progress() {
+        let (service, _socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
+        let server = service.inner();
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let query = tree_sitter::Query::new(
+            &language,
+            r#"((string_literal (string_content) @injection.content)
+                (#set! injection.language "html"))"#,
+        )
+        .expect("valid query");
+        server
+            .language
+            .query_store()
+            .insert_injection_query("rust".to_string(), std::sync::Arc::new(query));
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".to_string(), language.clone());
+        let text = r#"fn main() { let open = "<div>"; }"#;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&language).expect("set language");
+        let tree = parser.parse(text, None).expect("parse rust");
+        let uri = Url::parse("file:///reloading.rs").unwrap();
+        server
+            .documents
+            .insert(uri.clone(), text.to_string(), Some("rust".into()), None);
+        server
+            .documents
+            .update_document(uri.clone(), text.to_string(), Some(tree));
+        let injection = server.injection_coordinator();
+
+        assert!(
+            injection
+                .resolve_injection_data(&uri, "rust")
+                .is_some_and(|regions| regions.len() == 1),
+            "settled: the region resolves"
+        );
+
+        server
+            .parser_pool
+            .lock()
+            .expect("parser pool lock")
+            .begin_reload();
+        assert!(
+            injection.resolve_injection_data(&uri, "rust").is_none(),
+            "mid-reload, parser and query may disagree: could not look"
+        );
+        server
+            .parser_pool
+            .lock()
+            .expect("parser pool lock")
+            .finish_reload();
+        assert!(
+            injection
+                .resolve_injection_data(&uri, "rust")
+                .is_some_and(|regions| regions.len() == 1),
+            "settled again: the region resolves"
+        );
+    }
 }

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -258,11 +258,14 @@ impl InjectionCoordinator {
             self.bridge.cancel_eager_open(uri);
             return false;
         };
-        // `None` (query not loaded yet) opens nothing now; the parse that
-        // follows the query's arrival re-runs this eager open.
-        let injections = self
-            .resolve_injection_data(uri, &host_language)
-            .unwrap_or_default();
+        // `None`: the document could not be looked at (its language is still
+        // publishing, or it has no tree yet). Leave whatever is open alone —
+        // there is no evidence anything changed — and let the parse that
+        // lands once the language is in place run this pass for real.
+        let Some(injections) = self.resolve_injection_data(uri, &host_language) else {
+            self.documents.remove_edit_lock_if_unshared(uri, &edit_lock);
+            return true;
+        };
         if injections.is_empty() {
             self.bridge.cancel_eager_open(uri);
             return true;

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -690,6 +690,19 @@ impl InjectionCoordinator {
         }
     }
 
+    /// Whether `uri`'s current snapshot carries a tree — i.e. is a parse
+    /// result rather than a reload placeholder or a pre-parse slot. The
+    /// stored language of a document without one may predate the reload
+    /// that invalidated it (`invalidate_parse` keeps it until the replacement
+    /// parse lands), so a screen must not trust a rejection based on it.
+    pub(crate) fn snapshot_has_tree(&self, uri: &Url) -> bool {
+        self.documents.latest_snapshot(uri).is_some_and(|view| {
+            view.slot.snapshot.as_ref().is_some_and(|snapshot| {
+                snapshot.parsed_version == view.content_version && snapshot.tree.is_some()
+            })
+        })
+    }
+
     /// Whether `uri`'s published snapshot still matches its content — a cheap
     /// re-check for a caller that resolved something against it and needs to
     /// know the ground did not move underneath.

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -743,7 +743,15 @@ impl InjectionCoordinator {
         &self,
         uri: &Url,
     ) -> Option<(String, Option<Vec<BridgeInjection>>)> {
-        let host_language = self.document_language(uri)?;
+        let (host_language, settled) = self.screen_language(uri)?;
+        if !settled {
+            // The language did not come from a settled parse: between a
+            // reload and its replacement parse's publish, the stored id is
+            // the pre-reload language while the live tree may already be
+            // the replacement's — resolving would run one language's query
+            // against the other's tree. Nothing was looked at.
+            return Some((host_language, None));
+        }
         let injections = self.resolve_injection_data(uri, &host_language);
         Some((host_language, injections))
     }

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -37,6 +37,7 @@ pub(crate) struct InjectionCoordinator {
     auto_install: AutoInstallManager,
     bridge: std::sync::Arc<BridgeCoordinator>,
     diagnostics: std::sync::Arc<DiagnosticAggregator>,
+    settle_retry_waiters: crate::lsp::lsp_impl::settle_retry::SettleRetryWaiters,
 }
 
 /// What a bounded wait for a current tree actually found.
@@ -63,6 +64,7 @@ impl InjectionCoordinator {
             auto_install: server.auto_install.clone(),
             bridge: std::sync::Arc::clone(&server.bridge),
             diagnostics: std::sync::Arc::clone(&server.diagnostics),
+            settle_retry_waiters: server.settle_retry_waiters.clone(),
         }
     }
 
@@ -588,10 +590,16 @@ impl InjectionCoordinator {
     ) {
         const INJECTION_RETRY_BUDGET: std::time::Duration = std::time::Duration::from_secs(10);
         const INJECTION_RETRY_POLL: std::time::Duration = std::time::Duration::from_millis(50);
+        // One waiter per document: a burst of passes deferred by the same
+        // window re-runs the pass once, when the language settles.
+        let Some(claim) = self.settle_retry_waiters.claim("injection", uri) else {
+            return;
+        };
         let this = self.clone();
         let uri = uri.clone();
         let host_language = host_language.to_string();
         tokio::spawn(async move {
+            let _claim = claim;
             let deadline = tokio::time::Instant::now() + INJECTION_RETRY_BUDGET;
             loop {
                 tokio::time::sleep(INJECTION_RETRY_POLL).await;

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -195,19 +195,37 @@ impl InjectionCoordinator {
             return settled().then(Vec::new);
         };
 
-        let Some(doc) = self.documents.get(uri) else {
+        // Tree, text, language and lifetime from ONE current snapshot: the
+        // legacy document's tree can already be a replacement parse's while
+        // the current snapshot (and the language the caller screened) is
+        // still the previous one, and running one language's query against
+        // the other's tree would answer empty as if it had looked.
+        let Some(view) = self.documents.latest_snapshot(uri) else {
             return Some(Vec::new());
         };
-        let Some(tree) = doc.tree().cloned() else {
+        let Some(snapshot) = view
+            .slot
+            .snapshot
+            .as_ref()
+            .filter(|snapshot| snapshot.parsed_version == view.content_version)
+        else {
+            // Trailing or never parsed: could not look.
+            return None;
+        };
+        let Some(tree) = snapshot.tree.clone() else {
             // No tree under a published parser: a reload placeholder
             // (`Document::invalidate_parse`, version-current and tree-less) or
             // a parse that yielded nothing. The document could not be looked
             // at.
             return None;
         };
-        let text = doc.text_arc();
-        let incarnation = doc.incarnation();
-        drop(doc);
+        if snapshot.language.as_deref() != Some(host_language) {
+            // The tree belongs to another language than the one asked about
+            // (a re-detection between the caller's screen and this read).
+            return None;
+        }
+        let text = std::sync::Arc::clone(&snapshot.text);
+        let incarnation = snapshot.incarnation;
 
         let Some(regions) =
             collect_all_injections(&tree.root_node(), &text, Some(injection_query.as_ref()))
@@ -1098,6 +1116,39 @@ mod tests {
         );
     }
 
+    /// Publish `tree` as `uri`'s current parse snapshot under `language`,
+    /// the way a settled parse would.
+    fn publish_test_snapshot(
+        server: &crate::lsp::lsp_impl::Kakehashi,
+        uri: &Url,
+        text: &str,
+        tree: tree_sitter::Tree,
+        language: &str,
+    ) {
+        let content_version = server.documents.get(uri).unwrap().content_version();
+        let incarnation = server.documents.get(uri).unwrap().incarnation();
+        let landed = server
+            .documents
+            .get(uri)
+            .map(|doc| {
+                doc.publish_snapshot(std::sync::Arc::new(
+                    crate::document::snapshot::ParseSnapshot {
+                        text: std::sync::Arc::from(text),
+                        tree: Some(tree),
+                        language: Some(language.to_string()),
+                        parsed_version: content_version,
+                        incarnation,
+                        injection_regions: None,
+                        bridge_regions: None,
+                        resolved_regions: None,
+                        layer_trees: std::sync::OnceLock::new(),
+                    },
+                ))
+            })
+            .unwrap_or(false);
+        assert!(landed, "test publish must land");
+    }
+
     /// The snapshot fast path of `resolve_injection_data` must produce
     /// exactly what the inline (live-tree) resolution produces — the fast
     /// path's output is forwarded verbatim to downstream servers, so a
@@ -1335,7 +1386,8 @@ mod tests {
             .insert(uri.clone(), text.to_string(), Some("rust".into()), None);
         server
             .documents
-            .update_document(uri.clone(), text.to_string(), Some(tree));
+            .update_document(uri.clone(), text.to_string(), Some(tree.clone()));
+        publish_test_snapshot(server, &uri, text, tree, "rust");
         let injection = server.injection_coordinator();
 
         assert!(
@@ -1385,6 +1437,13 @@ mod tests {
             )
             .expect("current pass populates");
         let bridge_regions = populated.bridge_regions.expect("gate was true");
+        // A new revision, so the fast-path snapshot below is admitted (a
+        // second publish at the same revision is refused).
+        server.documents.update_document(
+            uri.clone(),
+            text.to_string(),
+            Some(parser.parse(text, None).expect("parse rust")),
+        );
         let content_version = server.documents.get(&uri).unwrap().content_version();
         let incarnation = server.documents.get(&uri).unwrap().incarnation();
         let landed = server
@@ -1394,7 +1453,9 @@ mod tests {
                 doc.publish_snapshot(std::sync::Arc::new(
                     crate::document::snapshot::ParseSnapshot {
                         text: std::sync::Arc::from(text),
-                        tree: None,
+                        // With a tree: a tree-less snapshot would not be
+                        // admitted over the tree-bearing one already current.
+                        tree: Some(parser.parse(text, None).expect("parse rust")),
                         language: Some("rust".to_string()),
                         parsed_version: content_version,
                         incarnation,
@@ -1505,7 +1566,8 @@ mod tests {
             .insert(uri.clone(), text.to_string(), Some("rust".into()), None);
         server
             .documents
-            .update_document(uri.clone(), text.to_string(), Some(tree));
+            .update_document(uri.clone(), text.to_string(), Some(tree.clone()));
+        publish_test_snapshot(server, &uri, text, tree, "rust");
         let injection = server.injection_coordinator();
 
         assert!(

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -38,6 +38,7 @@ pub(crate) struct InjectionCoordinator {
     bridge: std::sync::Arc<BridgeCoordinator>,
     diagnostics: std::sync::Arc<DiagnosticAggregator>,
     settle_retry_waiters: crate::lsp::lsp_impl::settle_retry::SettleRetryWaiters,
+    shutdown: tokio_util::sync::CancellationToken,
 }
 
 /// What a bounded wait for a current tree actually found.
@@ -65,6 +66,7 @@ impl InjectionCoordinator {
             bridge: std::sync::Arc::clone(&server.bridge),
             diagnostics: std::sync::Arc::clone(&server.diagnostics),
             settle_retry_waiters: server.settle_retry_waiters.clone(),
+            shutdown: server.shutdown_token.clone(),
         }
     }
 
@@ -310,11 +312,16 @@ impl InjectionCoordinator {
             // Nothing else re-runs this pass for a document whose sole parse
             // overlapped a publication or reload window (an injected
             // language's auto-install reload does not reparse hosts), so
-            // arrange the retry here — for THAT cause only. A document that
-            // is tree-less under a settled language gets a tree from its own
-            // next parse or never; retrying it would re-schedule itself on
-            // every attempt.
-            if self.language_is_unsettled(&host_language) {
+            // arrange the retry here. Every cause but one is transient (a
+            // language still publishing, a reload, a generation bump between
+            // the reads), and the cause is not re-sampled — it may already
+            // have settled — so the retry is admitted whenever the document
+            // could be looked at once things settle: it has a tree, or its
+            // language is what is unsettled. The one non-transient cause, a
+            // tree-less document under a settled language, gets a tree from
+            // its own next parse or never; retrying it would re-schedule
+            // itself on every attempt.
+            if self.snapshot_has_tree(uri) || self.language_is_unsettled(&host_language) {
                 self.retry_injection_pass_when_settled(
                     uri,
                     &host_language,
@@ -604,10 +611,13 @@ impl InjectionCoordinator {
         let uri = uri.clone();
         let host_language = host_language.to_string();
         tokio::spawn(async move {
-            let _claim = claim;
+            let claim = claim;
             let deadline = tokio::time::Instant::now() + INJECTION_RETRY_BUDGET;
             loop {
-                tokio::time::sleep(INJECTION_RETRY_POLL).await;
+                tokio::select! {
+                    _ = this.shutdown.cancelled() => return,
+                    _ = tokio::time::sleep(INJECTION_RETRY_POLL) => {}
+                }
                 // A host parser discovered from `searchPaths` (not declared)
                 // loses its registration to the generation bump of any
                 // reload — including an injected language's auto-install,
@@ -626,6 +636,10 @@ impl InjectionCoordinator {
                         target: "kakehashi::bridge",
                         "Re-running the injection pass for {uri}: {host_language} has settled"
                     );
+                    // Release the slot BEFORE the rerun: a reload starting
+                    // right now makes the rerun defer again, and its retry
+                    // must be able to claim the slot this waiter held.
+                    drop(claim);
                     let _ = this
                         .process_injections_for_incarnation(&uri, forward_did_change, incarnation)
                         .await;

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -555,6 +555,15 @@ impl InjectionCoordinator {
         //
         // The caller passes what is LEFT of the shared budget, so a sweep cannot
         // spend it several times over.
+        //
+        // A snapshot that is already current is answered without entering the
+        // timeout: the sweep keeps walking past its deadline with a ZERO
+        // budget, and a zero timeout can expire before the wait future gets
+        // to observe the snapshot — misreporting a current document as
+        // unsettled and leaving it un-reopened.
+        if self.snapshot_is_current(uri) {
+            return ParseWait::Current;
+        }
         use crate::lsp::lsp_impl::snapshot_read::SnapshotWait;
         match tokio::time::timeout(
             budget,
@@ -624,6 +633,69 @@ mod tests {
     use tokio::sync::Notify;
     use tower_lsp_server::LspService;
     use url::Url;
+
+    /// The re-open sweep keeps walking after its parse-wait deadline with a
+    /// zero budget; a document whose snapshot is already current must still
+    /// read as current then, and one whose parse is pending as unsettled.
+    #[tokio::test]
+    async fn zero_budget_wait_answers_from_the_snapshot_state() {
+        use tree_sitter::Parser;
+        let (service, _socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
+        let server = service.inner();
+        let injection = server.injection_coordinator();
+
+        let pending = Url::parse("file:///zero-budget-pending.md").unwrap();
+        server.documents.insert(
+            pending.clone(),
+            "# pending".to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        assert!(matches!(
+            injection
+                .ensure_document_parsed(&pending, std::time::Duration::ZERO)
+                .await,
+            super::ParseWait::Unsettled
+        ));
+
+        let current = Url::parse("file:///zero-budget-current.md").unwrap();
+        let text = "# current\n";
+        let incarnation = server.documents.insert(
+            current.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let mut parser = Parser::new();
+        parser.set_language(&language).unwrap();
+        let tree = parser.parse(text, None).unwrap();
+        let content_version = server.documents.get(&current).unwrap().content_version();
+        let landed = server
+            .documents
+            .get(&current)
+            .map(|doc| {
+                doc.publish_snapshot(Arc::new(crate::document::snapshot::ParseSnapshot {
+                    text: Arc::from(text),
+                    tree: Some(tree),
+                    language: Some("markdown".to_string()),
+                    parsed_version: content_version,
+                    incarnation,
+                    injection_regions: None,
+                    bridge_regions: None,
+                    resolved_regions: None,
+                    layer_trees: std::sync::OnceLock::new(),
+                }))
+            })
+            .unwrap_or(false);
+        assert!(landed, "test publish must land");
+        assert!(matches!(
+            injection
+                .ensure_document_parsed(&current, std::time::Duration::ZERO)
+                .await,
+            super::ParseWait::Current
+        ));
+    }
 
     #[tokio::test]
     async fn process_injections_finishes_before_fast_reopen() {

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -958,4 +958,88 @@ mod tests {
             assert_eq!(a.content, b.content, "clean content must match");
         }
     }
+
+    /// A reload publishes a version-current placeholder with no tree while
+    /// the replacement parse is still queued. With a parser published, such a
+    /// document could not be looked at; without one no tree will ever come,
+    /// and the reading is genuinely empty.
+    #[tokio::test]
+    async fn tree_less_document_is_undeterminable_only_while_a_parser_exists() {
+        let (service, _socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
+        let server = service.inner();
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let query = tree_sitter::Query::new(
+            &language,
+            r#"((string_literal (string_content) @injection.content)
+                (#set! injection.language "html"))"#,
+        )
+        .expect("valid query");
+        server
+            .language
+            .query_store()
+            .insert_injection_query("rust".to_string(), std::sync::Arc::new(query));
+        let uri = Url::parse("file:///tree_less.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".into()),
+            None,
+        );
+        server.documents.invalidate_all_parses();
+        let injection = server.injection_coordinator();
+
+        assert!(
+            injection
+                .resolve_injection_data(&uri, "rust")
+                .is_some_and(|regions| regions.is_empty()),
+            "without a parser nothing will ever be parsed: read as empty"
+        );
+
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".to_string(), language);
+        assert!(
+            injection.resolve_injection_data(&uri, "rust").is_none(),
+            "with a parser, a tree-less document could not be looked at"
+        );
+    }
+
+    /// Queries are published before the parser, so a language whose parser is
+    /// visible and whose injection query is absent genuinely has none; only a
+    /// language still publishing is undeterminable.
+    #[tokio::test]
+    async fn missing_injection_query_is_definitive_once_the_parser_is_published() {
+        let (service, _socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
+        let server = service.inner();
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let text = "fn main() {}";
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&language).expect("set language");
+        let tree = parser.parse(text, None).expect("parse rust");
+        let uri = Url::parse("file:///no_query.rs").unwrap();
+        server
+            .documents
+            .insert(uri.clone(), text.to_string(), Some("rust".into()), None);
+        server
+            .documents
+            .update_document(uri.clone(), text.to_string(), Some(tree));
+        let injection = server.injection_coordinator();
+
+        assert!(
+            injection.resolve_injection_data(&uri, "rust").is_none(),
+            "no parser published: the load may still be publishing its queries"
+        );
+
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".to_string(), language);
+        assert!(
+            injection
+                .resolve_injection_data(&uri, "rust")
+                .is_some_and(|regions| regions.is_empty()),
+            "parser published and no injection query: genuinely no injections"
+        );
+    }
 }

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -695,6 +695,16 @@ impl InjectionCoordinator {
     /// pre-reload value, so the snapshot's language wins once the parse is
     /// current and carries a tree.
     pub(crate) fn document_language(&self, uri: &Url) -> Option<String> {
+        self.screen_language(uri).map(|(language, _)| language)
+    }
+
+    /// [`Self::document_language`] together with whether the language came
+    /// from a settled parse (a current snapshot with a tree) — read from ONE
+    /// snapshot view, so a reload invalidating the parse (or a replacement
+    /// parse landing) between two reads cannot pair a settled tree with a
+    /// language that is not that tree's. The sweep's screen trusts a
+    /// rejection only when the flag is set.
+    pub(crate) fn screen_language(&self, uri: &Url) -> Option<(String, bool)> {
         let settled = self.documents.latest_snapshot(uri).and_then(|view| {
             view.slot.snapshot.as_ref().and_then(|snapshot| {
                 (snapshot.parsed_version == view.content_version && snapshot.tree.is_some())
@@ -702,13 +712,16 @@ impl InjectionCoordinator {
                     .flatten()
             })
         });
+        if let Some(language) = settled {
+            return Some((language, true));
+        }
         let stored = self
             .documents
             .get(uri)
             .and_then(|document| document.language_id().map(str::to_string));
-        settled
-            .or(stored)
+        stored
             .or_else(|| self.get_language_for_document(uri))
+            .map(|language| (language, false))
     }
 
     /// `uri`'s reopen generation, which scopes a downstream `didOpen` to the

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -1139,4 +1139,48 @@ mod tests {
             "settled again: the region resolves"
         );
     }
+
+    /// The re-open sweep screens hosts by language before a parser is
+    /// necessarily published (queries land first). A document whose stored
+    /// language is known but whose parser is still on its way must read as
+    /// "could not look" (inner `None`), not as having no language (outer
+    /// `None`, which the sweep skips as not this connection's document).
+    #[tokio::test]
+    async fn bridge_injections_falls_back_to_the_stored_language_while_the_parser_is_pending() {
+        let (service, _socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
+        let server = service.inner();
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let query = tree_sitter::Query::new(
+            &language,
+            r#"((string_literal (string_content) @injection.content)
+                (#set! injection.language "html"))"#,
+        )
+        .expect("valid query");
+        server
+            .language
+            .query_store()
+            .insert_injection_query("rust".to_string(), std::sync::Arc::new(query));
+        let uri = Url::parse("file:///pending_parser.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".into()),
+            None,
+        );
+        let injection = server.injection_coordinator();
+
+        assert_eq!(
+            injection.document_language(&uri).as_deref(),
+            Some("rust"),
+            "the stored language names the host while its parser is pending"
+        );
+        let (host_language, injections) = injection
+            .bridge_injections(&uri)
+            .expect("the stored language must name the host");
+        assert_eq!(host_language, "rust");
+        assert!(
+            injections.is_none(),
+            "no parser yet: the document could not be looked at"
+        );
+    }
 }

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -291,7 +291,12 @@ impl InjectionCoordinator {
             return false;
         }
 
-        let Some(host_language) = self.get_language_for_document(uri) else {
+        // Stored language first (see `document_language`): parser-aware
+        // detection answers `None` while the language is still publishing,
+        // which would cancel the eager batch and exit as if the document had
+        // no language, before the resolution below can answer "could not
+        // look" and leave existing state alone.
+        let Some(host_language) = self.document_language(uri) else {
             self.bridge.cancel_eager_open(uri);
             return false;
         };

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -305,6 +305,15 @@ impl InjectionCoordinator {
         // there is no evidence anything changed — and let the parse that
         // lands once the language is in place run this pass for real.
         let Some(injections) = self.resolve_injection_data(uri, &host_language) else {
+            // Nothing else re-runs this pass for a document whose sole parse
+            // overlapped the window (an injected language's auto-install
+            // reload does not reparse hosts), so arrange the retry here.
+            self.retry_injection_pass_when_settled(
+                uri,
+                &host_language,
+                forward_did_change,
+                incarnation,
+            );
             self.documents.remove_edit_lock_if_unshared(uri, &edit_lock);
             return true;
         };
@@ -545,6 +554,54 @@ impl InjectionCoordinator {
     fn get_language_for_document(&self, uri: &Url) -> Option<String> {
         detect_document_language(&self.language, &self.documents, uri)
     }
+    /// Re-run the tree-derived downstream pass for `uri` once the language's
+    /// publication or reload has settled, bounded (`INJECTION_RETRY_BUDGET`):
+    /// a pass that answered "could not look" opened nothing, and without an
+    /// edit no other parse would try again. The retried pass re-reads every
+    /// input and re-checks the lifetime, so a close, reopen or edit in the
+    /// meantime makes it a no-op or the newer text's own pass.
+    fn retry_injection_pass_when_settled(
+        &self,
+        uri: &Url,
+        host_language: &str,
+        forward_did_change: bool,
+        incarnation: u64,
+    ) {
+        const INJECTION_RETRY_BUDGET: std::time::Duration = std::time::Duration::from_secs(10);
+        const INJECTION_RETRY_POLL: std::time::Duration = std::time::Duration::from_millis(50);
+        let this = self.clone();
+        let uri = uri.clone();
+        let host_language = host_language.to_string();
+        tokio::spawn(async move {
+            let deadline = tokio::time::Instant::now() + INJECTION_RETRY_BUDGET;
+            loop {
+                tokio::time::sleep(INJECTION_RETRY_POLL).await;
+                let reloading = this
+                    .parser_pool
+                    .lock()
+                    .recover_poison("InjectionCoordinator::retry_injection_pass_when_settled")
+                    .reload_in_progress();
+                if !reloading && this.language.has_parser_available(&host_language) {
+                    log::debug!(
+                        target: "kakehashi::bridge",
+                        "Re-running the injection pass for {uri}: {host_language} has settled"
+                    );
+                    let _ = this
+                        .process_injections_for_incarnation(&uri, forward_did_change, incarnation)
+                        .await;
+                    return;
+                }
+                if tokio::time::Instant::now() >= deadline {
+                    log::debug!(
+                        target: "kakehashi::bridge",
+                        "Giving up the injection pass retry for {uri}: {host_language} did not settle"
+                    );
+                    return;
+                }
+            }
+        });
+    }
+
     /// The bridge coordinator, so the respawn re-open can drive the awaited
     /// `ensure_server_documents_open` (execute-command-routing-token).
     pub(crate) fn bridge(&self) -> &std::sync::Arc<BridgeCoordinator> {

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -564,17 +564,19 @@ impl InjectionCoordinator {
     /// screening many candidate documents can ask the configuration question
     /// before paying for a parse wait and an injection resolution.
     ///
-    /// Parser-aware detection answers `None` until the language's parser is
-    /// published, which a language load in progress makes true for a moment
-    /// (queries land first); the language the document was opened or parsed
-    /// under is then the answer, so the caller reads "could not look" from
-    /// the resolution instead of "no language" from here.
+    /// The language the document was opened or parsed under comes first:
+    /// parser-aware detection answers `None` — or, worse, another loaded
+    /// language the path or content also matches — until the declared
+    /// language's parser is published, which a load in progress makes true
+    /// for a moment (queries land first). Detection is the fallback for a
+    /// document with no stored language, so the caller reads "could not
+    /// look" from the resolution instead of "no language" or the wrong one
+    /// from here.
     pub(crate) fn document_language(&self, uri: &Url) -> Option<String> {
-        self.get_language_for_document(uri).or_else(|| {
-            self.documents
-                .get(uri)
-                .and_then(|document| document.language_id().map(str::to_string))
-        })
+        self.documents
+            .get(uri)
+            .and_then(|document| document.language_id().map(str::to_string))
+            .or_else(|| self.get_language_for_document(uri))
     }
 
     /// `uri`'s reopen generation, which scopes a downstream `didOpen` to the

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -669,10 +669,26 @@ impl InjectionCoordinator {
     /// document with no stored language, so the caller reads "could not
     /// look" from the resolution instead of "no language" or the wrong one
     /// from here.
+    ///
+    /// A settled parse names the language authoritatively: a reload that
+    /// changes how the document is detected publishes the new language on
+    /// the snapshot only (`reparse_latest`), while the stored id keeps the
+    /// pre-reload value, so the snapshot's language wins once the parse is
+    /// current and carries a tree.
     pub(crate) fn document_language(&self, uri: &Url) -> Option<String> {
-        self.documents
+        let settled = self.documents.latest_snapshot(uri).and_then(|view| {
+            view.slot.snapshot.as_ref().and_then(|snapshot| {
+                (snapshot.parsed_version == view.content_version && snapshot.tree.is_some())
+                    .then(|| snapshot.language.clone())
+                    .flatten()
+            })
+        });
+        let stored = self
+            .documents
             .get(uri)
-            .and_then(|document| document.language_id().map(str::to_string))
+            .and_then(|document| document.language_id().map(str::to_string));
+        settled
+            .or(stored)
             .or_else(|| self.get_language_for_document(uri))
     }
 
@@ -1465,6 +1481,62 @@ mod tests {
                 .resolve_injection_data(&uri, "rust")
                 .is_some_and(|regions| regions.len() == 1),
             "parser published: the region resolves"
+        );
+    }
+
+    /// A reload that changes how a document is detected publishes the new
+    /// language on the snapshot only; the stored id keeps the pre-reload
+    /// value. Once the replacement parse is current, the snapshot's language
+    /// must win, or the sweep and the eager pass keep working under a
+    /// language the document no longer has.
+    #[tokio::test]
+    async fn document_language_prefers_the_settled_snapshot_over_the_stored_id() {
+        let (service, _socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
+        let server = service.inner();
+        let language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let text = "# doc\n";
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&language).expect("set language");
+        let tree = parser.parse(text, None).expect("parse markdown");
+        let uri = Url::parse("file:///redetected.md").unwrap();
+        let incarnation = server.documents.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("derived-markdown".into()),
+            None,
+        );
+        let injection = server.injection_coordinator();
+        assert_eq!(
+            injection.document_language(&uri).as_deref(),
+            Some("derived-markdown"),
+            "before any parse settles, the stored id names the document"
+        );
+
+        let content_version = server.documents.get(&uri).unwrap().content_version();
+        let landed = server
+            .documents
+            .get(&uri)
+            .map(|doc| {
+                doc.publish_snapshot(std::sync::Arc::new(
+                    crate::document::snapshot::ParseSnapshot {
+                        text: std::sync::Arc::from(text),
+                        tree: Some(tree),
+                        language: Some("markdown".to_string()),
+                        parsed_version: content_version,
+                        incarnation,
+                        injection_regions: None,
+                        bridge_regions: None,
+                        resolved_regions: None,
+                        layer_trees: std::sync::OnceLock::new(),
+                    },
+                ))
+            })
+            .unwrap_or(false);
+        assert!(landed, "test publish must land");
+        assert_eq!(
+            injection.document_language(&uri).as_deref(),
+            Some("markdown"),
+            "a settled parse names the language authoritatively"
         );
     }
 }

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -105,11 +105,15 @@ impl InjectionCoordinator {
     ///
     /// Lock safety: the document store lock is held only long enough to clone the
     /// tree and text, then released before the tree traversal — no DashMap deadlock risk.
+    /// `None` when the host language's injection query is not in the store
+    /// — a lazy load or a reload still swapping queries in — so the caller
+    /// can tell "could not look" from "looked and found none": the re-open
+    /// sweep must not report a document repaired on the former.
     pub(crate) fn resolve_injection_data(
         &self,
         uri: &Url,
         host_language: &str,
-    ) -> Vec<BridgeInjection> {
+    ) -> Option<Vec<BridgeInjection>> {
         // Fast path (parse-snapshot ADR §3, never discover twice): the parse
         // pass that scheduled this downstream already derived the bridge
         // regions from its single injection-query run and published them on
@@ -127,25 +131,25 @@ impl InjectionCoordinator {
             // query would not discover. Mismatch falls back inline below.
             && *stamped_generation == self.cache.semantic_token_generation()
         {
-            return bridge_regions
-                .iter()
-                .map(|region| BridgeInjection {
-                    language: region.language.clone(),
-                    region_id: region.region_id.clone(),
-                    content: region.content.clone(),
-                })
-                .collect();
+            return Some(
+                bridge_regions
+                    .iter()
+                    .map(|region| BridgeInjection {
+                        language: region.language.clone(),
+                        region_id: region.region_id.clone(),
+                        content: region.content.clone(),
+                    })
+                    .collect(),
+            );
         }
 
-        let Some(injection_query) = self.language.injection_query(host_language) else {
-            return Vec::new();
-        };
+        let injection_query = self.language.injection_query(host_language)?;
 
         let Some(doc) = self.documents.get(uri) else {
-            return Vec::new();
+            return Some(Vec::new());
         };
         let Some(tree) = doc.tree().cloned() else {
-            return Vec::new();
+            return Some(Vec::new());
         };
         let text = doc.text_arc();
         let incarnation = doc.incarnation();
@@ -154,28 +158,30 @@ impl InjectionCoordinator {
         let Some(regions) =
             collect_all_injections(&tree.root_node(), &text, Some(injection_query.as_ref()))
         else {
-            return Vec::new();
+            return Some(Vec::new());
         };
 
         if regions.is_empty() {
-            return Vec::new();
+            return Some(Vec::new());
         }
 
-        InjectionResolver::resolve_from_regions(
-            &self.language,
-            self.bridge.node_tracker(),
-            uri,
-            &regions,
-            &text,
-            incarnation,
+        Some(
+            InjectionResolver::resolve_from_regions(
+                &self.language,
+                self.bridge.node_tracker(),
+                uri,
+                &regions,
+                &text,
+                incarnation,
+            )
+            .into_iter()
+            .map(|region| BridgeInjection {
+                language: region.injection_language,
+                region_id: region.region.region_id,
+                content: region.virtual_content,
+            })
+            .collect(),
         )
-        .into_iter()
-        .map(|region| BridgeInjection {
-            language: region.injection_language,
-            region_id: region.region.region_id,
-            content: region.virtual_content,
-        })
-        .collect()
     }
 
     /// Process injected languages: resolve injection data, optionally forward didChange,
@@ -240,7 +246,11 @@ impl InjectionCoordinator {
             self.bridge.cancel_eager_open(uri);
             return false;
         };
-        let injections = self.resolve_injection_data(uri, &host_language);
+        // `None` (query not loaded yet) opens nothing now; the parse that
+        // follows the query's arrival re-runs this eager open.
+        let injections = self
+            .resolve_injection_data(uri, &host_language)
+            .unwrap_or_default();
         if injections.is_empty() {
             self.bridge.cancel_eager_open(uri);
             return true;
@@ -517,7 +527,13 @@ impl InjectionCoordinator {
     /// when the document has no detectable language. Lets a caller re-derive the
     /// injected regions on demand (the respawn re-open), mirroring the
     /// didOpen/didChange discovery.
-    pub(crate) fn bridge_injections(&self, uri: &Url) -> Option<(String, Vec<BridgeInjection>)> {
+    /// The inner `None` means the host language's injection query is not in
+    /// the store right now: the document could not be looked at, which is
+    /// not the same as having no injections.
+    pub(crate) fn bridge_injections(
+        &self,
+        uri: &Url,
+    ) -> Option<(String, Option<Vec<BridgeInjection>>)> {
         let host_language = self.get_language_for_document(uri)?;
         let injections = self.resolve_injection_data(uri, &host_language);
         Some((host_language, injections))
@@ -888,7 +904,9 @@ mod tests {
             assert!(landed, "test publish must land");
         };
         publish(None, content_version);
-        let inline = injection.resolve_injection_data(&uri, "rust");
+        let inline = injection
+            .resolve_injection_data(&uri, "rust")
+            .expect("query present");
         assert_eq!(inline.len(), 1, "combined captures form one eager document");
 
         // FAST PATH: populate derives the bridge regions from the same tree
@@ -916,7 +934,9 @@ mod tests {
             Some((populated.generation, std::sync::Arc::new(bridge_regions))),
             content_version,
         );
-        let fast = injection.resolve_injection_data(&uri, "rust");
+        let fast = injection
+            .resolve_injection_data(&uri, "rust")
+            .expect("query present");
 
         assert_eq!(
             inline.len(),

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -1292,4 +1292,52 @@ mod tests {
             "no parser yet: the document could not be looked at"
         );
     }
+
+    /// A parser not yet published makes the document unlookable even when a
+    /// tree exists (a prior lifetime's parser, or a registry entry a reload
+    /// has scoped out): the query it would run may not be the one the
+    /// published parser will pair with.
+    #[tokio::test]
+    async fn treeful_document_under_a_pending_parser_is_undeterminable() {
+        let (service, _socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
+        let server = service.inner();
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let query = tree_sitter::Query::new(
+            &language,
+            r#"((string_literal (string_content) @injection.content)
+                (#set! injection.language "html"))"#,
+        )
+        .expect("valid query");
+        server
+            .language
+            .query_store()
+            .insert_injection_query("rust".to_string(), std::sync::Arc::new(query));
+        let text = r#"fn main() { let open = "<div>"; }"#;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&language).expect("set language");
+        let tree = parser.parse(text, None).expect("parse rust");
+        let uri = Url::parse("file:///treeful_pending.rs").unwrap();
+        server
+            .documents
+            .insert(uri.clone(), text.to_string(), Some("rust".into()), None);
+        server
+            .documents
+            .update_document(uri.clone(), text.to_string(), Some(tree));
+        let injection = server.injection_coordinator();
+
+        assert!(
+            injection.resolve_injection_data(&uri, "rust").is_none(),
+            "query present, parser not published: could not look"
+        );
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".to_string(), language);
+        assert!(
+            injection
+                .resolve_injection_data(&uri, "rust")
+                .is_some_and(|regions| regions.len() == 1),
+            "parser published: the region resolves"
+        );
+    }
 }

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -138,6 +138,12 @@ impl InjectionCoordinator {
         if !self.language.has_parser_available(host_language) {
             return None;
         }
+        // Re-asked right before every successful answer: a reload that
+        // begins after the checks above (the auto-install reload does not
+        // even invalidate documents) would otherwise turn regions read from
+        // the old query into evidence.
+        let settled =
+            || !reload_in_progress() && self.cache.semantic_token_generation() == generation_before;
         // Fast path (parse-snapshot ADR §3, never discover twice): the parse
         // pass that scheduled this downstream already derived the bridge
         // regions from its single injection-query run and published them on
@@ -155,16 +161,15 @@ impl InjectionCoordinator {
             // query would not discover. Mismatch falls back inline below.
             && *stamped_generation == self.cache.semantic_token_generation()
         {
-            return Some(
-                bridge_regions
-                    .iter()
-                    .map(|region| BridgeInjection {
-                        language: region.language.clone(),
-                        region_id: region.region_id.clone(),
-                        content: region.content.clone(),
-                    })
-                    .collect(),
-            );
+            let regions = bridge_regions
+                .iter()
+                .map(|region| BridgeInjection {
+                    language: region.language.clone(),
+                    region_id: region.region_id.clone(),
+                    content: region.content.clone(),
+                })
+                .collect();
+            return settled().then_some(regions);
         }
 
         // `None` below means "could not be looked at", which the re-open sweep
@@ -177,13 +182,13 @@ impl InjectionCoordinator {
         // reload in progress — or one that started between the reads, which
         // the generation bump reveals — makes the whole answer undeterminable.
         let injection_query = self.language.injection_query(host_language);
-        if reload_in_progress() || self.cache.semantic_token_generation() != generation_before {
+        if !settled() {
             return None;
         }
         let Some(injection_query) = injection_query else {
             // Queries are published before the parser, so a visible parser
             // with no injection query is definitive.
-            return Some(Vec::new());
+            return settled().then(Vec::new);
         };
 
         let Some(doc) = self.documents.get(uri) else {
@@ -203,30 +208,29 @@ impl InjectionCoordinator {
         let Some(regions) =
             collect_all_injections(&tree.root_node(), &text, Some(injection_query.as_ref()))
         else {
-            return Some(Vec::new());
+            return settled().then(Vec::new);
         };
 
         if regions.is_empty() {
-            return Some(Vec::new());
+            return settled().then(Vec::new);
         }
 
-        Some(
-            InjectionResolver::resolve_from_regions(
-                &self.language,
-                self.bridge.node_tracker(),
-                uri,
-                &regions,
-                &text,
-                incarnation,
-            )
-            .into_iter()
-            .map(|region| BridgeInjection {
-                language: region.injection_language,
-                region_id: region.region.region_id,
-                content: region.virtual_content,
-            })
-            .collect(),
+        let resolved = InjectionResolver::resolve_from_regions(
+            &self.language,
+            self.bridge.node_tracker(),
+            uri,
+            &regions,
+            &text,
+            incarnation,
         )
+        .into_iter()
+        .map(|region| BridgeInjection {
+            language: region.injection_language,
+            region_id: region.region.region_id,
+            content: region.virtual_content,
+        })
+        .collect();
+        settled().then_some(resolved)
     }
 
     /// Process injected languages: resolve injection data, optionally forward didChange,

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use url::Url;
 
 use crate::document::DocumentStore;
+use crate::error::LockResultExt;
 use crate::language::injection::{InjectionResolver, collect_all_injections};
 use crate::language::{DocumentParserPool, LanguageCoordinator, LanguageEvent};
 use crate::lsp::auto_install::AutoInstallManager;
@@ -145,8 +146,25 @@ impl InjectionCoordinator {
 
         // `None` below means "could not be looked at", which the re-open sweep
         // must tell apart from "has nothing" — the latter releases commands.
+        //
+        // The parser check and the query read are two reads of state a
+        // settings reload swaps in place (registry, then query store, under
+        // the reload guard). A pair straddling that swap could combine the old
+        // parser with a not-yet-published query and read as definitive, so a
+        // reload in progress — or one that started between the reads, which
+        // the generation bump reveals — makes the whole answer undeterminable.
+        let generation_before = self.cache.semantic_token_generation();
         let parser_published = self.language.has_parser_available(host_language);
-        let Some(injection_query) = self.language.injection_query(host_language) else {
+        let injection_query = self.language.injection_query(host_language);
+        let reload_in_progress = self
+            .parser_pool
+            .lock()
+            .recover_poison("InjectionCoordinator::resolve_injection_data")
+            .reload_in_progress();
+        if reload_in_progress || self.cache.semantic_token_generation() != generation_before {
+            return None;
+        }
+        let Some(injection_query) = injection_query else {
             // Queries are published before the parser, so a visible parser
             // with no injection query is definitive. Without the parser the
             // load is still publishing (or failed, and nothing will parse).

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -4530,3 +4530,44 @@ mod tests {
         let _ = loop_handle.await;
     }
 }
+
+/// Order the documents a re-open sweep considers so that every document
+/// whose parse is already current comes before any whose parse is pending.
+///
+/// The sweep has one budget for the whole pass and pays a parse wait per
+/// pending document; iterating the store's own (hash) order let a pending
+/// document ahead of a current one spend the budget the current one needed,
+/// and a current document behind it then went un-reopened. Stable: documents
+/// keep their relative order within each group.
+fn order_reopen_candidates(
+    hosts: Vec<url::Url>,
+    is_current: impl Fn(&url::Url) -> bool,
+) -> Vec<url::Url> {
+    let (current, pending): (Vec<_>, Vec<_>) = hosts.into_iter().partition(|host| is_current(host));
+    current.into_iter().chain(pending).collect()
+}
+
+#[cfg(test)]
+mod reopen_order_tests {
+    use super::order_reopen_candidates;
+    use url::Url;
+
+    #[test]
+    fn current_documents_come_before_pending_ones_in_stable_order() {
+        let hosts: Vec<Url> = [
+            "file:///a.md",
+            "file:///b.md",
+            "file:///c.md",
+            "file:///d.md",
+        ]
+        .iter()
+        .map(|u| Url::parse(u).unwrap())
+        .collect();
+        let pending = [hosts[0].clone(), hosts[2].clone()];
+
+        let ordered = order_reopen_candidates(hosts.clone(), |host| !pending.contains(host));
+
+        let names: Vec<&str> = ordered.iter().map(|u| u.path()).collect();
+        assert_eq!(names, vec!["/b.md", "/d.md", "/a.md", "/c.md"]);
+    }
+}

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1575,7 +1575,12 @@ fn spawn_upstream_request(
                 // closed, misses ones opened since, and is simply EMPTY when the
                 // dead connection never got far enough to hold anything, which is
                 // exactly when a replacement most needs the repair.
-                let hosts = context.injection.open_host_uris();
+                // Documents whose parse is already current go first: they
+                // need no wait, and a pending document ahead of them would
+                // spend the sweep's one budget on a wait they never needed.
+                let hosts = order_reopen_candidates(context.injection.open_host_uris(), |host| {
+                    context.injection.snapshot_is_current(host)
+                });
                 log::debug!(
                     target: "kakehashi::bridge",
                     "Bringing {key} up to date after {server:?} respawned: \
@@ -1599,7 +1604,11 @@ fn spawn_upstream_request(
                 // outstanding for tens of seconds, making each command pay the
                 // full wait repeatedly. On expiry the opens keep running detached
                 // and waiters are released, degrading to the pre-existing lazy
-                // heal rather than stalling.
+                // heal rather than stalling. The sweep itself never stops early:
+                // once the budget is spent it stops WAITING for pending parses,
+                // but still opens every document whose parse is current — a
+                // document nothing else will touch (no pending parse, no
+                // request on it) is otherwise never re-opened at all.
                 let injection = context.injection.clone();
                 let reopen_server = server.clone();
                 // `done` moves INTO the work task, so ONLY real completion
@@ -1635,6 +1644,7 @@ fn spawn_upstream_request(
                     // sweep is now sized by the workspace rather than by what
                     // one dead connection held.
                     let sweep_deadline = std::time::Instant::now() + REOPEN_WAIT;
+                    let mut budget_spent = false;
                     for host in hosts {
                         // Stop if nobody can hear the answer. `rearm` and a
                         // later `claim` both drop the registry's receiver, so a
@@ -1701,19 +1711,22 @@ fn spawn_upstream_request(
                         let remaining = sweep_deadline
                             .checked_duration_since(std::time::Instant::now())
                             .unwrap_or_default();
-                        if remaining.is_zero() {
+                        if remaining.is_zero() && !budget_spent {
                             // Out of budget with candidates still unexamined.
-                            // Report the connection as NOT caught up: the
-                            // waiters are about to time out anyway, and telling
-                            // them the sweep finished would release commands
-                            // onto documents this pass never reached.
+                            // Keep going without waiting: a document whose
+                            // parse is current still gets its open, and only a
+                            // document whose parse is pending is left to that
+                            // parse's own eager open. Report the connection as
+                            // NOT caught up: the waiters are about to time out
+                            // anyway, and telling them the sweep finished would
+                            // release commands onto documents this pass never
+                            // reached.
                             log::debug!(
                                 target: "kakehashi::bridge",
                                 "Re-open of {key} ran out of budget with candidates \
-                                 left; reporting it incomplete"
+                                 left; finishing the current ones without waiting"
                             );
-                            repaired = false;
-                            break;
+                            budget_spent = true;
                         }
                         use crate::lsp::lsp_impl::coordinator::ParseWait;
                         match injection.ensure_document_parsed(&host, remaining).await {

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -4587,11 +4587,14 @@ mod tests {
 /// Order the documents a re-open sweep considers so that every document
 /// whose parse is already current comes before any whose parse is pending.
 ///
-/// The sweep has one budget for the whole pass and pays a parse wait per
+/// The sweep has one parse-wait budget for the whole pass and pays a wait per
 /// pending document; iterating the store's own (hash) order let a pending
-/// document ahead of a current one spend the budget the current one needed,
-/// and a current document behind it then went un-reopened. Stable: documents
-/// keep their relative order within each group.
+/// document ahead of a current one spend the budget the current one needed.
+/// The sweep keeps walking once the budget is spent and a current snapshot is
+/// recognised without waiting, so the order decides how much of the budget
+/// the pending documents get (and so how many settle in time), not whether a
+/// current document is visited. Stable: documents keep their relative order
+/// within each group.
 fn order_reopen_candidates(
     hosts: Vec<url::Url>,
     is_current: impl Fn(&url::Url) -> bool,

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1697,24 +1697,27 @@ fn spawn_upstream_request(
                         // being published, so a load in progress reads as
                         // "could not look" below, not as "no language" here.
                         let screened_at = injection.document_incarnation(&host);
-                        // The tree state is read BEFORE the language: a
-                        // replacement parse landing between the two reads
-                        // then shows as "no settled tree" (and the rejection
-                        // is not trusted) rather than pairing a language read
-                        // before it with a tree read after it. Both are read
-                        // before the lifetime is re-checked below, so a close
-                        // and reopen in between shows as a lifetime change.
-                        let settled_tree = injection.snapshot_has_tree(&host);
-                        let reachable =
-                            injection
-                                .document_language(&host)
-                                .is_some_and(|candidate_language| {
+                        // The language and whether it comes from a settled
+                        // tree are read from ONE snapshot view: two reads
+                        // would let a replacement parse landing, or a reload
+                        // invalidating the parse, in between pair a settled
+                        // tree with a language that is not that tree's. Both
+                        // are read before the lifetime is re-checked below,
+                        // so a close and reopen in between shows as a
+                        // lifetime change.
+                        let (reachable, settled_tree) = injection
+                            .screen_language(&host)
+                            .map(|(candidate_language, settled_tree)| {
+                                (
                                     injection.bridge().host_language_can_reach_server(
                                         &settings,
                                         &candidate_language,
                                         &reopen_server,
-                                    )
-                                });
+                                    ),
+                                    settled_tree,
+                                )
+                            })
+                            .unwrap_or((false, false));
                         // Only trust a REJECTION if the document did not change
                         // lifetime underneath it. A close+reopen under a
                         // different `languageId` between the two reads would

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1623,13 +1623,16 @@ fn spawn_upstream_request(
                 // sender instead, which waiters read as "can never finish".
                 let mut work = tokio::spawn(async move {
                     // Whether this connection ended up holding everything current
-                    // state says it should. Only an APPLICABLE host that failed
-                    // to open clears it — a host that supplies nothing for this
-                    // connection is not a failed repair, it is not this
-                    // connection's document. Counting those would report failure
-                    // on essentially every respawn (most open documents bridge
-                    // nowhere near any one server), holding the barrier shut and
-                    // making every command pay the full wait and then fail soft.
+                    // state says it should. Cleared by an APPLICABLE host that
+                    // failed to open, and by a host this pass could not look at
+                    // (parse unsettled, language still publishing, tree-less
+                    // placeholder) whose applicability is therefore unknown — a
+                    // host that supplies nothing for this connection is not a
+                    // failed repair, it is not this connection's document.
+                    // Counting those would report failure on essentially every
+                    // respawn (most open documents bridge nowhere near any one
+                    // server), holding the barrier shut and making every
+                    // command pay the full wait and then fail soft.
                     let mut repaired = true;
                     // e2e-only fault injection: hold the re-open BEFORE any
                     // didOpen goes out, so the ordering e2e can force the window

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1697,6 +1697,14 @@ fn spawn_upstream_request(
                         // being published, so a load in progress reads as
                         // "could not look" below, not as "no language" here.
                         let screened_at = injection.document_incarnation(&host);
+                        // The tree state is read BEFORE the language: a
+                        // replacement parse landing between the two reads
+                        // then shows as "no settled tree" (and the rejection
+                        // is not trusted) rather than pairing a language read
+                        // before it with a tree read after it. Both are read
+                        // before the lifetime is re-checked below, so a close
+                        // and reopen in between shows as a lifetime change.
+                        let settled_tree = injection.snapshot_has_tree(&host);
                         let reachable =
                             injection
                                 .document_language(&host)
@@ -1720,12 +1728,6 @@ fn spawn_upstream_request(
                         // stored language in place until the replacement
                         // parse lands, so a rejection read from it is not
                         // definitive either.
-                        // The tree state is read BEFORE the lifetime is
-                        // re-checked, so a close and reopen between the two
-                        // reads shows up as a lifetime change (and falls
-                        // through) rather than pairing the old language's
-                        // rejection with the new lifetime's tree.
-                        let settled_tree = injection.snapshot_has_tree(&host);
                         if !reachable
                             && settled_tree
                             && injection.document_incarnation(&host) == screened_at

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1687,6 +1687,10 @@ fn spawn_upstream_request(
                         // direction. (A `languageId` change needs
                         // didClose+didOpen, which bumps the incarnation, so the
                         // stale-reject window is narrow rather than absent.)
+                        // `document_language` falls back to the language the
+                        // document was opened under while its parser is still
+                        // being published, so a load in progress reads as
+                        // "could not look" below, not as "no language" here.
                         let screened_at = injection.document_incarnation(&host);
                         let reachable =
                             injection

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1673,10 +1673,12 @@ fn spawn_upstream_request(
                         // which is pure configuration, answered from a memo
                         // with no parse, no tree and no I/O. Paying the parse
                         // wait and the injection resolution before asking it
-                        // would spend this connection's fixed budget in
-                        // proportion to WORKSPACE SIZE rather than to the work
-                        // that belongs to it, and the budget is what `done`
-                        // must signal inside.
+                        // would spend the shared parse-wait deadline — and the
+                        // time every command waits on `done` — in proportion
+                        // to WORKSPACE SIZE rather than to the work that
+                        // belongs to this connection. (The sweep itself is
+                        // not bounded: past the deadline it stops waiting,
+                        // not walking.)
                         //
                         // Reading the language before the parse wait keeps the
                         // incarnation/injections ordering intact, because the

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1715,7 +1715,15 @@ fn spawn_upstream_request(
                         // since a skip is indistinguishable from "nothing to
                         // repair". On a mismatch fall through and let the
                         // authoritative path, which re-reads both, decide.
-                        if !reachable && injection.document_incarnation(&host) == screened_at {
+                        // Likewise a document without a current tree: a reload
+                        // that changed how it is detected leaves the OLD
+                        // stored language in place until the replacement
+                        // parse lands, so a rejection read from it is not
+                        // definitive either.
+                        if !reachable
+                            && injection.document_incarnation(&host) == screened_at
+                            && injection.snapshot_has_tree(&host)
+                        {
                             continue;
                         }
                         // Await the tree first: a re-open racing an edit would

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1778,8 +1778,12 @@ fn spawn_upstream_request(
                             // language is still publishing, or a reload
                             // placeholder left it tree-less while its
                             // replacement parse is queued. Not "nothing to
-                            // repair" — report the connection incomplete; the
-                            // parse that lands next re-opens eagerly.
+                            // repair" — report the connection incomplete; a
+                            // parse that lands re-opens eagerly. (A document
+                            // that stays tree-less has no regions to route
+                            // anywhere; the one command that fails soft on
+                            // the incomplete report is the cost of not
+                            // guessing.)
                             log::debug!(
                                 target: "kakehashi::bridge",
                                 "Re-open of {key}: {host} could not be looked at \

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1772,6 +1772,21 @@ fn spawn_upstream_request(
                         else {
                             continue;
                         };
+                        let Some(injections) = injections else {
+                            // The host language's injection query is not in
+                            // the store right now (a lazy load or a reload
+                            // still swapping queries in): this pass could not
+                            // look, which is not "nothing to repair". Report
+                            // the connection incomplete; the parse that
+                            // follows the query's arrival re-opens eagerly.
+                            log::debug!(
+                                target: "kakehashi::bridge",
+                                "Re-open of {key}: {host} has no injection query loaded yet; \
+                                 reporting the connection incomplete"
+                            );
+                            repaired = false;
+                            continue;
+                        };
                         if injections.is_empty() {
                             // Empty means one of two very different things: this
                             // host genuinely has no region for this server, or

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1720,9 +1720,15 @@ fn spawn_upstream_request(
                         // stored language in place until the replacement
                         // parse lands, so a rejection read from it is not
                         // definitive either.
+                        // The tree state is read BEFORE the lifetime is
+                        // re-checked, so a close and reopen between the two
+                        // reads shows up as a lifetime change (and falls
+                        // through) rather than pairing the old language's
+                        // rejection with the new lifetime's tree.
+                        let settled_tree = injection.snapshot_has_tree(&host);
                         if !reachable
+                            && settled_tree
                             && injection.document_incarnation(&host) == screened_at
-                            && injection.snapshot_has_tree(&host)
                         {
                             continue;
                         }

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1845,11 +1845,12 @@ fn spawn_upstream_request(
                         }
                     }
                     // Report what actually happened. `true` releases waiters;
-                    // `false` leaves them to time out and fail soft, which is
-                    // correct when the claimed connection is still empty — a
-                    // command sent there would fail downstream anyway, less
-                    // legibly. A send error means a later respawn's claim
-                    // superseded this barrier, and that respawn owns it now.
+                    // `false` (and the sender dropping right after) makes them
+                    // fail soft at once, which is correct when the claimed
+                    // connection is still empty — a command sent there would
+                    // fail downstream anyway, less legibly. A send error means
+                    // a later respawn's claim superseded this barrier, and
+                    // that respawn owns it now.
                     let _ = done.send(repaired);
                 });
                 // Bound only how long THIS task waits. The work owns the signal,

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1605,8 +1605,9 @@ fn spawn_upstream_request(
                 // `done` applies its own `REOPEN_WAIT` and fails soft when it
                 // passes; expiry here releases nobody — `done` stays pending
                 // until the sweep really finishes, so a command arriving later
-                // finds a settled answer. The sweep never stops early: once
-                // its parse-wait deadline passes it stops WAITING for pending
+                // finds a settled answer. The sweep does not stop early on its
+                // parse-wait deadline (only on `done` losing every waiter): once
+                // that deadline passes it stops WAITING for pending
                 // parses but still opens every document whose parse is
                 // current (a document nothing else will touch — no pending
                 // parse, no request on it — is otherwise never re-opened),

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1773,15 +1773,16 @@ fn spawn_upstream_request(
                             continue;
                         };
                         let Some(injections) = injections else {
-                            // The host language's injection query is not in
-                            // the store right now (a lazy load or a reload
-                            // still swapping queries in): this pass could not
-                            // look, which is not "nothing to repair". Report
-                            // the connection incomplete; the parse that
-                            // follows the query's arrival re-opens eagerly.
+                            // The document could not be looked at: its
+                            // language is still publishing, or a reload
+                            // placeholder left it tree-less while its
+                            // replacement parse is queued. Not "nothing to
+                            // repair" — report the connection incomplete; the
+                            // parse that lands next re-opens eagerly.
                             log::debug!(
                                 target: "kakehashi::bridge",
-                                "Re-open of {key}: {host} has no injection query loaded yet; \
+                                "Re-open of {key}: {host} could not be looked at \
+                                 (language still publishing, or no tree yet); \
                                  reporting the connection incomplete"
                             );
                             repaired = false;

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1597,18 +1597,21 @@ fn spawn_upstream_request(
                 // and saying so is how the derivation stays scoped to
                 // `(server, root)` instead of cross-opening one root's documents
                 // onto another root's process.
-                // Bound the WAIT, not the work — the shape the inline heal used.
-                // `ensure_server_documents_open` can block up to the init timeout
-                // on a cold downstream, and `done` gates every command on this
-                // connection: an unbounded loop would keep the barrier
-                // outstanding for tens of seconds, making each command pay the
-                // full wait repeatedly. On expiry the opens keep running detached
-                // and waiters are released, degrading to the pre-existing lazy
-                // heal rather than stalling. The sweep itself never stops early:
-                // once the budget is spent it stops WAITING for pending parses,
-                // but still opens every document whose parse is current — a
-                // document nothing else will touch (no pending parse, no
-                // request on it) is otherwise never re-opened at all.
+                // `REOPEN_WAIT` bounds two things, neither of them the sweep's
+                // total lifetime: how long the sweep WAITS for pending parses
+                // (one shared deadline for the pass, below) and how long this
+                // actor watches the sweep before letting it finish in the
+                // background (the `timeout` after the spawn). Each waiter on
+                // `done` applies its own `REOPEN_WAIT` and fails soft when it
+                // passes; expiry here releases nobody — `done` stays pending
+                // until the sweep really finishes, so a command arriving later
+                // finds a settled answer. The sweep never stops early: once
+                // its parse-wait deadline passes it stops WAITING for pending
+                // parses but still opens every document whose parse is
+                // current (a document nothing else will touch — no pending
+                // parse, no request on it — is otherwise never re-opened),
+                // and `repaired` turns false only when an applicable document
+                // stayed unsettled or failed to open.
                 let injection = context.injection.clone();
                 let reopen_server = server.clone();
                 // `done` moves INTO the work task, so ONLY real completion
@@ -1636,10 +1639,10 @@ fn spawn_upstream_request(
                     // release builds do not contain this branch.
                     #[cfg(feature = "e2e")]
                     e2e_stall_reopen().await;
-                    // ONE budget for the whole sweep, not one per host. Each
-                    // surviving host can park waiting for its tree, so a
-                    // per-host bound lets ten of them spend `REOPEN_WAIT` ten
-                    // times over — and the barrier promises to settle inside it
+                    // ONE parse-wait deadline for the whole sweep, not one per
+                    // host. Each surviving host can park waiting for its tree,
+                    // so a per-host bound lets ten of them spend `REOPEN_WAIT`
+                    // ten times over — and a waiter only ever waits that long
                     // ONCE. Deriving the set is what makes that reachable: the
                     // sweep is now sized by the workspace rather than by what
                     // one dead connection held.
@@ -1712,15 +1715,13 @@ fn spawn_upstream_request(
                             .checked_duration_since(std::time::Instant::now())
                             .unwrap_or_default();
                         if remaining.is_zero() && !budget_spent {
-                            // Out of budget with candidates still unexamined.
-                            // Keep going without waiting: a document whose
-                            // parse is current still gets its open, and only a
-                            // document whose parse is pending is left to that
-                            // parse's own eager open. Report the connection as
-                            // NOT caught up: the waiters are about to time out
-                            // anyway, and telling them the sweep finished would
-                            // release commands onto documents this pass never
-                            // reached.
+                            // Parse-wait deadline passed with candidates still
+                            // unexamined. Keep going without waiting: a
+                            // document whose parse is current still gets its
+                            // open, and only a document whose parse is pending
+                            // is left to that parse's own eager open — which
+                            // is what turns `repaired` false below, not the
+                            // deadline itself.
                             log::debug!(
                                 target: "kakehashi::bridge",
                                 "Re-open of {key} ran out of budget with candidates \

--- a/src/lsp/lsp_impl/settle_retry.rs
+++ b/src/lsp/lsp_impl/settle_retry.rs
@@ -11,24 +11,38 @@ use url::Url;
 use crate::error::LockResultExt;
 
 /// The set of hosts that already have a settle-retry waiter of a given kind.
+///
+/// A waiter bound to a document lifetime carries that lifetime in its key:
+/// a close and reopen at the same URI while it is active must get its own
+/// waiter, since the old one exits at its lifetime check once the language
+/// settles and would otherwise take the reopened document's retry with it.
+/// (kind, host, lifetime the waiter is bound to — `None` for host-level work).
+type WaiterKey = (&'static str, Url, Option<u64>);
+
 #[derive(Clone, Default)]
 pub(crate) struct SettleRetryWaiters {
-    active: Arc<Mutex<HashSet<(&'static str, Url)>>>,
+    active: Arc<Mutex<HashSet<WaiterKey>>>,
 }
 
-/// Held by the one active waiter of its (kind, host); releases the slot on
-/// drop, so every exit of the waiter — settled, expired, panicked — frees it.
+/// Held by the one active waiter of its (kind, host, lifetime); releases the
+/// slot on drop, so every exit of the waiter — settled, expired, panicked —
+/// frees it.
 pub(crate) struct SettleRetryClaim {
     waiters: SettleRetryWaiters,
-    key: (&'static str, Url),
+    key: WaiterKey,
 }
 
 impl SettleRetryWaiters {
-    /// Claim the (kind, host) slot; `None` when a waiter is already active,
-    /// in which case the caller has nothing to do — the active waiter
+    /// Claim the (kind, host, lifetime) slot; `None` when a waiter is already
+    /// active, in which case the caller has nothing to do — the active waiter
     /// re-runs the same work once the language settles.
-    pub(crate) fn claim(&self, kind: &'static str, host: &Url) -> Option<SettleRetryClaim> {
-        let key = (kind, host.clone());
+    pub(crate) fn claim(
+        &self,
+        kind: &'static str,
+        host: &Url,
+        lifetime: Option<u64>,
+    ) -> Option<SettleRetryClaim> {
+        let key = (kind, host.clone(), lifetime);
         let inserted = self
             .active
             .lock()
@@ -41,11 +55,11 @@ impl SettleRetryWaiters {
     }
 
     #[cfg(test)]
-    pub(crate) fn is_active(&self, kind: &'static str, host: &Url) -> bool {
+    pub(crate) fn is_active(&self, kind: &'static str, host: &Url, lifetime: Option<u64>) -> bool {
         self.active
             .lock()
             .recover_poison("SettleRetryWaiters::is_active")
-            .contains(&(kind, host.clone()))
+            .contains(&(kind, host.clone(), lifetime))
     }
 }
 
@@ -69,25 +83,46 @@ mod tests {
         let waiters = SettleRetryWaiters::default();
         let host = Url::parse("file:///a.md").unwrap();
         let other = Url::parse("file:///b.md").unwrap();
-        let first = waiters.claim("republish", &host).expect("first claim");
+        let first = waiters
+            .claim("republish", &host, None)
+            .expect("first claim");
         assert!(
-            waiters.claim("republish", &host).is_none(),
+            waiters.claim("republish", &host, None).is_none(),
             "second waiter coalesces"
         );
         assert!(
-            waiters.claim("injection", &host).is_some(),
+            waiters.claim("injection", &host, Some(1)).is_some(),
             "another kind is independent"
         );
         assert!(
-            waiters.claim("republish", &other).is_some(),
+            waiters.claim("republish", &other, None).is_some(),
             "another host is independent"
         );
-        assert!(waiters.is_active("republish", &host));
+        assert!(waiters.is_active("republish", &host, None));
         drop(first);
-        assert!(!waiters.is_active("republish", &host));
+        assert!(!waiters.is_active("republish", &host, None));
         assert!(
-            waiters.claim("republish", &host).is_some(),
+            waiters.claim("republish", &host, None).is_some(),
             "the slot is free again"
+        );
+    }
+
+    /// A reopened lifetime's retry must not be dropped because the closed
+    /// lifetime's waiter still holds the URI.
+    #[test]
+    fn a_reopened_lifetime_gets_its_own_waiter() {
+        let waiters = SettleRetryWaiters::default();
+        let host = Url::parse("file:///a.md").unwrap();
+        let _closed = waiters
+            .claim("injection", &host, Some(1))
+            .expect("lifetime 1");
+        assert!(
+            waiters.claim("injection", &host, Some(1)).is_none(),
+            "same lifetime coalesces"
+        );
+        assert!(
+            waiters.claim("injection", &host, Some(2)).is_some(),
+            "lifetime 2 is its own retry"
         );
     }
 }

--- a/src/lsp/lsp_impl/settle_retry.rs
+++ b/src/lsp/lsp_impl/settle_retry.rs
@@ -1,0 +1,93 @@
+//! One settle-retry waiter per (kind, host): a burst of deferrals during a
+//! reload or a language publication must not spawn one polling task each,
+//! all of which would then serialize through the host's republish lock (or
+//! re-run the injection pass) once the language settles.
+
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+
+use url::Url;
+
+use crate::error::LockResultExt;
+
+/// The set of hosts that already have a settle-retry waiter of a given kind.
+#[derive(Clone, Default)]
+pub(crate) struct SettleRetryWaiters {
+    active: Arc<Mutex<HashSet<(&'static str, Url)>>>,
+}
+
+/// Held by the one active waiter of its (kind, host); releases the slot on
+/// drop, so every exit of the waiter — settled, expired, panicked — frees it.
+pub(crate) struct SettleRetryClaim {
+    waiters: SettleRetryWaiters,
+    key: (&'static str, Url),
+}
+
+impl SettleRetryWaiters {
+    /// Claim the (kind, host) slot; `None` when a waiter is already active,
+    /// in which case the caller has nothing to do — the active waiter
+    /// re-runs the same work once the language settles.
+    pub(crate) fn claim(&self, kind: &'static str, host: &Url) -> Option<SettleRetryClaim> {
+        let key = (kind, host.clone());
+        let inserted = self
+            .active
+            .lock()
+            .recover_poison("SettleRetryWaiters::claim")
+            .insert(key.clone());
+        inserted.then(|| SettleRetryClaim {
+            waiters: self.clone(),
+            key,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_active(&self, kind: &'static str, host: &Url) -> bool {
+        self.active
+            .lock()
+            .recover_poison("SettleRetryWaiters::is_active")
+            .contains(&(kind, host.clone()))
+    }
+}
+
+impl Drop for SettleRetryClaim {
+    fn drop(&mut self) {
+        self.waiters
+            .active
+            .lock()
+            .recover_poison("SettleRetryClaim::drop")
+            .remove(&self.key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SettleRetryWaiters;
+    use url::Url;
+
+    #[test]
+    fn one_waiter_per_kind_and_host_until_it_drops() {
+        let waiters = SettleRetryWaiters::default();
+        let host = Url::parse("file:///a.md").unwrap();
+        let other = Url::parse("file:///b.md").unwrap();
+        let first = waiters.claim("republish", &host).expect("first claim");
+        assert!(
+            waiters.claim("republish", &host).is_none(),
+            "second waiter coalesces"
+        );
+        assert!(
+            waiters.claim("injection", &host).is_some(),
+            "another kind is independent"
+        );
+        assert!(
+            waiters.claim("republish", &other).is_some(),
+            "another host is independent"
+        );
+        assert!(waiters.is_active("republish", &host));
+        drop(first);
+        assert!(!waiters.is_active("republish", &host));
+        assert!(
+            waiters.claim("republish", &host).is_some(),
+            "the slot is free again"
+        );
+    }
+}

--- a/src/lsp/lsp_impl/text_document/did_save.rs
+++ b/src/lsp/lsp_impl/text_document/did_save.rs
@@ -125,7 +125,7 @@ impl Kakehashi {
             .get(uri)
             .map(|document| (document.incarnation(), document.content_version()));
         if current_lineage == Some((saved_incarnation, saved_content_version))
-            && let Some((_, injections)) = self.injection_coordinator().bridge_injections(uri)
+            && let Some((_, Some(injections))) = self.injection_coordinator().bridge_injections(uri)
         {
             pool.sync_and_forward_did_save_to_virtual_docs(uri, saved_incarnation, &injections)
                 .await;


### PR DESCRIPTION
## Summary

`e2e_code_action::a_completed_reopen_releases_the_command_it_was_holding` failed in roughly two of three full e2e runs on `main`. Tracing a failing run showed the respawn re-open sweep skipping the second host: its snapshot carried an **empty** cached bridge-region set, published by a parse pass that ran while the markdown injection query was not yet in the query store, and nothing recomputed it without an edit. One level down, the reason the query was missing: **every language publication registered the parser before compiling its queries**, and `has_parser_available` reads the registry lock-free, so a concurrent parse saw the parser with no queries.

This PR fixes that at the source and makes every reader of the injection state answer "could not look" instead of "nothing there" while a language is unsettled. It grew well beyond a flake fix through the review rounds; the pieces are:

### Language publication order (root cause)
- Queries are published **before** the parser on all three paths (`publish_dynamic_language`, `load_single_language`, `register_derived_from_base`), so a visible parser implies visible queries.
- Each path runs as one `registration_lock` section, and a duplicate concurrent load that finds a current registration keeps the published queries instead of clearing them.
- The second generation bump happens before the reload guard is released.

### Injection resolution is tri-state
- `resolve_injection_data` returns `None` ("could not look") when the parser is not published, a reload is in progress, the generation moved across its reads, the current snapshot is trailing or tree-less, or the snapshot's language is not the one asked about; it reads tree, text, language and lifetime from **one current snapshot** rather than the legacy tree. "Parser visible, no injection query" is a definitive empty set.
- `populate_injections` publishes `PopulatedInjections::undetermined` (all region fields `None`) only while the parser is unpublished; a settled language without an injection query keeps its definitive empty set and its fast paths.
- `bridge_injections` is `Option<(language, Option<Vec<_>>)>`; the eager pass leaves open work alone on an undeterminable result; virtual `didSave` forwards only on a determinate one (no regression: the window previously read as empty).

### Re-open sweep
- Candidates are ordered current-first (`order_reopen_candidates`); once the parse-wait budget is spent the sweep keeps walking without waiting instead of breaking out.
- `ensure_document_parsed` answers a current snapshot synchronously before the wait and after the timeout, and a document closed since enumeration reads as `Gone` even on a spent budget.
- The language screen reads the language and whether it came from a settled tree from one snapshot view (`screen_language`: settled snapshot language, then stored id, then parser-aware detection) and trusts a rejection only for a settled tree; the authoritative resolution runs only from a settled parse. An unlookable host reports the connection incomplete (one command fails soft; the parse that lands re-opens eagerly).

### Settle-retries
- A pass that could not look because the language was unsettled, and a diagnostic republish deferred for the same reason, spawn a bounded (10 s, 50 ms poll) retry once the parser is published and no reload is in progress; a `searchPaths`-discovered host parser is re-published via `ensure_language_loaded_async`. Retries are coalesced per (kind, host, lifetime) by `SettleRetryWaiters`, release their slot before the rerun, and observe shutdown.

### Diagnostic republish
- `current_region_offsets` takes language, tree, text and lifetime from one current snapshot, defers while the parser is unpublished or a reload is in progress (re-asked before every definitive answer), releases its document guard before any further store lookup, and defers when the document moved since the geometry was captured.

### Tests and docs
- Unit tests pin: publication order, duplicate-load queries kept, tri-state resolution (tree-less, pending parser, reload in progress, treeful under a pending parser), stored-language fallback, settled-snapshot language, candidate ordering, zero-budget wait (current / closed), retry coalescing per lifetime, diagnostic geometry deferrals.
- The code-lens warning-capture assertion is scoped to its own lines (the capture is process-wide).
- ADRs and comments updated: the three bounds around the sweep, the incomplete report for unlookable hosts, candidate ordering.
- The e2e test itself is unchanged: with the fixes it passes in its original shape across repeated full-suite runs.

### Known, accepted
- An edit between the sweep's resolution and its didOpen can ghost-open a removed region until the next edit (pre-existing; the sweep's open reads the latest recorded content, and a forward that finds the pre-send claim orders its didChange behind the didOpen).
- An incomplete report is retired after one failed wait (`pending_reopen` policy: keeping it would fail every later command).
- Other whole-document readers still collapse the reload window to empty: #1056. Reload can resurrect a removed host server from a parked eager batch: #1055.

## Verification

- `cargo fmt --check`, `cargo clippy -- -D warnings` clean
- `cargo test --lib` (3679 passed, 2 ignored); `--test integration --bins` (79 + 11)
- `cargo test --features e2e --test e2e`: repeated full runs green at each push (the original flake no longer reproduces); merged onto current `main` (with #1049) it builds and passes the language/injection/lifecycle/diagnostic suites and the code-action e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhEfVnacTxTiURX5ftDwmn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved language support reliability by ensuring parser features are available only after required queries are ready, including duplicate publications.
  - Improved embedded-language resolution and diagnostics during parsing, reloading, or temporary query unavailability.
  - Added bounded, coordinated retries for unresolved embedded-language processing and diagnostic updates.
  - Enhanced document recovery after restarts, prioritizing current documents and continuing incomplete recovery in the background.
  - Prevented virtual document save notifications when embedded-language data is incomplete.
  - Refined code-lens warning handling and semantic-token updates during language changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
