### PR TITLE
refactor(document): install a parse's tree and snapshot through one store primitive

### DIFF
--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -256,11 +256,10 @@ preference order:
     identity, a stored `region_id` is only ever served for the exact tree it was
     minted on — consistent with the `InjectionMap` / tracker state for that tree;
     a changed tree misses and the miss-path mints fresh, as today.
-  - **Publication scheme:** publish the tree first; build discovery; then attach it
-    to the parse result via a *second* CAS that no-ops unless the tree / parse
-    epoch is still the one just published. Discovery is therefore briefly *absent*
-    between the two CASes (a request in that window re-discovers inline), but never
-    attached to the wrong tree.
+  - **Publication scheme:** build discovery on the tree value first, then install
+    tree and discovery-carrying snapshot in one `install_parse`; there is no window
+    in which the snapshot exists without its discovery, and discovery is never
+    attached to the wrong tree (the install rejects a tree whose inputs moved on).
 - **Alternative — a parse epoch.** If coupling into the parse result is too
   invasive, key a separate `DiscoveredInjectionCache` on a **fresh monotonic
   per-parse epoch** — *not* `incarnation` (preserved across edits, so it cannot
@@ -277,14 +276,14 @@ obligation), and parse ordering (below) affects only hit-rate.
 
 **Currency — hit-rate, not correctness.** Correctness rests on the tree-identity
 binding above; ordering only governs how often a reusable discovery is *available*
-when the request runs. In the reparse loop, when a tree lands the order is
-set-tree → `populate_injections` → `advance_watermark` / `mark_parse_finished`
+when the request runs. In the reparse loop the order is
+`populate_injections` → `install_parse` → `mark_parse_finished` / `advance_watermark`
 (`src/lsp/lsp_impl/coordinator/parse.rs`), and the semantic handler's settle waits on the parse
 watermark + parse-completion before snapshotting the tree
 (`src/lsp/lsp_impl/text_document/semantic_tokens.rs`), so in the common debounced case the
 snapshot already carries (or its epoch already matches) the populated discovery.
-On the branches where `populate_injections` is skipped (the CAS-fail `if stored`
-guard, the no-tree / error paths — `advance_watermark` still runs there), when the
+On the branches where `populate_injections` does not run (the no-tree / error
+paths — `advance_watermark` still runs there), when the
 200 ms settle budget expires, or on the on-demand-parse fallback, there is simply
 no discovery to reuse and the request re-discovers inline. No ordering guarantee
 is load-bearing.

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -238,10 +238,11 @@ preference order:
   from one atomic snapshot — physically one unit, so there is **no reader-side gate
   to get wrong**: a snapshot carries discovery (reuse) or does not (the
   on-demand-parse fallback tree → discover inline). The only gate is on the
-  *writer* side — the second CAS below that attaches discovery only to the tree it
-  was built for. Realizability, given `populate_injections` runs *after* the
-  tree CAS (`set_parse_result_if_text_and_incarnation_unchanged`, defined in
-  `src/document/store.rs` and invoked from `src/lsp/lsp_impl/coordinator/parse.rs`):
+  *writer* side — the install below attaches discovery only to the tree it
+  was built for. Realizability, given `populate_injections` runs *before* the
+  install (`DocumentStore::install_parse`, invoked from
+  `src/lsp/lsp_impl/coordinator/parse.rs`) on the tree value, guarding its own
+  cache commits by the tracker's epoch and the lifetime:
   - **No *new* `NodeTracker` mutation.** `populate_injections` *already* calls
     `tracker.get_or_create` today, to mint the `region_id` on each
     `CacheableInjectionRegion` it inserts into the `InjectionMap` (which

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -243,16 +243,17 @@ preference order:
   install (`DocumentStore::install_parse`, invoked from
   `src/lsp/lsp_impl/coordinator/parse.rs`) on the tree value, guarding its own
   cache commits by the tracker's epoch and the lifetime:
-  - **No *new* `NodeTracker` mutation.** `populate_injections` *already* calls
-    `tracker.get_or_create` today, to mint the `region_id` on each
-    `CacheableInjectionRegion` it inserts into the `InjectionMap` (which
-    `invalidate_for_edits` needs for token-cache eviction). The discovery build
-    must **reuse that same id** — it is produced by the same shared stage, from the
-    same `Q`, so the lever adds *no* off-ingress `get_or_create` beyond today's.
-    (The pre-existing off-ingress minting, and its interaction with a concurrent
-    subsequent edit, is governed by
-    [lazy-node-identity-tracking](lazy-node-identity-tracking.md) and is neither
-    worsened nor in scope to fix here.) Because reuse is bound to the tree
+  - **No *new* `NodeTracker` mutation.** `populate_injections` *already* mints
+    the `region_id` on each `CacheableInjectionRegion` it inserts into the
+    `InjectionMap` (which `invalidate_for_edits` needs for token-cache eviction),
+    through the tracker's epoch/incarnation-guarded batch mint
+    (`mint_batch_if_unshifted`) and commit (`commit_if_unshifted`): a pass whose
+    document was edited, closed, or reopened since it latched its epoch mints
+    nothing and commits nothing. The discovery build must **reuse that same id** —
+    it is produced by the same shared stage, from the same `Q`, so the lever adds
+    *no* off-ingress minting beyond today's, and inherits the same guard
+    ([lazy-node-identity-tracking](lazy-node-identity-tracking.md)). Because reuse
+    is bound to the tree
     identity, a stored `region_id` is only ever served for the exact tree it was
     minted on — consistent with the `InjectionMap` / tracker state for that tree;
     a changed tree misses and the miss-path mints fresh, as today.

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -117,11 +117,12 @@ mapping is not one-to-one and must be stated precisely:
   (which already owns the parse lifecycle), not onto the read-side slot. Deleting
   `parse_states` is contingent on those two moves.
 
-The store's tree/watermark CAS methods (four tree writes —
-`update_tree_if_text_unchanged`, `update_tree_if_text_and_language_unchanged`,
-`attach_tree_if_absent`, `set_parse_result_if_text_and_incarnation_unchanged` —
-plus the two watermark advances `advance_watermark` /
-`advance_watermark_for_incarnation`) collapse to **one publish primitive**,
+The store's tree/watermark CAS methods (the tree writes — now collapsed into
+`DocumentStore::install_parse`, which attaches the legacy tree iff the parse's
+inputs still describe the document and publishes the snapshot iff the cell
+admits it, both under the document's entry guard — plus the two watermark
+advances `advance_watermark` / `advance_watermark_for_incarnation`) collapse to
+**one publish primitive**,
 executed inside `send_if_modified` so the guard and the write are atomic under the
 channel's own lock (the co-location is what makes this a single atomic
 check-then-act rather than a cross-map TOCTOU against `Document.incarnation`):
@@ -509,15 +510,20 @@ inside the existing safety contracts at each step:
   preserving the `populate → finish` ordering the injection-map invalidation
   depends on.
 - **Stage 2 — versioned snapshot reads.** Introduce `SnapshotSlot` + the `watch`
-  channel + `latest_snapshot`. **The parse loop dual-writes under one guard**: the
-  legacy tree CAS (the incremental seed still reads `Document::tree`/`pending_seed`,
-  which Stage 3 removes) is made strict-version like the publish, both writes run
-  under the same `(incarnation, parsed_version)` guard, and the **snapshot publish is the sole commit point** — all downstream (refresh, forwarding, diagnostics,
-  shared cache writes) gate on the *publish* result, never the legacy CAS (§2). So
+  channel + `latest_snapshot`. **The parse loop installs the legacy tree and the
+  snapshot through one store primitive** (`install_parse`): the legacy tree (the
+  incremental seed still reads `Document::tree`/`pending_seed`, which Stage 3
+  removes) is attached iff the parse's inputs still describe the document, the
+  snapshot is published iff the cell admits it, and both happen under the same
+  entry guard — there is no attach-only path. The **snapshot publish is the sole
+  commit point** — all downstream (refresh, forwarding, diagnostics, shared cache
+  writes) gate on the *publish* result, never the tree attach (§2). So
   `latest_snapshot` retains a servable tree across an edit's `tree.take()`; the two
-  stores may transiently sit at different versions (a lost legacy CAS just reseeds
+  stores may transiently sit at different versions (a rejected attach just reseeds
   next pass), but no **reader** sees the difference because every reader reads the
-  snapshot, not the legacy tree. `populate`'s split into geometry derivation and
+  snapshot, not the legacy tree. The populate pass runs *before* the install, on
+  the tree value; it guards its own cache commits by the tracker's epoch and the
+  lifetime, so a pass whose text moved on commits nothing. `populate`'s split into geometry derivation and
   the latch-gated tracker reconciliation (§3) is **already in**. Take the
   grammar auto-install off the read handlers (`compute_captures` no longer triggers
   `ensure_injection_languages_loaded_for_document` inline): the parse loop
@@ -540,11 +546,12 @@ inside the existing safety contracts at each step:
   `wait_for_epoch` / `ensure_document_parsed` **and** the inline-parse fallbacks
   (`try_parse_and_update_document`, `selection_range_impl`) — closing the
   resurrection vector. Delivers *instant reads* and *lifecycle independent of
-  parsing*. Without the dual-write this stage would reproduce the empty-after-edit
-  regression, so it is mandatory here, not deferred.
+  parsing*. Without the single install this stage would reproduce the
+  empty-after-edit regression, so it is mandatory here, not deferred.
 - **Stage 3 — consolidation.** Remove `Document::tree` / `pending_seed` (the seed
-  now lives on the scheduler), collapse the CAS methods into the one publish
-  primitive, delete the watermark waits, and prune the now-superseded passages
+  now lives on the scheduler) and the legacy readers, delete the watermark waits,
+  and prune the now-superseded passages (the CAS methods are already collapsed
+  into `install_parse`)
   from per-document-parse-scheduler (its tree-clear-on-edit and watermark/epoch
   sections) per delete-on-supersede — done **here**, when the behavior actually
   changes, not before. Per the repo's structural-vs-behavioral separation
@@ -690,8 +697,9 @@ dequeue hook (§4).
 `ParseSnapshot` published into the `SnapshotSlot` `watch` cell on the
 `Document` entry through the §2 publish primitive (bootstrap/strict-version/
 incarnation guard, `u64::MAX` close sentinel, reserved in `next_incarnation`
-and refused by the guard itself); the parse loop dual-writes on every
-resolution path and emits `semanticTokens/refresh` at its publish point;
+and refused by the guard itself); the parse loop installs tree and snapshot
+through `install_parse` on every resolution path and emits
+`semanticTokens/refresh` at its publish point;
 `semanticTokens` full/delta serve-current via the parked wait (initially
 shipped serve-stale; revised on live-editor evidence — see §3) and
 `captures/full` likewise serve-current (initially serve-stale; revised after

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -518,10 +518,11 @@ inside the existing safety contracts at each step:
   channel + `latest_snapshot`. **The parse loop installs the legacy tree and the
   snapshot through one store primitive** (`install_parse`): the legacy tree (the
   incremental seed still reads `Document::tree`/`pending_seed`, which Stage 3
-  removes) is attached iff the parse's inputs still describe the document, the
-  snapshot is published iff the cell admits it, the tree is attached only when the
-  snapshot was, and both happen under the same entry guard — there is no
-  attach-only path. The **snapshot publish is the sole commit point** —
+  removes) is attached iff the parse's inputs still describe the document AND
+  the snapshot was admitted, the snapshot is published iff the language still
+  matches and the cell admits it, and both happen under the same entry guard —
+  there is no attach-only path, while publish-without-attach (a stale but
+  consistent parse) is allowed. The **snapshot publish is the sole commit point** —
   `semanticTokens/refresh` gates on the publish result, and the legacy-tree-
   dependent downstream (`mark_parse_finished`, the open parse's tree-dependent
   follow-ups) gates on the attach until Stage 3 removes the legacy tree (§2). So

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -117,13 +117,12 @@ mapping is not one-to-one and must be stated precisely:
   (which already owns the parse lifecycle), not onto the read-side slot. Deleting
   `parse_states` is contingent on those two moves.
 
-The store's tree/watermark CAS methods (the tree writes — now collapsed into
-`DocumentStore::install_parse`, which attaches the legacy tree iff the parse's
-inputs still describe the document and publishes the snapshot iff the cell
-admits it, both under the document's entry guard — plus the two watermark
-advances `advance_watermark` / `advance_watermark_for_incarnation`) collapse to
-**one publish primitive**,
-executed inside `send_if_modified` so the guard and the write are atomic under the
+The store's tree writes are already collapsed into `DocumentStore::install_parse`
+(the snapshot publish below inside `send_if_modified`, then — only if it was
+admitted — the legacy tree attach, both under the document's entry guard); the
+two watermark advances `advance_watermark` / `advance_watermark_for_incarnation`
+still remain to be folded into the **one publish primitive**, which is executed
+inside `send_if_modified` so the guard and the write are atomic under the
 channel's own lock (the co-location is what makes this a single atomic
 check-then-act rather than a cross-map TOCTOU against `Document.incarnation`):
 
@@ -202,22 +201,24 @@ enforced by co-location today, become explicit scheduler invariants:
   scratch. "Leaves no accumulated edits" is an explicit reset, not an emergent
   property.
 
-A parse pass therefore has a **single version/incarnation-guarded commit sequence**, so no downstream effect ever escapes for a snapshot that lost the CAS:
-compute the tree, region map, and tokens **privately** (nothing shared mutated);
-revalidate `incarnation == current_incarnation`; run the one publish primitive; and
-emit the downstream — `semanticTokens/refresh`, injected-language forwarding,
-diagnostic republish, and any shared injection-token-cache write — **only if that exact publish succeeded** (the shared `NodeTracker` is not mutated on this path at
-all; see §3), in the order the
-per-document-parse-scheduler loop already uses (`populate → mark finished →
-downstream`). A rejected publish (a racing edit or reopen advanced the slot) emits
-nothing and mutates no shared state. The two Stage-2 stores are **not** written in
-one cross-store transaction — that is unnecessary, because they are not co-equal:
-the **snapshot publish is the sole commit point and runs first**, and every
-downstream effect gates on *its* result. The legacy tree CAS that follows is a
-Stage-2-only compatibility shim feeding the incremental seed (which still reads
-`Document::tree` until Stage 3 removes it); it is made strict-version so it never
-regresses, but if it *loses* a race the only consequence is that the next pass
-reseeds from the current snapshot instead of the legacy tree — a self-correcting
+A parse pass therefore has a **single version/incarnation-guarded commit sequence**, so no downstream effect ever escapes for a snapshot that lost the admission:
+compute the tree, region map, and tokens on the tree value (the populate pass
+commits its injection caches under its own tracker-epoch/lifetime guard, so a
+pass whose text moved on commits nothing there); run the one install
+(`install_parse`: the snapshot publish, then — only if admitted — the legacy tree
+attach, under one entry guard); and emit the downstream — `semanticTokens/refresh`,
+injected-language forwarding, diagnostic republish — gated on the install's
+result, in the order the per-document-parse-scheduler loop already uses
+(`populate → install → mark finished → downstream`). A rejected publish (a racing
+edit or reopen advanced the slot) emits nothing and attaches nothing. The two
+Stage-2 stores are written by one primitive but are not co-equal: the **snapshot
+publish is the sole commit point**; the legacy tree attach that accompanies it is
+a Stage-2-only compatibility shim feeding the incremental seed (which still reads
+`Document::tree` until Stage 3 removes it). `semanticTokens/refresh` gates on the
+publish; the legacy-tree-dependent downstream (`mark_parse_finished`, the open
+parse's tree-dependent follow-ups) gates on the attach until Stage 3, and an
+attach can only be refused when the inputs moved on — in which case the next pass
+reseeds from the current snapshot instead of the legacy tree, a self-correcting
 perf blip, never a served inconsistency, since readers already read the snapshot,
 not the legacy tree. So no reader-visible divergence can arise from the ordering.
 
@@ -514,10 +515,12 @@ inside the existing safety contracts at each step:
   snapshot through one store primitive** (`install_parse`): the legacy tree (the
   incremental seed still reads `Document::tree`/`pending_seed`, which Stage 3
   removes) is attached iff the parse's inputs still describe the document, the
-  snapshot is published iff the cell admits it, and both happen under the same
-  entry guard — there is no attach-only path. The **snapshot publish is the sole
-  commit point** — all downstream (refresh, forwarding, diagnostics, shared cache
-  writes) gate on the *publish* result, never the tree attach (§2). So
+  snapshot is published iff the cell admits it, the tree is attached only when the
+  snapshot was, and both happen under the same entry guard — there is no
+  attach-only path. The **snapshot publish is the sole commit point** —
+  `semanticTokens/refresh` gates on the publish result, and the legacy-tree-
+  dependent downstream (`mark_parse_finished`, the open parse's tree-dependent
+  follow-ups) gates on the attach until Stage 3 removes the legacy tree (§2). So
   `latest_snapshot` retains a servable tree across an edit's `tree.take()`; the two
   stores may transiently sit at different versions (a rejected attach just reseeds
   next pass), but no **reader** sees the difference because every reader reads the
@@ -624,7 +627,8 @@ inside the existing safety contracts at each step:
   see the refined language without depending on `Document::language_id` being
   rewritten or requiring a re-`didOpen`.
 - State and coupling shrink: two `watch` maps collapse to one, six store CAS /
-  watermark methods to one publish primitive, and the `pending_seed` invariant
+  watermark methods to one publish primitive (tree writes done — `install_parse`;
+  watermark advances pending), and the `pending_seed` invariant
   surface on `Document` is deleted (favorable on the State > Coupling > Complexity
   > Code ordering the repo optimizes for).
 

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -201,7 +201,7 @@ enforced by co-location today, become explicit scheduler invariants:
   scratch. "Leaves no accumulated edits" is an explicit reset, not an emergent
   property.
 
-A parse pass therefore has a **single version/incarnation-guarded commit sequence**, so no downstream effect ever escapes for a snapshot that lost the admission:
+A parse pass therefore has a **single version/incarnation-guarded commit sequence**, so no reader-visible publication or downstream emission ever escapes for a snapshot that lost the admission:
 compute the tree, region map, and tokens on the tree value (the populate pass
 commits its injection caches under its own tracker-epoch/lifetime guard, so a
 pass whose text moved on commits nothing there); run the one install
@@ -210,7 +210,11 @@ attach, under one entry guard); and emit the downstream — `semanticTokens/refr
 injected-language forwarding, diagnostic republish — gated on the install's
 result, in the order the per-document-parse-scheduler loop already uses
 (`populate → install → mark finished → downstream`). A rejected publish (a racing
-edit or reopen advanced the slot) emits nothing and attaches nothing. The two
+edit or reopen advanced the slot) emits nothing and attaches nothing. (Two
+parses of the *same* version — an install reparse racing the edit reparse — may
+both commit their populate bookkeeping before one of them loses the equal-version
+admission; those commits are equivalent, keyed by the same tree coordinates under
+the same epoch, so the loser's cache entries are the winner's.) The two
 Stage-2 stores are written by one primitive but are not co-equal: the **snapshot
 publish is the sole commit point**; the legacy tree attach that accompanies it is
 a Stage-2-only compatibility shim feeding the incremental seed (which still reads

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -221,8 +221,8 @@ a Stage-2-only compatibility shim feeding the incremental seed (which still read
 `Document::tree` until Stage 3 removes it). `semanticTokens/refresh` gates on the
 publish; the legacy-tree-dependent downstream (`mark_parse_finished`, the open
 parse's tree-dependent follow-ups) gates on the attach until Stage 3, and an
-attach can only be refused when the inputs moved on — in which case the next pass
-reseeds from the current snapshot instead of the legacy tree, a self-correcting
+attach is refused only when the inputs moved on or an equal-version sibling
+already landed the same tree — in either case the next pass reseeds from the current snapshot instead of the legacy tree, a self-correcting
 perf blip, never a served inconsistency, since readers already read the snapshot,
 not the legacy tree. So no reader-visible divergence can arise from the ordering.
 

--- a/docs/architecture-decisions/per-document-parse-scheduler.md
+++ b/docs/architecture-decisions/per-document-parse-scheduler.md
@@ -465,9 +465,10 @@ rather than resurrecting the closed document. Injection orchestration runs
 downstream of the parse, off the ingress path. The text-owning actor of Option 4 is
 not pursued; see Considered Options.
 
-One narrow divergence remains, in injection publication: a close+reopen can slip
-between a successful tree CAS and the subsequent unguarded `injection_map` publish,
-together with a pass-B-no-tree edge. It is benign, and deliberately left scoped-out,
+One narrow divergence remains, in injection publication: the `injection_map`
+publish happens in the populate pass, which now runs *before* the tree install
+and guards its own commit by the tracker's epoch and the lifetime (see
+parse-snapshot-architecture, Stage 2), together with a pass-B-no-tree edge. It is benign, and deliberately left scoped-out,
 for three reasons. First, blast radius: `injection_map` is invalidation bookkeeping —
 read only by `invalidate_for_edits`/`get_injections`, never on the semantic-token
 render path, which re-derives regions from the tree — so a stale entry is at worst a
@@ -476,7 +477,8 @@ transient mis-invalidation for a live document or an unread leak for a closed on
 the single-flight scheduler lets the freshest populate win, and any stale entry is
 replaced on the next successful parse or cleared on reopen. Third, the principled fix —
 tagging `injection_map` with the incarnation — costs a representation change and reader
-threading to close a near-unreachable case (the cross-incarnation overwrite is already
-closed: there is no `.await` between the tree CAS and `populate_injections`, so a fresh
-incarnation cannot squeeze in), and would still miss the same-incarnation
+threading to close a near-unreachable case (the cross-incarnation overwrite is
+closed at populate's own guard — its commit checks the incarnation under the
+tracker entry's lock — not by ordering against the tree install), and would still
+miss the same-incarnation
 pass-B-no-tree edge — a net-negative trade.

--- a/src/document.rs
+++ b/src/document.rs
@@ -13,3 +13,5 @@ pub(crate) use injections::{
 };
 pub(crate) use model::Document;
 pub use store::DocumentStore;
+
+pub(crate) use store::ParseInputs;

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -57,7 +57,9 @@ pub struct Document {
     ///
     /// **Read by `reparse_latest` only** — never by `tree()` / `snapshot()`, which
     /// must stay `None` until the reparse lands. Cleared the moment a fresh tree is
-    /// attached (`set_tree`) — a present tree means the seed is consumed — and on a
+    /// attached (`set_parse_result`, reached only through
+    /// `DocumentStore::install_parse`) — a present tree means the seed is
+    /// consumed — and on a
     /// full-text sync (`apply_edit_and_seed` with no `InputEdit`s), where seeding an
     /// unedited tree against wholly-replaced text would violate tree-sitter's
     /// incremental contract and corrupt external scanners (#348).
@@ -264,15 +266,8 @@ impl Document {
         self.pending_seed = None;
     }
 
-    /// Attach a parsed tree **without** touching the text.
-    ///
-    /// For an on-demand reader parse whose parsed text already equals the stored
-    /// text: there is no content-version transition to record, so the text is
-    /// neither re-cloned nor replaced.
-    ///
-    /// Clears `pending_seed`: a present reader-visible tree means the off-ingress
-    /// reparse's seed has been consumed (the tree it would have produced is now
-    /// here), so the next `didChange` seeds from this fresh tree, not a stale seed.
+    /// Drop the tree and the seed on a settings/grammar reload and publish a
+    /// tree-less placeholder at the bumped version (see `ParseSnapshot`).
     pub(crate) fn invalidate_parse(&mut self) {
         self.tree = None;
         self.pending_seed = None;
@@ -296,14 +291,17 @@ impl Document {
         });
     }
 
-    /// Store the open-time parse result — the detected `language` and the parsed
-    /// `tree` (`None` for a parsed-to-nothing / no-language open) —
-    /// **preserving the existing text**.
+    /// Store a parse result — the `language` and the parsed `tree` (`None` for
+    /// a parsed-to-nothing / no-language parse) — **preserving the existing
+    /// text**. Reached only through `DocumentStore::install_parse`, for every
+    /// parse path (open, installed-grammar reparse, edit reparse); the text
+    /// was stored when the document was registered, so the result is recorded
+    /// in place rather than re-inserting a copy of the (potentially large)
+    /// text.
     ///
-    /// For the didOpen parse, whose text was already stored when the document was
-    /// registered: it reparses that same text and records the result *in place*,
-    /// rather than re-inserting a fresh copy of the (potentially large) text. Clears
-    /// any `pending_seed` (the open path never has one — it is set only by an edit).
+    /// Clears `pending_seed`: a present reader-visible tree means the
+    /// off-ingress reparse's seed has been consumed, so the next `didChange`
+    /// seeds from this fresh tree, not a stale seed.
     pub(crate) fn set_parse_result(&mut self, language: Option<String>, tree: Option<Tree>) {
         self.language_id = language;
         self.tree = tree;
@@ -540,7 +538,7 @@ mod tests {
 
     /// Attaching a fresh tree consumes (clears) the pending seed.
     #[test]
-    fn set_tree_clears_pending_seed() {
+    fn set_parse_result_clears_pending_seed() {
         let mut parser = tree_sitter::Parser::new();
         parser
             .set_language(&tree_sitter_rust::LANGUAGE.into())

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -200,12 +200,15 @@ impl Document {
     /// `send_if_modified` so the guard and the write are atomic under the
     /// channel's own lock. Returns whether the publish landed; a rejected
     /// publish (a racing edit's newer snapshot, a reopen, a close) must make
-    /// the caller emit no downstream effects.
-    pub(crate) fn publish_snapshot(&self, snapshot: Arc<ParseSnapshot>) -> bool {
+    /// the caller emit no downstream effects. Takes the snapshot by reference
+    /// so the caller keeps ownership of a rejected one and can drop it after
+    /// releasing whatever guard it holds: destroying a tree and its region
+    /// vectors is not free.
+    pub(crate) fn publish_snapshot(&self, snapshot: &Arc<ParseSnapshot>) -> bool {
         let mut installed = false;
         self.snapshot_tx.send_if_modified(|slot| {
-            if slot.admits(&snapshot) {
-                slot.snapshot = Some(Arc::clone(&snapshot));
+            if slot.admits(snapshot) {
+                slot.snapshot = Some(Arc::clone(snapshot));
                 installed = true;
             }
             installed

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -273,11 +273,6 @@ impl Document {
     /// Clears `pending_seed`: a present reader-visible tree means the off-ingress
     /// reparse's seed has been consumed (the tree it would have produced is now
     /// here), so the next `didChange` seeds from this fresh tree, not a stale seed.
-    pub(crate) fn set_tree(&mut self, tree: Tree) {
-        self.tree = Some(tree);
-        self.pending_seed = None;
-    }
-
     pub(crate) fn invalidate_parse(&mut self) {
         self.tree = None;
         self.pending_seed = None;
@@ -411,12 +406,6 @@ mod tests {
 
         // A parse-result write does not bump.
         let tree = parser.parse("fn main() { }", None).unwrap();
-        doc.set_tree(tree.clone());
-        assert_eq!(
-            doc.content_version(),
-            1,
-            "set_tree is not an input mutation"
-        );
         doc.set_parse_result(Some("rust".to_string()), Some(tree));
         assert_eq!(
             doc.content_version(),
@@ -571,7 +560,7 @@ mod tests {
         assert!(doc.pending_seed().is_some());
 
         let reparsed = parser.parse("fn main() { }", None).unwrap();
-        doc.set_tree(reparsed);
+        doc.set_parse_result(Some("rust".to_string()), Some(reparsed));
 
         assert!(doc.tree().is_some());
         assert!(

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -606,33 +606,6 @@ impl DocumentStore {
         stored
     }
 
-    pub(crate) fn set_parse_result_if_inputs_unchanged(
-        &self,
-        uri: &Url,
-        expected_text: &Arc<str>,
-        expected_incarnation: u64,
-        expected_content_version: u64,
-        language: Option<&str>,
-        tree: Option<Tree>,
-    ) -> bool {
-        let has_tree = tree.is_some();
-        let stored = self.documents.get_mut(uri).is_some_and(|mut doc| {
-            if doc.incarnation() == expected_incarnation
-                && doc.content_version() == expected_content_version
-                && Arc::ptr_eq(&doc.text_arc(), expected_text)
-            {
-                doc.set_parse_result(language.map(String::from), tree);
-                true
-            } else {
-                false
-            }
-        });
-        if stored && has_tree {
-            self.mark_tree_available_if_tracked(uri);
-        }
-        stored
-    }
-
     /// Return the per-document `didChange` serialization lock, creating it on
     /// first use. Callers hold the guard across the document's edit critical
     /// section so concurrent edits to the same document apply in order. See the
@@ -1179,16 +1152,29 @@ mod tests {
         assert_eq!(store.invalidate_all_parses(), vec![uri.clone()]);
 
         let stale_tree = parser.parse("fn main() {}", None).unwrap();
-        assert!(
-            !store.set_parse_result_if_inputs_unchanged(
-                &uri,
-                &pre_reload_text,
+        let stale = store.install_parse(
+            &uri,
+            ParseInputs {
+                text: &pre_reload_text,
+                language_id: Some(Some("rust")),
                 incarnation,
-                0,
-                Some("rust"),
-                Some(stale_tree),
-            ),
-            "a pre-reload parse must not restore the legacy tree"
+                content_version: 0,
+            },
+            Arc::new(super::super::snapshot::ParseSnapshot {
+                text: Arc::clone(&pre_reload_text),
+                tree: Some(stale_tree),
+                language: Some("rust".to_string()),
+                parsed_version: 0,
+                incarnation,
+                injection_regions: None,
+                bridge_regions: None,
+                resolved_regions: None,
+                layer_trees: std::sync::OnceLock::new(),
+            }),
+        );
+        assert!(
+            !stale.attached && !stale.published,
+            "a pre-reload parse must neither restore the legacy tree nor land its snapshot"
         );
 
         let document = store.get(&uri).unwrap();

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -686,9 +686,11 @@ pub(crate) struct SnapshotView {
 /// snapshot's own admission rule decides the publish independently.
 pub(crate) struct ParseInputs<'a> {
     pub(crate) text: &'a str,
-    /// `Some(id)` requires the document's stored language to still be `id`
-    /// (an off-ingress reparse must not attach to a relabelled reopen);
-    /// `None` leaves the language to the snapshot (first-parse detection).
+    /// `Some(expected)` requires the document's stored language to still be
+    /// `expected` (`Some(None)`: still unlabelled) — an off-ingress reparse
+    /// must not attach to a relabelled reopen — and leaves the stored
+    /// language as it is; the tree alone is attached. `None` lets the
+    /// snapshot's language (first-parse detection) become the stored one.
     pub(crate) language_id: Option<Option<&'a str>>,
     pub(crate) incarnation: u64,
     pub(crate) content_version: u64,
@@ -739,7 +741,14 @@ impl DocumentStore {
                 let inputs_unchanged = doc.incarnation() == expected.incarnation
                     && doc.content_version() == expected.content_version
                     && doc.text() == expected.text;
-                let language = snapshot.language.clone();
+                // A checked language is kept as stored: the reparses attach
+                // a tree, they do not relabel (the snapshot carries the
+                // detected name for its own readers). Only the open parse
+                // (`language_id: None`) records what it detected.
+                let language = match expected.language_id {
+                    None => snapshot.language.clone(),
+                    Some(_) => doc.language_id().map(String::from),
+                };
                 let tree = snapshot.tree.clone();
                 let published = doc.publish_snapshot(snapshot);
                 let attached = inputs_unchanged && published;
@@ -844,6 +853,78 @@ mod tests {
                     && s.parsed_version != view.content_version)),
             "the stale snapshot is in the cell, trailing the edited revision"
         );
+    }
+
+    /// A reparse checks the stored language and attaches the tree without
+    /// relabelling the document: detection may resolve a stored `sh` to its
+    /// `bash` base, and the stored id stays `sh` (the snapshot carries the
+    /// detected name). The open parse, which checks nothing, records what it
+    /// detected — the label a client-supplied `text` becomes `markdown`.
+    #[test]
+    fn install_parse_relabels_only_on_the_open_parse() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///label.md").unwrap();
+        let text = "# doc\n";
+        let incarnation = store.insert(uri.clone(), text.to_string(), Some("sh".into()), None);
+        let (expected_text, content_version) = {
+            let doc = store.get(&uri).unwrap();
+            (doc.text_arc(), doc.content_version())
+        };
+        let reparse = store.install_parse(
+            &uri,
+            ParseInputs {
+                text: &expected_text,
+                language_id: Some(Some("sh")),
+                incarnation,
+                content_version,
+            },
+            Arc::new(super::super::snapshot::ParseSnapshot {
+                text: Arc::clone(&expected_text),
+                tree: Some(markdown_tree(text)),
+                language: Some("bash".to_string()),
+                parsed_version: content_version,
+                incarnation,
+                injection_regions: None,
+                bridge_regions: None,
+                resolved_regions: None,
+                layer_trees: std::sync::OnceLock::new(),
+            }),
+        );
+        assert!(reparse.attached && reparse.published);
+        assert_eq!(
+            store.get(&uri).unwrap().language_id(),
+            Some("sh"),
+            "a checked reparse keeps the stored language"
+        );
+
+        let uri2 = Url::parse("file:///label2.md").unwrap();
+        let incarnation2 = store.insert(uri2.clone(), text.to_string(), Some("text".into()), None);
+        let (expected_text2, content_version2) = {
+            let doc = store.get(&uri2).unwrap();
+            (doc.text_arc(), doc.content_version())
+        };
+        let open = store.install_parse(
+            &uri2,
+            ParseInputs {
+                text: &expected_text2,
+                language_id: None,
+                incarnation: incarnation2,
+                content_version: content_version2,
+            },
+            parse_snapshot(
+                &expected_text2,
+                Some(markdown_tree(text)),
+                content_version2,
+                incarnation2,
+            ),
+        );
+        assert!(open.attached && open.published);
+        assert_eq!(
+            store.get(&uri2).unwrap().language_id(),
+            Some("markdown"),
+            "the open parse records the detected language"
+        );
+        assert!(store.get(&uri2).unwrap().tree().is_some());
     }
 
     /// An off-ingress reparse names the language it parsed under; a reopen

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -987,13 +987,45 @@ impl DocumentStore {
     /// document iff `expected` still describes the document, and publish
     /// `snapshot` iff the cell admits it — both under the document's entry
     /// lock, as the one way a parse reaches readers.
+    ///
+    /// The two writes share one `get_mut` guard, so no reader can observe a
+    /// tree without its snapshot (or the reverse) and no path can attach a
+    /// tree without publishing: this is the only attach entry point. The
+    /// snapshot may land while the tree does not — a parse of text an edit
+    /// has moved on from is stale but consistent, which serve-stale readers
+    /// consume (parse-snapshot ADR); the cell's admission rule rejects an
+    /// out-of-order version on its own.
     pub(crate) fn install_parse(
         &self,
-        _uri: &Url,
-        _expected: ParseInputs<'_>,
-        _snapshot: Arc<super::snapshot::ParseSnapshot>,
+        uri: &Url,
+        expected: ParseInputs<'_>,
+        snapshot: Arc<super::snapshot::ParseSnapshot>,
     ) -> ParseInstall {
-        ParseInstall::default()
+        let has_tree = snapshot.tree.is_some();
+        let outcome = self
+            .documents
+            .get_mut(uri)
+            .map_or_else(ParseInstall::default, |mut doc| {
+                let inputs_unchanged = doc.incarnation() == expected.incarnation
+                    && doc.content_version() == expected.content_version
+                    && doc.text() == expected.text
+                    && expected
+                        .language_id
+                        .is_none_or(|language_id| doc.language_id() == language_id);
+                if inputs_unchanged {
+                    doc.set_parse_result(snapshot.language.clone(), snapshot.tree.clone());
+                }
+                ParseInstall {
+                    attached: inputs_unchanged,
+                    published: doc.publish_snapshot(snapshot),
+                }
+            });
+        // A different map (`parse_states`): touched only after the document
+        // guard above is released.
+        if outcome.attached && has_tree {
+            self.mark_tree_available_if_tracked(uri);
+        }
+        outcome
     }
 }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -1095,11 +1095,12 @@ mod tests {
         assert!(store.get(&uri).unwrap().tree().is_none());
         assert_eq!(store.get(&uri).unwrap().language_id(), Some("text"));
         // A language mismatch alone (the document was relabelled in place)
-        // also rejects the tree.
+        // also rejects the tree — and leaves the cell exactly as it was.
         let (reopened_text, reopened_version) = {
             let doc = store.get(&uri).unwrap();
             (doc.text_arc(), doc.content_version())
         };
+        let cell_before = store.latest_snapshot(&uri).and_then(|v| v.slot.snapshot);
         let mismatched = store.install_parse(
             &uri,
             ParseInputs {
@@ -1119,6 +1120,58 @@ mod tests {
             mismatched,
             ParseInstall::default(),
             "a language the document no longer has must neither attach nor publish"
+        );
+        assert!(store.get(&uri).unwrap().tree().is_none());
+        let cell_after = store.latest_snapshot(&uri).and_then(|v| v.slot.snapshot);
+        assert!(
+            match (&cell_before, &cell_after) {
+                (None, None) => true,
+                (Some(then), Some(now)) => Arc::ptr_eq(then, now),
+                _ => false,
+            },
+            "a rejected language must not touch the published snapshot"
+        );
+    }
+
+    /// The text is compared by allocation identity, not content: a parse that
+    /// read a different `Arc<str>` with the same bytes did not read the
+    /// document's own text, so its tree is not attached — while the snapshot,
+    /// judged only by the cell's admission rule, still publishes.
+    #[test]
+    fn install_parse_compares_the_text_by_identity_not_content() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///identity.md").unwrap();
+        let text = "# doc\n";
+        let incarnation =
+            store.insert(uri.clone(), text.to_string(), Some("markdown".into()), None);
+        let content_version = store.get(&uri).unwrap().content_version();
+        let other_allocation: Arc<str> = Arc::from(text);
+        assert_ne!(
+            Arc::as_ptr(&other_allocation),
+            Arc::as_ptr(&store.get(&uri).unwrap().text_arc())
+        );
+        let outcome = store.install_parse(
+            &uri,
+            ParseInputs {
+                text: &other_allocation,
+                language_id: Some(Some("markdown")),
+                incarnation,
+                content_version,
+            },
+            parse_snapshot(
+                &other_allocation,
+                Some(markdown_tree(text)),
+                content_version,
+                incarnation,
+            ),
+        );
+        assert_eq!(
+            outcome,
+            ParseInstall {
+                attached: false,
+                published: true
+            },
+            "equal bytes from another allocation are not the document's text"
         );
         assert!(store.get(&uri).unwrap().tree().is_none());
     }
@@ -1234,7 +1287,11 @@ mod tests {
         // The same parse installed again (a sibling reparse of the same
         // revision): the cell refuses an equal-version tree swap, and the
         // tree must not be re-attached either — nothing lands without its
-        // snapshot.
+        // snapshot. Identity, not just the reported outcome: the stored tree
+        // and the cell's snapshot must be the very ones the first install
+        // landed.
+        let landed_tree = store.get(&uri).unwrap().tree().map(|t| t.root_node().id());
+        let landed_snapshot = store.latest_snapshot(&uri).and_then(|v| v.slot.snapshot);
         let again = store.install_parse(
             &uri,
             ParseInputs {
@@ -1254,6 +1311,19 @@ mod tests {
             again,
             ParseInstall::default(),
             "an equal-version duplicate lands neither tree nor snapshot"
+        );
+        assert_eq!(
+            store.get(&uri).unwrap().tree().map(|t| t.root_node().id()),
+            landed_tree,
+            "the duplicate must not swap the attached tree"
+        );
+        assert!(
+            store
+                .latest_snapshot(&uri)
+                .and_then(|v| v.slot.snapshot)
+                .zip(landed_snapshot)
+                .is_some_and(|(now, then)| Arc::ptr_eq(&now, &then)),
+            "the duplicate must not swap the published snapshot"
         );
 
         // An edit moved the document on: the parse of the old text attaches

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -731,10 +731,16 @@ impl DocumentStore {
         snapshot: Arc<super::snapshot::ParseSnapshot>,
     ) -> ParseInstall {
         let has_tree = snapshot.tree.is_some();
+        let (version, incarnation) = (snapshot.parsed_version, snapshot.incarnation);
+        // The snapshot this install evicts is dropped only after the guard
+        // is released: dropping a tree (and its layer trees) is not free, and
+        // the shard's readers would wait on it otherwise.
+        let mut evicted = None;
         let outcome = self
             .documents
             .get_mut(uri)
             .map_or_else(ParseInstall::default, |mut doc| {
+                evicted = doc.latest_snapshot_slot().snapshot;
                 if expected
                     .language_id
                     .is_some_and(|language_id| doc.language_id() != language_id)
@@ -763,6 +769,13 @@ impl DocumentStore {
                     published,
                 }
             });
+        drop(evicted);
+        if !outcome.published {
+            log::debug!(
+                target: "kakehashi::snapshot",
+                "publish rejected for {uri}: v{version} inc{incarnation}"
+            );
+        }
         // A different map (`parse_states`): touched only after the document
         // guard above is released.
         if outcome.attached && has_tree {

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -943,6 +943,108 @@ mod tests {
         assert!(store.get(&uri2).unwrap().tree().is_some());
     }
 
+    /// A same-language, identical-text reopen draws a new lifetime with the
+    /// revision counter back at zero: the incarnation is the only input that
+    /// tells the prior lifetime's parse apart, in both check modes.
+    #[test]
+    fn install_parse_rejects_the_prior_lifetime_after_an_identical_reopen() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///reopen.md").unwrap();
+        let text = "# doc\n";
+        let incarnation = store.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let (expected_text, content_version) = {
+            let doc = store.get(&uri).unwrap();
+            (doc.text_arc(), doc.content_version())
+        };
+        store.remove(&uri);
+        let reopened = store.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        assert_ne!(reopened, incarnation);
+        assert_eq!(
+            store.get(&uri).unwrap().content_version(),
+            content_version,
+            "the reopened lifetime restarts its revision counter"
+        );
+        // The reopened document's allocation differs, but a prior-lifetime
+        // parse holding the reopened text (a re-read that raced the close)
+        // must still be told apart by the lifetime alone.
+        let reopened_text = store.get(&uri).unwrap().text_arc();
+        for language_id in [Some(Some("markdown")), None] {
+            let stale = store.install_parse(
+                &uri,
+                ParseInputs {
+                    text: &reopened_text,
+                    language_id,
+                    incarnation,
+                    content_version,
+                },
+                parse_snapshot(
+                    &reopened_text,
+                    Some(markdown_tree(text)),
+                    content_version,
+                    incarnation,
+                ),
+            );
+            assert_eq!(
+                stale,
+                ParseInstall::default(),
+                "the prior lifetime's parse must land nothing (mode {language_id:?})"
+            );
+            assert!(store.get(&uri).unwrap().tree().is_none());
+        }
+        drop(expected_text);
+    }
+
+    /// `didClose` drops the parse state before the document; an install that
+    /// lands in that window must not recreate the parse state for a
+    /// document that is going away.
+    #[test]
+    fn install_parse_does_not_recreate_parse_state_dropped_by_a_close() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///closing.md").unwrap();
+        let text = "# doc\n";
+        let incarnation = store.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let (expected_text, content_version) = {
+            let doc = store.get(&uri).unwrap();
+            (doc.text_arc(), doc.content_version())
+        };
+        store.parse_states.remove(&uri);
+        let installed = store.install_parse(
+            &uri,
+            ParseInputs {
+                text: &expected_text,
+                language_id: None,
+                incarnation,
+                content_version,
+            },
+            parse_snapshot(
+                &expected_text,
+                Some(markdown_tree(text)),
+                content_version,
+                incarnation,
+            ),
+        );
+        assert!(installed.attached, "the document itself is still there");
+        assert!(
+            !store.parse_states.contains_key(&uri),
+            "a parse state the close already dropped must not be recreated"
+        );
+    }
+
     /// An off-ingress reparse names the language it parsed under; a reopen
     /// that relabelled the URI (same text, new lifetime and language) must
     /// not receive the tree, and neither must a same-language reopen with

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -634,7 +634,7 @@ impl DocumentStore {
             resolved_regions: None,
             layer_trees: std::sync::OnceLock::new(),
         };
-        doc.publish_snapshot(Arc::new(snapshot));
+        doc.publish_snapshot(&Arc::new(snapshot));
     }
 
     /// The CURRENT snapshot's fully resolved injection regions, or `None` when
@@ -741,9 +741,10 @@ impl DocumentStore {
     ) -> ParseInstall {
         let has_tree = snapshot.tree.is_some();
         let (version, incarnation) = (snapshot.parsed_version, snapshot.incarnation);
-        // The snapshot this install evicts is dropped only after the guard
-        // is released: dropping a tree (and its layer trees) is not free, and
-        // the shard's readers would wait on it otherwise.
+        // The snapshot this install evicts — and `snapshot` itself when the
+        // cell rejects it — is dropped only after the guard is released:
+        // dropping a tree (and its layer trees, its region vectors) is not
+        // free, and the shard's readers would wait on it otherwise.
         let mut evicted = None;
         let outcome = self
             .documents
@@ -768,7 +769,7 @@ impl DocumentStore {
                     Some(_) => doc.language_id().map(String::from),
                 };
                 let tree = snapshot.tree.clone();
-                let published = doc.publish_snapshot(snapshot);
+                let published = doc.publish_snapshot(&snapshot);
                 let attached = inputs_unchanged && published;
                 if attached {
                     doc.set_parse_result(language, tree);
@@ -778,7 +779,10 @@ impl DocumentStore {
                     published,
                 }
             });
+        // Likewise a rejected `snapshot` (still owned here: the publish
+        // borrows) — destroyed only after the guard is released.
         drop(evicted);
+        drop(snapshot);
         if !outcome.published {
             log::debug!(
                 target: "kakehashi::snapshot",
@@ -1456,7 +1460,7 @@ mod tests {
         fn publish(store: &DocumentStore, uri: &Url, snapshot: ParseSnapshot) -> bool {
             store
                 .get(uri)
-                .map(|doc| doc.publish_snapshot(Arc::new(snapshot)))
+                .map(|doc| doc.publish_snapshot(&Arc::new(snapshot)))
                 .unwrap_or(false)
         }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -354,258 +354,6 @@ impl DocumentStore {
         self.ensure_watermark_entry(uri, incarnation);
     }
 
-    /// Store `new_tree` for an **existing** document, but only if its current text
-    /// still equals `expected_text`. Returns `true` iff the tree was stored.
-    ///
-    /// This is the safe persistence path for an **on-demand reader parse** (e.g.
-    /// `kakehashi/node`'s parse fallback). Unlike [`update_document`] it is
-    /// **non-inserting**: a `Vacant` entry — the document was closed while the
-    /// parse ran — is left untouched, so a parse completing after a `didClose`
-    /// cannot **resurrect** the document. Folding the text-equality check into the
-    /// same atomic `get_mut` lock also closes the check-then-write window against a
-    /// concurrent `didChange`: a tree parsed from now-stale text is dropped rather
-    /// than associated with the newer text. The availability update is likewise
-    /// non-inserting (see `mark_tree_available_if_tracked`), so the parse-state
-    /// isn't resurrected either.
-    /// Test-only since the snapshot conversion removed the last production
-    /// caller (the node handlers' on-demand parse); store tests still exercise
-    /// the CAS semantics its non-test siblings share.
-    #[cfg(test)]
-    pub(crate) fn update_tree_if_text_unchanged(
-        &self,
-        uri: &Url,
-        expected_text: &str,
-        new_tree: Tree,
-    ) -> bool {
-        // `get_mut` (non-inserting, borrowed key) rather than `entry(uri.clone())`:
-        // a missing document — a concurrent didClose removed it — yields `None` and
-        // is left untouched, so the parse can't resurrect it, and we avoid cloning
-        // the `Url`. The `RefMut` holds the shard write lock for the whole arm, so
-        // the text check and the tree write are atomic against didChange/didClose.
-        // Text already equals `expected_text`, so only the tree is attached — no
-        // text re-clone.
-        let stored = if let Some(mut doc) = self.documents.get_mut(uri) {
-            if doc.text() == expected_text {
-                doc.set_tree(new_tree);
-                true
-            } else {
-                false
-            }
-        } else {
-            false
-        };
-        if stored {
-            // Non-inserting too: don't recreate a parse-state for a URI a
-            // concurrent didClose may have just dropped.
-            self.mark_tree_available_if_tracked(uri);
-        }
-        stored
-    }
-
-    /// Like [`update_tree_if_text_unchanged`], but additionally requires the
-    /// document's `language_id` to still equal `expected_language_id` **and** its
-    /// open incarnation to still equal `expected_incarnation`.
-    ///
-    /// For the off-ingress edit reparse (`reparse_latest`), whose tree was parsed
-    /// from the text, grammar, and lifetime observed at read time. Three axes,
-    /// checked atomically under the same `get_mut` shard lock as the tree write:
-    /// - **text** rejects a within-lifetime stale parse — a `didChange` landed
-    ///   while parsing, so the tree is of now-superseded text (the scheduler's
-    ///   `dirty` loop reparses the newer text);
-    /// - **language** rejects a close + reopen with identical text but a different
-    ///   `language_id` — a tree parsed by the *old* grammar must not attach to the
-    ///   relabelled document;
-    /// - **incarnation** rejects a close + reopen even with identical text *and*
-    ///   language — the tree belongs to the prior lifetime, and attaching it to
-    ///   the reopened document (then advancing its watermark on the old ticket)
-    ///   would let a new-lifetime reader observe a parse it never requested. This
-    ///   is the [`(incarnation, ticket)`](Document::incarnation) epoch's
-    ///   incarnation half; the text and language checks remain because they guard
-    ///   the orthogonal within-lifetime races above.
-    #[cfg(test)]
-    pub(crate) fn update_tree_if_text_and_language_unchanged(
-        &self,
-        uri: &Url,
-        expected_text: &str,
-        expected_language_id: Option<&str>,
-        expected_incarnation: u64,
-        new_tree: Tree,
-    ) -> bool {
-        let stored = if let Some(mut doc) = self.documents.get_mut(uri) {
-            if doc.incarnation() == expected_incarnation
-                && doc.text() == expected_text
-                && doc.language_id() == expected_language_id
-            {
-                doc.set_tree(new_tree);
-                true
-            } else {
-                false
-            }
-        } else {
-            false
-        };
-        if stored {
-            self.mark_tree_available_if_tracked(uri);
-        }
-        stored
-    }
-
-    pub(crate) fn update_tree_if_parse_inputs_unchanged(
-        &self,
-        uri: &Url,
-        expected_text: &str,
-        expected_language_id: Option<&str>,
-        expected_incarnation: u64,
-        expected_content_version: u64,
-        new_tree: Tree,
-    ) -> bool {
-        let stored = self.documents.get_mut(uri).is_some_and(|mut doc| {
-            if doc.incarnation() == expected_incarnation
-                && doc.content_version() == expected_content_version
-                && doc.text() == expected_text
-                && doc.language_id() == expected_language_id
-            {
-                doc.set_tree(new_tree);
-                true
-            } else {
-                false
-            }
-        });
-        if stored {
-            self.mark_tree_available_if_tracked(uri);
-        }
-        stored
-    }
-
-    /// Like [`update_tree_if_text_and_language_unchanged`], but additionally stores
-    /// the tree only if the document currently has **no** tree. For the off-ingress
-    /// install reparse (`reparse_installed_document`), whose "don't clobber a
-    /// concurrent parse" guard is a `tree.is_some()` pre-check: a parse attaching a
-    /// tree for the same text *between* that pre-check and this write would otherwise
-    /// be overwritten. Folding the `tree.is_none()` check into the same `get_mut`
-    /// shard lock as the text comparison makes the guard atomic.
-    ///
-    /// Carries the same `language` and `incarnation` axes as
-    /// [`update_tree_if_text_and_language_unchanged`], for the same reason: the
-    /// install reparse is off-ingress, so a `didClose` + reopen (possibly relabelling
-    /// the language) can race it. Without these checks the freshly-installed grammar's
-    /// tree could attach to a reopened — even relabelled — document.
-    #[cfg(test)]
-    pub(crate) fn attach_tree_if_absent(
-        &self,
-        uri: &Url,
-        expected_text: &str,
-        expected_language_id: Option<&str>,
-        expected_incarnation: u64,
-        new_tree: Tree,
-    ) -> bool {
-        let stored = if let Some(mut doc) = self.documents.get_mut(uri) {
-            if doc.tree().is_none()
-                && doc.incarnation() == expected_incarnation
-                && doc.text() == expected_text
-                && doc.language_id() == expected_language_id
-            {
-                doc.set_tree(new_tree);
-                true
-            } else {
-                false
-            }
-        } else {
-            false
-        };
-        if stored {
-            self.mark_tree_available_if_tracked(uri);
-        }
-        stored
-    }
-
-    pub(crate) fn attach_tree_if_parse_inputs_unchanged(
-        &self,
-        uri: &Url,
-        expected_text: &str,
-        expected_language_id: Option<&str>,
-        expected_incarnation: u64,
-        expected_content_version: u64,
-        new_tree: Tree,
-    ) -> bool {
-        let stored = self.documents.get_mut(uri).is_some_and(|mut doc| {
-            if doc.tree().is_none()
-                && doc.incarnation() == expected_incarnation
-                && doc.content_version() == expected_content_version
-                && doc.text() == expected_text
-                && doc.language_id() == expected_language_id
-            {
-                doc.set_tree(new_tree);
-                true
-            } else {
-                false
-            }
-        });
-        if stored {
-            self.mark_tree_available_if_tracked(uri);
-        }
-        stored
-    }
-
-    /// Record the didOpen parse's detected `language` + optional `tree` on the
-    /// **existing** document, preserving its already-stored text, but only if the
-    /// text and incarnation observed when the parse read them are unchanged.
-    /// Returns `true` iff it was stored.
-    ///
-    /// For the **off-ingress** didOpen parse ([`parse_document`]). Unlike
-    /// [`update_tree_if_text_and_language_unchanged`] it **sets** the language rather
-    /// than checking it: the open parse refines the language guess stored during
-    /// `didOpen` with content detection (`detect_language`), so it is the writer of the
-    /// authoritative language — there is no language to match against. The two axes
-    /// it does check, atomically under the same `get_mut` shard lock as the write:
-    /// - **text** rejects a within-lifetime stale parse — a `didChange` landed while
-    ///   parsing, so this tree (and its language, possibly shebang-derived) is of
-    ///   now-superseded text; the scheduler's reparse covers the newer text. The
-    ///   check is `Arc::ptr_eq` on the `Arc<str>` the parse captured, **O(1)** — any
-    ///   text mutation (`didChange`) or reopen swaps in a *fresh* allocation, so
-    ///   pointer identity is exactly "same text this parse read" without an O(n)
-    ///   byte compare under the shard write lock (this is the large-document open
-    ///   path). A spurious mismatch could only drop a still-valid tree to a harmless
-    ///   reparse, never attach a stale one;
-    /// - **incarnation** rejects a close + reopen — the result belongs to the prior
-    ///   lifetime and must neither attach its tree nor clobber the reopened
-    ///   document's freshly-inserted language.
-    ///
-    /// **Non-inserting** (`get_mut`): a document a concurrent `didClose` removed is
-    /// left gone, not resurrected — the resurrection-safety the open parse needs once
-    /// it runs off the ingress ticket. Availability is marked only when a tree
-    /// landed (the no-tree paths rely on the caller's `mark_parse_finished(false)`).
-    #[cfg(test)]
-    pub(crate) fn set_parse_result_if_text_and_incarnation_unchanged(
-        &self,
-        uri: &Url,
-        expected_text: &Arc<str>,
-        expected_incarnation: u64,
-        language: Option<&str>,
-        tree: Option<Tree>,
-    ) -> bool {
-        let has_tree = tree.is_some();
-        // `language` is borrowed: the `String` allocation is deferred to inside the
-        // successful CAS branch (`language.map(String::from)`), so a CAS that rejects
-        // (a `didChange`/reopen raced this off-ingress parse) allocates nothing.
-        let stored = if let Some(mut doc) = self.documents.get_mut(uri) {
-            if doc.incarnation() == expected_incarnation
-                && Arc::ptr_eq(&doc.text_arc(), expected_text)
-            {
-                doc.set_parse_result(language.map(String::from), tree);
-                true
-            } else {
-                false
-            }
-        } else {
-            false
-        };
-        if stored && has_tree {
-            self.mark_tree_available_if_tracked(uri);
-        }
-        stored
-    }
-
     /// Return the per-document `didChange` serialization lock, creating it on
     /// first use. Callers hold the guard across the document's edit critical
     /// section so concurrent edits to the same document apply in order. See the
@@ -1033,6 +781,137 @@ mod tests {
         })
     }
 
+    /// An off-ingress reparse names the language it parsed under; a reopen
+    /// that relabelled the URI (same text, new lifetime and language) must
+    /// not receive the tree, and neither must a same-language reopen with
+    /// identical text — the tree belongs to the prior lifetime.
+    #[test]
+    fn install_parse_rejects_a_relabelled_or_reopened_document() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///relabel.md").unwrap();
+        let text = "# doc\n";
+        let incarnation = store.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let (expected_text, content_version) = {
+            let doc = store.get(&uri).unwrap();
+            (doc.text_arc(), doc.content_version())
+        };
+        // Relabelled reopen: same text, different language and lifetime.
+        store.remove(&uri);
+        let reopened = store.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("text".to_string()),
+            None,
+        );
+        assert_ne!(reopened, incarnation);
+        let stale = store.install_parse(
+            &uri,
+            ParseInputs {
+                text: &expected_text,
+                language_id: Some(Some("markdown")),
+                incarnation,
+                content_version,
+            },
+            parse_snapshot(
+                &expected_text,
+                Some(markdown_tree(text)),
+                content_version,
+                incarnation,
+            ),
+        );
+        assert_eq!(stale, ParseInstall::default());
+        assert!(store.get(&uri).unwrap().tree().is_none());
+        assert_eq!(store.get(&uri).unwrap().language_id(), Some("text"));
+        // A language mismatch alone (the document was relabelled in place)
+        // also rejects the tree.
+        let (reopened_text, reopened_version) = {
+            let doc = store.get(&uri).unwrap();
+            (doc.text_arc(), doc.content_version())
+        };
+        let mismatched = store.install_parse(
+            &uri,
+            ParseInputs {
+                text: &reopened_text,
+                language_id: Some(Some("markdown")),
+                incarnation: reopened,
+                content_version: reopened_version,
+            },
+            parse_snapshot(
+                &reopened_text,
+                Some(markdown_tree(text)),
+                reopened_version,
+                reopened,
+            ),
+        );
+        assert!(
+            !mismatched.attached,
+            "a language the document no longer has must not attach"
+        );
+        assert!(store.get(&uri).unwrap().tree().is_none());
+    }
+
+    /// A parse that found a language but produced no tree still records the
+    /// language (host bridging needs only text + language) and publishes a
+    /// tree-less snapshot; a closed document keeps no parse state.
+    #[test]
+    fn install_parse_records_a_language_without_a_tree_and_nothing_after_close() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///no-tree.md").unwrap();
+        let text = "# doc\n";
+        let incarnation = store.insert(uri.clone(), text.to_string(), None, None);
+        let (expected_text, content_version) = {
+            let doc = store.get(&uri).unwrap();
+            (doc.text_arc(), doc.content_version())
+        };
+        let installed = store.install_parse(
+            &uri,
+            ParseInputs {
+                text: &expected_text,
+                language_id: None,
+                incarnation,
+                content_version,
+            },
+            parse_snapshot(&expected_text, None, content_version, incarnation),
+        );
+        assert_eq!(
+            installed,
+            ParseInstall {
+                attached: true,
+                published: true
+            }
+        );
+        let doc = store.get(&uri).unwrap();
+        assert_eq!(doc.language_id(), Some("markdown"));
+        assert!(doc.tree().is_none());
+        drop(doc);
+
+        store.remove(&uri);
+        store.install_parse(
+            &uri,
+            ParseInputs {
+                text: &expected_text,
+                language_id: None,
+                incarnation,
+                content_version,
+            },
+            parse_snapshot(
+                &expected_text,
+                Some(markdown_tree(text)),
+                content_version,
+                incarnation,
+            ),
+        );
+        assert!(
+            store.get(&uri).is_none() && !store.parse_states.contains_key(&uri),
+            "an install into a closed document must not resurrect it or its parse state"
+        );
+    }
+
     /// The one way a parse reaches readers: the legacy tree and the snapshot
     /// land together, or — when the document moved on — neither the tree
     /// (inputs changed) nor a snapshot the cell does not admit.
@@ -1387,439 +1266,6 @@ mod tests {
         );
     }
 
-    fn parse_rust(text: &str) -> Tree {
-        let mut parser = tree_sitter::Parser::new();
-        parser
-            .set_language(&tree_sitter_rust::LANGUAGE.into())
-            .unwrap();
-        parser.parse(text, None).unwrap()
-    }
-
-    #[test]
-    fn update_tree_if_text_unchanged_does_not_resurrect_closed_document() {
-        let store = DocumentStore::new();
-        let uri = Url::parse("file:///closed.rs").unwrap();
-        // No document inserted: models a didClose that removed the entry while an
-        // on-demand reader parse was still running.
-        let stored =
-            store.update_tree_if_text_unchanged(&uri, "fn main() {}", parse_rust("fn main() {}"));
-        assert!(
-            !stored,
-            "must not store a tree for a vacant (closed) document"
-        );
-        assert!(
-            store.get(&uri).is_none(),
-            "the closed document must not be resurrected by the reader parse"
-        );
-    }
-
-    #[test]
-    fn update_tree_if_text_unchanged_stores_when_text_matches() {
-        let store = DocumentStore::new();
-        let uri = Url::parse("file:///live.rs").unwrap();
-        store.insert(
-            uri.clone(),
-            "fn main() {}".to_string(),
-            Some("rust".to_string()),
-            None,
-        );
-
-        let stored =
-            store.update_tree_if_text_unchanged(&uri, "fn main() {}", parse_rust("fn main() {}"));
-        assert!(stored, "a live document with unchanged text gets the tree");
-        assert!(
-            store.get(&uri).unwrap().tree().is_some(),
-            "the parsed tree must be visible after the CAS write"
-        );
-    }
-
-    #[test]
-    fn update_tree_if_text_unchanged_drops_stale_text_parse() {
-        let store = DocumentStore::new();
-        let uri = Url::parse("file:///edited.rs").unwrap();
-        // The document moved on (a didChange landed) while the parse for the old
-        // text was in flight.
-        store.insert(
-            uri.clone(),
-            "fn newer() {}".to_string(),
-            Some("rust".to_string()),
-            None,
-        );
-
-        let stored =
-            store.update_tree_if_text_unchanged(&uri, "fn main() {}", parse_rust("fn main() {}"));
-        assert!(!stored, "a tree parsed from now-stale text must be dropped");
-        assert!(
-            store.get(&uri).unwrap().tree().is_none(),
-            "the stale tree must not overwrite the current text's (still-absent) tree"
-        );
-    }
-
-    #[test]
-    fn attach_tree_if_absent_stores_only_when_no_tree_present() {
-        let store = DocumentStore::new();
-        let uri = Url::parse("file:///absent.rs").unwrap();
-        store.insert(
-            uri.clone(),
-            "fn main() {}".to_string(),
-            Some("rust".to_string()),
-            None,
-        );
-        let incarnation = store.get(&uri).unwrap().incarnation();
-
-        // No tree yet → stores.
-        assert!(store.attach_tree_if_absent(
-            &uri,
-            "fn main() {}",
-            Some("rust"),
-            incarnation,
-            parse_rust("fn main() {}")
-        ));
-        let first = store.get(&uri).unwrap().tree().unwrap().root_node().id();
-
-        // A tree is now present → a second attach must NOT clobber it (the guard
-        // is atomic with the write, unlike a separate tree.is_some() pre-check).
-        assert!(!store.attach_tree_if_absent(
-            &uri,
-            "fn main() {}",
-            Some("rust"),
-            incarnation,
-            parse_rust("fn main() {}")
-        ));
-        assert_eq!(
-            store.get(&uri).unwrap().tree().unwrap().root_node().id(),
-            first,
-            "an existing tree must be preserved, not overwritten"
-        );
-    }
-
-    #[test]
-    fn attach_tree_if_absent_rejects_a_reopen_with_a_fresh_incarnation() {
-        let store = DocumentStore::new();
-        let uri = Url::parse("file:///reinstalled.rs").unwrap();
-        store.insert(
-            uri.clone(),
-            "fn main() {}".to_string(),
-            Some("rust".to_string()),
-            None,
-        );
-        // An install reparse read this lifetime's incarnation, then the document was
-        // closed and reopened (same text + language, no tree yet) while the install
-        // finished.
-        let stale_incarnation = store.get(&uri).unwrap().incarnation();
-        store.remove(&uri);
-        store.insert(
-            uri.clone(),
-            "fn main() {}".to_string(),
-            Some("rust".to_string()),
-            None,
-        );
-
-        assert!(
-            !store.attach_tree_if_absent(
-                &uri,
-                "fn main() {}",
-                Some("rust"),
-                stale_incarnation,
-                parse_rust("fn main() {}")
-            ),
-            "a freshly-installed grammar's tree from the prior lifetime must not \
-             attach to the reopened document"
-        );
-        assert!(
-            store.get(&uri).unwrap().tree().is_none(),
-            "the reopened document keeps no tree from the closed lifetime"
-        );
-    }
-
-    #[test]
-    fn update_tree_if_text_and_language_unchanged_rejects_a_changed_language() {
-        let store = DocumentStore::new();
-        let uri = Url::parse("file:///relabelled.rs").unwrap();
-        // Document was reopened with the same text but a different language_id
-        // while an old-grammar parse was in flight.
-        store.insert(
-            uri.clone(),
-            "fn main() {}".to_string(),
-            Some("ruby".to_string()),
-            None,
-        );
-        let incarnation = store.get(&uri).unwrap().incarnation();
-
-        let stored = store.update_tree_if_text_and_language_unchanged(
-            &uri,
-            "fn main() {}",
-            Some("rust"),
-            incarnation,
-            parse_rust("fn main() {}"),
-        );
-        assert!(
-            !stored,
-            "a tree parsed for a different language must be rejected"
-        );
-        assert!(
-            store.get(&uri).unwrap().tree().is_none(),
-            "the relabelled document keeps no wrong-grammar tree"
-        );
-
-        // Same language and incarnation → stores.
-        assert!(store.update_tree_if_text_and_language_unchanged(
-            &uri,
-            "fn main() {}",
-            Some("ruby"),
-            incarnation,
-            parse_rust("fn main() {}"),
-        ));
-        assert!(store.get(&uri).unwrap().tree().is_some());
-    }
-
-    #[test]
-    fn update_tree_if_text_and_language_unchanged_rejects_a_reopen_with_a_fresh_incarnation() {
-        let store = DocumentStore::new();
-        let uri = Url::parse("file:///reopened.rs").unwrap();
-        store.insert(
-            uri.clone(),
-            "fn main() {}".to_string(),
-            Some("rust".to_string()),
-            None,
-        );
-        // An off-ingress parse read this lifetime's incarnation, then the document
-        // was closed and reopened with identical text and language while the parse
-        // was in flight.
-        let stale_incarnation = store.get(&uri).unwrap().incarnation();
-        store.remove(&uri);
-        store.insert(
-            uri.clone(),
-            "fn main() {}".to_string(),
-            Some("rust".to_string()),
-            None,
-        );
-
-        let stored = store.update_tree_if_text_and_language_unchanged(
-            &uri,
-            "fn main() {}",
-            Some("rust"),
-            stale_incarnation,
-            parse_rust("fn main() {}"),
-        );
-        assert!(
-            !stored,
-            "a tree from the prior lifetime must not attach to the reopened \
-             document even when text and language are identical"
-        );
-        assert!(
-            store.get(&uri).unwrap().tree().is_none(),
-            "the reopened document keeps no tree from the closed lifetime"
-        );
-    }
-
-    #[test]
-    fn attach_tree_if_absent_does_not_resurrect_closed_document() {
-        let store = DocumentStore::new();
-        let uri = Url::parse("file:///closed.rs").unwrap();
-        // No document exists, so the CAS rejects regardless of the expected
-        // language/incarnation (they are never compared on the Vacant path).
-        assert!(!store.attach_tree_if_absent(
-            &uri,
-            "fn main() {}",
-            Some("rust"),
-            1,
-            parse_rust("fn main() {}")
-        ));
-        assert!(
-            store.get(&uri).is_none(),
-            "must not resurrect a closed document"
-        );
-    }
-
-    #[test]
-    fn set_parse_result_if_text_and_incarnation_unchanged_sets_language_and_tree() {
-        let store = DocumentStore::new();
-        let uri = Url::parse("file:///open_refine.rs").unwrap();
-        // didOpen inserted the document with the client language ID ("text"); the
-        // open parse refines it to the content-detected "rust" and attaches a tree.
-        store.insert(
-            uri.clone(),
-            "fn main() {}".to_string(),
-            Some("text".to_string()),
-            None,
-        );
-        let (incarnation, text) = {
-            let doc = store.get(&uri).unwrap();
-            (doc.incarnation(), doc.text_arc())
-        };
-
-        assert!(store.set_parse_result_if_text_and_incarnation_unchanged(
-            &uri,
-            &text,
-            incarnation,
-            Some("rust"),
-            Some(parse_rust("fn main() {}")),
-        ));
-        let doc = store.get(&uri).unwrap();
-        assert_eq!(
-            doc.language_id(),
-            Some("rust"),
-            "the open parse must SET (refine) the language, not just check it"
-        );
-        assert!(doc.tree().is_some(), "the tree must be attached");
-    }
-
-    #[test]
-    fn set_parse_result_if_text_and_incarnation_unchanged_records_language_without_a_tree() {
-        // The parse-failed-but-language-detected path (parse timeout / parser
-        // unavailable / join error): the open parse records the detected language
-        // with NO tree, so a host-bridged document keeps its language after a parse
-        // failure rather than being nulled out.
-        let store = DocumentStore::new();
-        let uri = Url::parse("file:///open_lang_no_tree.rs").unwrap();
-        store.insert(
-            uri.clone(),
-            "fn main() {}".to_string(),
-            Some("text".to_string()),
-            None,
-        );
-        let (incarnation, text) = {
-            let doc = store.get(&uri).unwrap();
-            (doc.incarnation(), doc.text_arc())
-        };
-
-        assert!(store.set_parse_result_if_text_and_incarnation_unchanged(
-            &uri,
-            &text,
-            incarnation,
-            Some("rust"),
-            None,
-        ));
-        let doc = store.get(&uri).unwrap();
-        assert_eq!(
-            doc.language_id(),
-            Some("rust"),
-            "the detected language is recorded even though the parse produced no tree"
-        );
-        assert!(
-            doc.tree().is_none(),
-            "no tree lands on the parse-failure path"
-        );
-    }
-
-    #[test]
-    fn set_parse_result_if_text_and_incarnation_unchanged_rejects_stale_text() {
-        let store = DocumentStore::new();
-        let uri = Url::parse("file:///open_stale_text.rs").unwrap();
-        store.insert(
-            uri.clone(),
-            "fn main() {}".to_string(),
-            Some("rust".to_string()),
-            None,
-        );
-        // Capture the text the parse "read" (its Arc identity) before the edit.
-        let (incarnation, text) = {
-            let doc = store.get(&uri).unwrap();
-            (doc.incarnation(), doc.text_arc())
-        };
-        // A didChange landed mid-parse, moving the text on (same lifetime).
-        store.apply_edit_clearing_tree(&uri, "fn newer() {}".to_string(), &[]);
-
-        let stored = store.set_parse_result_if_text_and_incarnation_unchanged(
-            &uri,
-            &text,
-            incarnation,
-            Some("rust"),
-            Some(parse_rust("fn main() {}")),
-        );
-        assert!(!stored, "a tree parsed from now-stale text must be dropped");
-        assert!(
-            store.get(&uri).unwrap().tree().is_none(),
-            "the stale tree must not overwrite the newer text's (still-absent) tree"
-        );
-    }
-
-    #[test]
-    fn set_parse_result_if_text_and_incarnation_unchanged_rejects_a_reopen() {
-        let store = DocumentStore::new();
-        let uri = Url::parse("file:///open_reopen.rs").unwrap();
-        store.insert(
-            uri.clone(),
-            "fn main() {}".to_string(),
-            Some("rust".to_string()),
-            None,
-        );
-        // The open parse read this lifetime's incarnation + text, then a didClose +
-        // reopen (identical text + language) raced it while parsing.
-        let (stale_incarnation, stale_text) = {
-            let doc = store.get(&uri).unwrap();
-            (doc.incarnation(), doc.text_arc())
-        };
-        store.remove(&uri);
-        store.insert(
-            uri.clone(),
-            "fn main() {}".to_string(),
-            Some("rust".to_string()),
-            None,
-        );
-
-        let stored = store.set_parse_result_if_text_and_incarnation_unchanged(
-            &uri,
-            &stale_text,
-            stale_incarnation,
-            Some("rust"),
-            Some(parse_rust("fn main() {}")),
-        );
-        assert!(
-            !stored,
-            "a tree from the prior lifetime must not attach to the reopened document"
-        );
-        assert!(
-            store.get(&uri).unwrap().tree().is_none(),
-            "the reopened document keeps no tree from the closed lifetime"
-        );
-    }
-
-    #[test]
-    fn set_parse_result_if_text_and_incarnation_unchanged_does_not_resurrect_closed_document() {
-        let store = DocumentStore::new();
-        let uri = Url::parse("file:///open_closed.rs").unwrap();
-        // No document exists (a didClose removed it before the off-ingress parse ran).
-        assert!(!store.set_parse_result_if_text_and_incarnation_unchanged(
-            &uri,
-            &Arc::<str>::from("fn main() {}"),
-            1,
-            Some("rust"),
-            Some(parse_rust("fn main() {}")),
-        ));
-        assert!(
-            store.get(&uri).is_none(),
-            "the off-ingress open parse must not resurrect a closed document"
-        );
-    }
-
-    #[test]
-    fn update_tree_if_text_unchanged_does_not_recreate_parse_state_after_close() {
-        let store = DocumentStore::new();
-        let uri = Url::parse("file:///race.rs").unwrap();
-        store.insert(
-            uri.clone(),
-            "fn main() {}".to_string(),
-            Some("rust".to_string()),
-            None,
-        );
-        // `remove` (didClose) drops `parse_states` before `documents`; model the
-        // window where the parse-state is already gone but our in-flight CAS still
-        // sees the document.
-        store.parse_states.remove(&uri);
-
-        let stored =
-            store.update_tree_if_text_unchanged(&uri, "fn main() {}", parse_rust("fn main() {}"));
-        assert!(stored, "the still-present document gets the tree");
-        assert!(
-            store.parse_states.get(&uri).is_none(),
-            "the availability update must not recreate a parse-state for a URI whose \
-             parse-state a concurrent close already removed"
-        );
-    }
-
-    /// Read the published watermark ticket for a URI (test-only; the field is private).
     fn watermark_of(store: &DocumentStore, uri: &Url) -> Option<u64> {
         store.watermarks.get(uri).map(|s| s.borrow().ticket)
     }

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -681,9 +681,13 @@ pub(crate) struct SnapshotView {
 }
 
 /// What a parse pass expects the document to still be when its result is
-/// installed: the exact inputs it parsed. A document that moved on (an edit,
-/// a close and reopen, a relabelled language) rejects the legacy tree; the
-/// snapshot's own admission rule decides the publish independently.
+/// installed: the exact inputs it parsed. A relabelled language rejects the
+/// whole install; otherwise the cell's admission rule decides the publish,
+/// and the legacy tree is attached only when the snapshot was admitted AND
+/// the text, incarnation and content version are unchanged — so a document
+/// that moved on (an edit, a close and reopen) can still publish an older
+/// snapshot without attaching its tree, and an equal-version sibling parse
+/// attaches nothing even with unchanged inputs.
 pub(crate) struct ParseInputs<'a> {
     /// The exact text allocation the parse read (`Document::text_arc`);
     /// compared by identity, not content — this is the large-document open
@@ -702,9 +706,11 @@ pub(crate) struct ParseInputs<'a> {
 /// The outcome of [`DocumentStore::install_parse`].
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ParseInstall {
-    /// The legacy tree (and language) were attached: the inputs were unchanged.
+    /// The legacy tree (and language) were attached: the inputs were
+    /// unchanged and the snapshot was admitted (implies `published`).
     pub(crate) attached: bool,
-    /// The snapshot landed in the document's cell: the slot admitted it.
+    /// The snapshot landed in the document's cell: the language matched and
+    /// the slot admitted it.
     pub(crate) published: bool,
 }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -685,7 +685,10 @@ pub(crate) struct SnapshotView {
 /// a close and reopen, a relabelled language) rejects the legacy tree; the
 /// snapshot's own admission rule decides the publish independently.
 pub(crate) struct ParseInputs<'a> {
-    pub(crate) text: &'a str,
+    /// The exact text allocation the parse read (`Document::text_arc`);
+    /// compared by identity, not content — this is the large-document open
+    /// path and the compare runs under the shard's write guard.
+    pub(crate) text: &'a Arc<str>,
     /// `Some(expected)` requires the document's stored language to still be
     /// `expected` (`Some(None)`: still unlabelled) — an off-ingress reparse
     /// must not attach to a relabelled reopen — and leaves the stored
@@ -740,7 +743,7 @@ impl DocumentStore {
                 }
                 let inputs_unchanged = doc.incarnation() == expected.incarnation
                     && doc.content_version() == expected.content_version
-                    && doc.text() == expected.text;
+                    && Arc::ptr_eq(&doc.text_arc(), expected.text);
                 // A checked language is kept as stored: the reparses attach
                 // a tree, they do not relabel (the snapshot carries the
                 // detected name for its own readers). Only the open parse

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -959,9 +959,169 @@ pub(crate) struct SnapshotView {
     pub(crate) content_version: u64,
 }
 
+/// What a parse pass expects the document to still be when its result is
+/// installed: the exact inputs it parsed. A document that moved on (an edit,
+/// a close and reopen, a relabelled language) rejects the legacy tree; the
+/// snapshot's own admission rule decides the publish independently.
+pub(crate) struct ParseInputs<'a> {
+    pub(crate) text: &'a str,
+    /// `Some(id)` requires the document's stored language to still be `id`
+    /// (an off-ingress reparse must not attach to a relabelled reopen);
+    /// `None` leaves the language to the snapshot (first-parse detection).
+    pub(crate) language_id: Option<Option<&'a str>>,
+    pub(crate) incarnation: u64,
+    pub(crate) content_version: u64,
+}
+
+/// The outcome of [`DocumentStore::install_parse`].
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ParseInstall {
+    /// The legacy tree (and language) were attached: the inputs were unchanged.
+    pub(crate) attached: bool,
+    /// The snapshot landed in the document's cell: the slot admitted it.
+    pub(crate) published: bool,
+}
+
+impl DocumentStore {
+    /// Install a parse result: attach its tree (and language) to the legacy
+    /// document iff `expected` still describes the document, and publish
+    /// `snapshot` iff the cell admits it — both under the document's entry
+    /// lock, as the one way a parse reaches readers.
+    pub(crate) fn install_parse(
+        &self,
+        _uri: &Url,
+        _expected: ParseInputs<'_>,
+        _snapshot: Arc<super::snapshot::ParseSnapshot>,
+    ) -> ParseInstall {
+        ParseInstall::default()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn markdown_tree(text: &str) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_md::LANGUAGE.into())
+            .unwrap();
+        parser.parse(text, None).unwrap()
+    }
+
+    fn parse_snapshot(
+        text: &Arc<str>,
+        tree: Option<tree_sitter::Tree>,
+        parsed_version: u64,
+        incarnation: u64,
+    ) -> Arc<super::super::snapshot::ParseSnapshot> {
+        Arc::new(super::super::snapshot::ParseSnapshot {
+            text: Arc::clone(text),
+            tree,
+            language: Some("markdown".to_string()),
+            parsed_version,
+            incarnation,
+            injection_regions: None,
+            bridge_regions: None,
+            resolved_regions: None,
+            layer_trees: std::sync::OnceLock::new(),
+        })
+    }
+
+    /// The one way a parse reaches readers: the legacy tree and the snapshot
+    /// land together, or — when the document moved on — neither the tree
+    /// (inputs changed) nor a snapshot the cell does not admit.
+    #[test]
+    fn install_parse_lands_tree_and_snapshot_together_or_not_at_all() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///install.md").unwrap();
+        let text = "# doc\n";
+        let incarnation = store.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let (expected_text, content_version) = {
+            let doc = store.get(&uri).unwrap();
+            (doc.text_arc(), doc.content_version())
+        };
+
+        let outcome = store.install_parse(
+            &uri,
+            ParseInputs {
+                text: &expected_text,
+                language_id: Some(Some("markdown")),
+                incarnation,
+                content_version,
+            },
+            parse_snapshot(
+                &expected_text,
+                Some(markdown_tree(text)),
+                content_version,
+                incarnation,
+            ),
+        );
+        assert_eq!(
+            outcome,
+            ParseInstall {
+                attached: true,
+                published: true
+            }
+        );
+        assert!(store.get(&uri).unwrap().tree().is_some(), "tree attached");
+        assert!(
+            store.latest_snapshot(&uri).is_some_and(|view| view
+                .slot
+                .snapshot
+                .as_ref()
+                .is_some_and(|s| s.parsed_version == view.content_version && s.tree.is_some())),
+            "snapshot published and current"
+        );
+
+        // An edit moved the document on: the parse of the old text attaches
+        // nothing, and its snapshot (an older version) is not admitted.
+        store.update_document(uri.clone(), "# doc edited\n".to_string(), None);
+        let stale = store.install_parse(
+            &uri,
+            ParseInputs {
+                text: &expected_text,
+                language_id: Some(Some("markdown")),
+                incarnation,
+                content_version,
+            },
+            parse_snapshot(
+                &expected_text,
+                Some(markdown_tree(text)),
+                content_version,
+                incarnation,
+            ),
+        );
+        assert_eq!(stale, ParseInstall::default());
+        assert!(
+            store.get(&uri).unwrap().tree().is_none(),
+            "a stale parse must not attach to the edited document"
+        );
+
+        // A closed document: nothing to install into.
+        store.remove(&uri);
+        let gone = store.install_parse(
+            &uri,
+            ParseInputs {
+                text: &expected_text,
+                language_id: None,
+                incarnation,
+                content_version,
+            },
+            parse_snapshot(
+                &expected_text,
+                Some(markdown_tree(text)),
+                content_version,
+                incarnation,
+            ),
+        );
+        assert_eq!(gone, ParseInstall::default());
+    }
 
     #[test]
     fn reload_invalidation_clears_open_document_trees() {

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -709,13 +709,16 @@ impl DocumentStore {
     /// `snapshot` iff the cell admits it — both under the document's entry
     /// lock, as the one way a parse reaches readers.
     ///
-    /// The two writes share one `get_mut` guard, so no reader can observe a
-    /// tree without its snapshot (or the reverse) and no path can attach a
-    /// tree without publishing: this is the only attach entry point. The
-    /// snapshot may land while the tree does not — a parse of text an edit
-    /// has moved on from is stale but consistent, which serve-stale readers
-    /// consume (parse-snapshot ADR); the cell's admission rule rejects an
-    /// out-of-order version on its own.
+    /// The two writes share one `get_mut` guard, and the tree is attached
+    /// only when the snapshot was admitted, so no reader can observe a tree
+    /// whose snapshot is not in the cell and no path can attach a tree
+    /// without publishing: this is the only attach entry point. The reverse
+    /// is allowed — the snapshot may land while the tree does not, when the
+    /// inputs moved on: a parse of text an edit has moved on from is stale
+    /// but consistent, which serve-stale readers consume (parse-snapshot
+    /// ADR), and the cell's admission rule rejects an out-of-order version on
+    /// its own. A language check that fails rejects both: the tree belongs
+    /// to a language the document no longer has, and so does the snapshot.
     pub(crate) fn install_parse(
         &self,
         uri: &Url,
@@ -727,18 +730,25 @@ impl DocumentStore {
             .documents
             .get_mut(uri)
             .map_or_else(ParseInstall::default, |mut doc| {
+                if expected
+                    .language_id
+                    .is_some_and(|language_id| doc.language_id() != language_id)
+                {
+                    return ParseInstall::default();
+                }
                 let inputs_unchanged = doc.incarnation() == expected.incarnation
                     && doc.content_version() == expected.content_version
-                    && doc.text() == expected.text
-                    && expected
-                        .language_id
-                        .is_none_or(|language_id| doc.language_id() == language_id);
-                if inputs_unchanged {
-                    doc.set_parse_result(snapshot.language.clone(), snapshot.tree.clone());
+                    && doc.text() == expected.text;
+                let language = snapshot.language.clone();
+                let tree = snapshot.tree.clone();
+                let published = doc.publish_snapshot(snapshot);
+                let attached = inputs_unchanged && published;
+                if attached {
+                    doc.set_parse_result(language, tree);
                 }
                 ParseInstall {
-                    attached: inputs_unchanged,
-                    published: doc.publish_snapshot(snapshot),
+                    attached,
+                    published,
                 }
             });
         // A different map (`parse_states`): touched only after the document
@@ -779,6 +789,61 @@ mod tests {
             resolved_regions: None,
             layer_trees: std::sync::OnceLock::new(),
         })
+    }
+
+    /// A parse of text an edit has moved on from — before that edit's own
+    /// reparse published — lands its snapshot as stale but consistent (the
+    /// cell admits a newer version than it holds) while the tree, which
+    /// would be a reader-visible tree of the wrong text, does not attach.
+    #[test]
+    fn install_parse_publishes_a_stale_but_consistent_snapshot_without_attaching() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///stale.md").unwrap();
+        let text = "# doc\n";
+        let incarnation = store.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let (expected_text, content_version) = {
+            let doc = store.get(&uri).unwrap();
+            (doc.text_arc(), doc.content_version())
+        };
+        // The edit lands first; its reparse has not published yet.
+        store.update_document(uri.clone(), "# doc edited\n".to_string(), None);
+        let outcome = store.install_parse(
+            &uri,
+            ParseInputs {
+                text: &expected_text,
+                language_id: Some(Some("markdown")),
+                incarnation,
+                content_version,
+            },
+            parse_snapshot(
+                &expected_text,
+                Some(markdown_tree(text)),
+                content_version,
+                incarnation,
+            ),
+        );
+        assert_eq!(
+            outcome,
+            ParseInstall {
+                attached: false,
+                published: true
+            }
+        );
+        assert!(store.get(&uri).unwrap().tree().is_none());
+        assert!(
+            store.latest_snapshot(&uri).is_some_and(|view| view
+                .slot
+                .snapshot
+                .as_ref()
+                .is_some_and(|s| s.parsed_version == content_version
+                    && s.parsed_version != view.content_version)),
+            "the stale snapshot is in the cell, trailing the edited revision"
+        );
     }
 
     /// An off-ingress reparse names the language it parsed under; a reopen
@@ -848,9 +913,10 @@ mod tests {
                 reopened,
             ),
         );
-        assert!(
-            !mismatched.attached,
-            "a language the document no longer has must not attach"
+        assert_eq!(
+            mismatched,
+            ParseInstall::default(),
+            "a language the document no longer has must neither attach nor publish"
         );
         assert!(store.get(&uri).unwrap().tree().is_none());
     }
@@ -961,6 +1027,31 @@ mod tests {
                 .as_ref()
                 .is_some_and(|s| s.parsed_version == view.content_version && s.tree.is_some())),
             "snapshot published and current"
+        );
+
+        // The same parse installed again (a sibling reparse of the same
+        // revision): the cell refuses an equal-version tree swap, and the
+        // tree must not be re-attached either — nothing lands without its
+        // snapshot.
+        let again = store.install_parse(
+            &uri,
+            ParseInputs {
+                text: &expected_text,
+                language_id: Some(Some("markdown")),
+                incarnation,
+                content_version,
+            },
+            parse_snapshot(
+                &expected_text,
+                Some(markdown_tree(text)),
+                content_version,
+                incarnation,
+            ),
+        );
+        assert_eq!(
+            again,
+            ParseInstall::default(),
+            "an equal-version duplicate lands neither tree nor snapshot"
         );
 
         // An edit moved the document on: the parse of the old text attaches

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -150,8 +150,8 @@ impl DocumentStore {
     /// Unlike [`update_tree_availability`] this does **not** create the entry
     /// (`get`, not `parse_sender`'s get-or-insert). For a live document the entry
     /// always exists (created on insert), so this is equivalent; but for the
-    /// non-inserting reader CAS it avoids resurrecting a parse-state for a URI that
-    /// a concurrent `didClose` removed — `remove` drops `parse_states` first, so a
+    /// non-inserting `install_parse` (which may run after a `didClose`) it avoids
+    /// resurrecting a parse-state for a URI that a concurrent `didClose` removed — `remove` drops `parse_states` first, so a
     /// get-or-insert here would recreate a ghost `has_tree = true` for a closed
     /// document. Holding the `Ref` serializes against that `remove`.
     fn mark_tree_available_if_tracked(&self, uri: &Url) {
@@ -712,7 +712,10 @@ impl DocumentStore {
     /// Install a parse result: attach its tree (and language) to the legacy
     /// document iff `expected` still describes the document, and publish
     /// `snapshot` iff the cell admits it — both under the document's entry
-    /// lock, as the one way a parse reaches readers.
+    /// lock, as the one way a parse reaches readers. The `parse_states`
+    /// `has_tree` flip runs after that guard is released (a different map);
+    /// it is non-inserting, so a `didClose` between the two leaves no ghost
+    /// entry.
     ///
     /// The two writes share one `get_mut` guard, and the tree is attached
     /// only when the snapshot was admitted, so no reader can observe a tree

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -273,9 +273,9 @@ impl CacheCoordinator {
         // the token handlers use.
         let generation = self.semantic_token_generation();
         // Entry half of the mint reconciliation (parse-snapshot ADR §3):
-        // populate runs post-CAS but an edit can land DURING this pass and
-        // shift the live-coordinate NodeTracker, making this pass's tree
-        // coordinates stale. `entry_mint_epoch` (latched by the caller,
+        // populate runs before the parse is installed, on the tree value, but
+        // an edit can land DURING this pass and shift the live-coordinate
+        // NodeTracker, making this pass's tree coordinates stale. `entry_mint_epoch` (latched by the caller,
         // BEFORE its liveness validation — see the doc comment) is
         // re-checked inside every tracker-mutating step below (the batch
         // mint and the commit), so a stale pass mints nothing and clobbers

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -679,31 +679,27 @@ mod tests {
         let mut parser = tree_sitter::Parser::new();
         parser.set_language(&language).unwrap();
         let tree = parser.parse(text, None).unwrap();
-        assert!(documents.set_parse_result_if_inputs_unchanged(
+        let installed = documents.install_parse(
             &uri,
-            &expected_text,
-            incarnation,
-            content_version,
-            Some("markdown"),
-            Some(tree.clone()),
-        ));
-        let snapshot = crate::document::snapshot::ParseSnapshot {
-            text: expected_text,
-            tree: Some(tree),
-            language: Some("markdown".to_string()),
-            parsed_version: content_version,
-            incarnation,
-            injection_regions: None,
-            bridge_regions: None,
-            resolved_regions: None,
-            layer_trees: std::sync::OnceLock::new(),
-        };
-        assert!(
-            documents
-                .get(&uri)
-                .unwrap()
-                .publish_snapshot(std::sync::Arc::new(snapshot))
+            crate::document::ParseInputs {
+                text: &expected_text,
+                language_id: Some(Some("markdown")),
+                incarnation,
+                content_version,
+            },
+            std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
+                text: std::sync::Arc::clone(&expected_text),
+                tree: Some(tree),
+                language: Some("markdown".to_string()),
+                parsed_version: content_version,
+                incarnation,
+                injection_regions: None,
+                bridge_regions: None,
+                resolved_regions: None,
+                layer_trees: std::sync::OnceLock::new(),
+            }),
         );
+        assert!(installed.attached && installed.published);
 
         assert!(
             tokio::time::timeout(std::time::Duration::from_secs(1), &mut wait)
@@ -733,14 +729,31 @@ mod tests {
         let mut parser = tree_sitter::Parser::new();
         parser.set_language(&language).unwrap();
         let tree = parser.parse(text, None).unwrap();
-        assert!(server.documents.set_parse_result_if_inputs_unchanged(
-            &uri,
-            &expected_text,
-            incarnation,
-            content_version,
-            Some("markdown"),
-            Some(tree),
-        ));
+        assert!(
+            server
+                .documents
+                .install_parse(
+                    &uri,
+                    crate::document::ParseInputs {
+                        text: &expected_text,
+                        language_id: Some(Some("markdown")),
+                        incarnation,
+                        content_version,
+                    },
+                    std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
+                        text: std::sync::Arc::clone(&expected_text),
+                        tree: Some(tree),
+                        language: Some("markdown".to_string()),
+                        parsed_version: content_version,
+                        incarnation,
+                        injection_regions: None,
+                        bridge_regions: None,
+                        resolved_regions: None,
+                        layer_trees: std::sync::OnceLock::new(),
+                    }),
+                )
+                .attached
+        );
 
         assert!(document_matches_lineage(
             &server.documents.get(&uri).unwrap(),

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -3541,7 +3541,7 @@ mod tests {
             .documents
             .get(&publishing)
             .map(|doc| {
-                doc.publish_snapshot(std::sync::Arc::new(
+                doc.publish_snapshot(&std::sync::Arc::new(
                     crate::document::snapshot::ParseSnapshot {
                         text: std::sync::Arc::from(text),
                         tree: Some(tree),

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -974,7 +974,7 @@ mod tests {
             .documents
             .get(&current)
             .map(|doc| {
-                doc.publish_snapshot(Arc::new(crate::document::snapshot::ParseSnapshot {
+                doc.publish_snapshot(&Arc::new(crate::document::snapshot::ParseSnapshot {
                     text: Arc::from(text),
                     tree: Some(tree),
                     language: Some("markdown".to_string()),
@@ -1131,7 +1131,7 @@ mod tests {
             .documents
             .get(uri)
             .map(|doc| {
-                doc.publish_snapshot(std::sync::Arc::new(
+                doc.publish_snapshot(&std::sync::Arc::new(
                     crate::document::snapshot::ParseSnapshot {
                         text: std::sync::Arc::from(text),
                         tree: Some(tree),
@@ -1207,7 +1207,7 @@ mod tests {
                 .documents
                 .get(&uri)
                 .map(|doc| {
-                    doc.publish_snapshot(std::sync::Arc::new(
+                    doc.publish_snapshot(&std::sync::Arc::new(
                         crate::document::snapshot::ParseSnapshot {
                             text: std::sync::Arc::from(text),
                             tree: Some(tree.clone()),
@@ -1450,7 +1450,7 @@ mod tests {
             .documents
             .get(&uri)
             .map(|doc| {
-                doc.publish_snapshot(std::sync::Arc::new(
+                doc.publish_snapshot(&std::sync::Arc::new(
                     crate::document::snapshot::ParseSnapshot {
                         text: std::sync::Arc::from(text),
                         // With a tree: a tree-less snapshot would not be
@@ -1619,7 +1619,7 @@ mod tests {
             .documents
             .get(&uri)
             .map(|doc| {
-                doc.publish_snapshot(std::sync::Arc::new(
+                doc.publish_snapshot(&std::sync::Arc::new(
                     crate::document::snapshot::ParseSnapshot {
                         text: std::sync::Arc::from(text),
                         tree: Some(tree),

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -333,8 +333,9 @@ impl ParseCoordinator {
         //   the tracker at `(0, epoch+1)` — indistinguishable from a
         //   reopen's first mint, so the latch alone cannot refuse it; the
         //   reopen case fails the incarnation check);
-        // - currency (`content_version` unchanged since the parse's CAS —
-        //   an edit that already landed makes this pass's tree stale).
+        // - currency (`content_version` unchanged since the parse captured
+        //   its inputs — an edit that already landed makes this pass's tree
+        //   stale).
         // Anything landing AFTER the lock drops is caught by the latch
         // re-check inside the batch mint / commit (`cleanup` bumps the
         // epoch before it removes; an edit-shift bumps the generation).

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -291,46 +291,6 @@ impl ParseCoordinator {
         }
     }
 
-    /// Publish a parse pass's [`ParseSnapshot`](crate::document::snapshot::ParseSnapshot)
-    /// into the document's snapshot cell (parse-snapshot ADR §2, Stage-2
-    /// dual-write). The cell's own guard (incarnation + strict version) decides
-    /// admission; a document a `didClose` already removed simply has no cell to
-    /// publish into (its detached cell holds the closed sentinel). Returns
-    /// whether the publish landed.
-    ///
-    /// During the dual-write stage this runs alongside the legacy tree CAS and
-    /// may admit a snapshot the legacy CAS rejects — deliberately: a parse of
-    /// text an edit has since moved on from is *stale but consistent*, exactly
-    /// what serve-stale readers consume, while the legacy tree must stay
-    /// current-text-only. No single reader mixes the two sources (cell readers
-    /// consume the snapshot's own (text, tree); legacy readers snapshot the
-    /// store under one shard Ref), and every parse pass runs the legacy CAS
-    /// BEFORE this publish: a legacy-tree reader woken by the publish (the
-    /// explicit-action waiters read `doc.snapshot()` after
-    /// `wait_for_current_snapshot`) therefore finds the store already
-    /// settled — either the tree attached, or a racing edit rejected the CAS,
-    /// in which case the cell is not Current for that reader either. The
-    /// legacy store and its remaining readers go away in Stage 3.
-    fn publish_parse_snapshot(
-        &self,
-        uri: &Url,
-        snapshot: crate::document::snapshot::ParseSnapshot,
-    ) -> bool {
-        let (version, incarnation) = (snapshot.parsed_version, snapshot.incarnation);
-        let landed = self
-            .documents
-            .get(uri)
-            .map(|doc| doc.publish_snapshot(std::sync::Arc::new(snapshot)))
-            .unwrap_or(false);
-        if !landed {
-            log::debug!(
-                target: "kakehashi::snapshot",
-                "publish rejected for {uri}: v{version} inc{incarnation}"
-            );
-        }
-        landed
-    }
-
     /// Run `CacheCoordinator::populate_injections` as a compute-pool work-unit
     /// and await it.
     ///
@@ -862,20 +822,13 @@ impl ParseCoordinator {
             // when the tree actually landed, so a `didClose` racing this
             // reparse can't leave stale injection entries for a gone
             // document. (`Tree` clone is a cheap refcount bump.)
-            let stored = self.documents.attach_tree_if_parse_inputs_unchanged(
-                &uri,
-                &text,
-                expected_language_id.as_deref(),
-                expected_incarnation,
-                content_version,
-                tree.clone(),
-            );
-            // Populate BEFORE the publish so the discovery rides the snapshot
-            // (ADR §3); the cell guard still rejects a stale lifetime or an
-            // out-of-order version at publish. A rejected CAS skips populate —
-            // the snapshot still publishes as stale-but-consistent.
-            let regions = if stored {
-                self.populate_injections_on_pool(
+            // Populate BEFORE the install so the discovery rides the snapshot
+            // (ADR §3); populate guards itself against a pass whose text or
+            // lifetime moved on, and the install then lands the tree and the
+            // snapshot together — the cell still rejects a stale lifetime or
+            // an out-of-order version on its own.
+            let regions = self
+                .populate_injections_on_pool(
                     uri.clone(),
                     text.clone(),
                     tree.clone(),
@@ -884,13 +837,16 @@ impl ParseCoordinator {
                     content_version,
                     version_cancel.clone(),
                 )
-                .await
-            } else {
-                PopulatedSnapshotRegions::default()
-            };
-            let published = self.publish_parse_snapshot(
+                .await;
+            let installed = self.documents.install_parse(
                 &uri,
-                crate::document::snapshot::ParseSnapshot {
+                crate::document::ParseInputs {
+                    text: &text,
+                    language_id: Some(expected_language_id.as_deref()),
+                    incarnation: expected_incarnation,
+                    content_version,
+                },
+                std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
                     text: text.clone(),
                     tree: Some(tree.clone()),
                     language: Some(language_name.clone()),
@@ -900,19 +856,19 @@ impl ParseCoordinator {
                     bridge_regions: regions.bridge_regions,
                     resolved_regions: regions.resolved_regions,
                     layer_trees: std::sync::OnceLock::new(),
-                },
+                }),
             );
             // Serve-stale's heal signal, mirroring reparse_latest: a token
             // request answered empty (or 15s-capped) while the install was
             // still compiling has no lineage to re-drive it — without the
             // refresh, a slow install leaves the document unhighlighted
             // until an incidental edit.
-            if published {
+            if installed.published {
                 events.push(crate::language::LanguageEvent::semantic_tokens_refresh(
                     language_name.clone(),
                 ));
             }
-            if stored {
+            if installed.attached {
                 break;
             }
             // CAS rejected: the text moved under us (a concurrent `didChange`).
@@ -1067,22 +1023,14 @@ impl ParseCoordinator {
             // identical-text reopen — the tree belongs to the prior lifetime
             // and must not attach to the reopened document (nor let the
             // watermark advance below run on the old lifetime's ticket).
-            let stored = self.documents.update_tree_if_parse_inputs_unchanged(
-                uri,
-                &text,
-                language_id.as_deref(),
-                incarnation,
-                content_version,
-                tree.clone(),
-            );
-            // Populate BEFORE the publish so the derived discovery rides the
+            // Populate BEFORE the install so the derived discovery rides the
             // snapshot (ADR §3, don't-discover-twice); readers keep serving the
-            // previous snapshot for populate's duration. A rejected legacy CAS
-            // (the text moved on mid-parse) skips populate — the snapshot still
-            // publishes as stale-but-consistent (its readers discover inline;
-            // the scheduler's dirty loop is already reparsing the newer text).
-            let regions = if stored {
-                self.populate_injections_on_pool(
+            // previous snapshot for populate's duration. Populate guards itself
+            // against a pass whose text moved on mid-parse (the scheduler's
+            // dirty loop is already reparsing the newer text), and the install
+            // then lands the tree and the snapshot together.
+            let regions = self
+                .populate_injections_on_pool(
                     uri.clone(),
                     text.clone(),
                     tree.clone(),
@@ -1091,18 +1039,21 @@ impl ParseCoordinator {
                     content_version,
                     version_cancel.clone(),
                 )
-                .await
-            } else {
-                PopulatedSnapshotRegions::default()
-            };
+                .await;
             let tree_less_upgrade = self.documents.latest_snapshot(uri).is_some_and(|view| {
                 view.slot.snapshot.is_some_and(|snapshot| {
                     snapshot.parsed_version == content_version && snapshot.tree.is_none()
                 })
             });
-            let published = self.publish_parse_snapshot(
+            let installed = self.documents.install_parse(
                 uri,
-                crate::document::snapshot::ParseSnapshot {
+                crate::document::ParseInputs {
+                    text: &text,
+                    language_id: Some(language_id.as_deref()),
+                    incarnation,
+                    content_version,
+                },
+                std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
                     text: text.clone(),
                     tree: Some(tree.clone()),
                     language: Some(language_name.clone()),
@@ -1112,8 +1063,9 @@ impl ParseCoordinator {
                     bridge_regions: regions.bridge_regions,
                     resolved_regions: regions.resolved_regions,
                     layer_trees: std::sync::OnceLock::new(),
-                },
+                }),
             );
+            let published = installed.published;
             // Serve-stale's heal signal (ADR §3), narrowed to the cases the
             // workspace-scoped request is actually FOR. `refresh` is expensive
             // for the client (Neovim's handler cancels its in-flight token

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -417,9 +417,10 @@ impl ParseCoordinator {
     /// calling this, so the parse re-reads that stored text (a cheap `Arc<str>`
     /// refcount bump, [`text_arc`](crate::document::Document::text_arc)) rather than
     /// carrying a second owned `String`, and records the detected language + tree
-    /// **in place** via the non-inserting, text + incarnation CAS
-    /// [`set_parse_result_if_text_and_incarnation_unchanged`] instead of re-inserting a
-    /// fresh copy of the text. Net: zero full-document text copies in the open parse.
+    /// **in place** through the non-inserting, text + incarnation guarded
+    /// [`install_parse`](crate::document::DocumentStore::install_parse) instead of
+    /// re-inserting a fresh copy of the text. Net: zero full-document text copies
+    /// in the open parse.
     /// That store write is **non-inserting** and lifetime-guarded, so it is
     /// resurrection-safe and stale-safe once the open parse moves off the ingress
     /// ticket: a `didClose` racing it stays closed, and a `didChange` / reopen landing
@@ -533,23 +534,6 @@ impl ParseCoordinator {
             };
 
             if let Some(tree) = parsed_tree {
-                // Legacy tree CAS BEFORE the snapshot publish: a legacy-store
-                // reader woken by the publish (the explicit-action waiters
-                // read `doc.snapshot()` after `wait_for_current_snapshot`)
-                // must find the tree already attached — publish-first opened
-                // a window where the cell said Current while the legacy store
-                // was still tree-less, silently no-opping a user-triggered
-                // formatting. The CAS is non-inserting (text + incarnation
-                // checked), so a tree parsed from open-time text/lifetime is
-                // dropped when a `didChange` moved the text on or a
-                // `didClose`/reopen changed the incarnation — the publish
-                // below still lands in that case (stale-but-consistent is
-                // exactly what serve-stale readers consume; the cell guard
-                // independently rejects out-of-order versions). Only populate
-                // the injection caches when the tree actually landed, so a
-                // `didClose` racing this off-ingress parse can't leave stale
-                // injection entries for a gone document. (`Tree` clone is a
-                // cheap refcount bump.)
                 // Populate BEFORE the install so the derived discovery rides
                 // the snapshot (ADR §3 don't-discover-twice); populate guards
                 // itself against a pass whose text or lifetime moved on (the
@@ -676,11 +660,10 @@ impl ParseCoordinator {
     ///
     /// - re-reads the **latest** store text rather than the open-time text (a
     ///   `didChange` may have landed while the install ran), and
-    /// - persists through the **non-inserting**, tree-absent `attach_tree_if_absent`
-    ///   CAS, so a `didClose` during the install leaves the document gone instead
-    ///   of resurrecting it (the install/parse resurrection vector the actor ADR
-    ///   calls out), and a `didChange` between the read and the write drops the
-    ///   now-stale tree.
+    /// - persists through the **non-inserting** `install_parse`, so a `didClose`
+    ///   during the install leaves the document gone instead of resurrecting it
+    ///   (the install/parse resurrection vector the actor ADR calls out), and a
+    ///   `didChange` between the read and the write drops the now-stale tree.
     ///
     /// No watermark advance: the originating `didOpen`'s skip-parse branch already
     /// resolved that ticket's watermark, and this reparse carries no ticket.
@@ -891,9 +874,9 @@ impl ParseCoordinator {
     /// it runs in a spawned loop, *not* on the writer ticket. When the edit stashed a
     /// `pending_seed` (the pre-edit tree with this edit's `InputEdit`s applied) the
     /// parse is **incremental**, seeded from it; a full-text sync stashes no seed and
-    /// parses from scratch (which keeps #348 closed). The tree write
-    /// is the non-inserting text **and language** CAS
-    /// [`update_tree_if_text_and_language_unchanged`]: a closed (Vacant) document is
+    /// parses from scratch (which keeps #348 closed). The tree write is the
+    /// non-inserting, text **and language** guarded
+    /// [`install_parse`](crate::document::DocumentStore::install_parse): a closed (Vacant) document is
     /// left gone (resurrection-safe), a text that moved on (a `didChange` landed
     /// while parsing) is dropped — the scheduler's `dirty` loop then reparses the
     /// newer text — and a reopen that changed the language is rejected (no

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -10,9 +10,9 @@ use crate::lsp::lsp_impl::{Kakehashi, build_notifier};
 use crate::lsp::settings_manager::SettingsManager;
 
 /// Everything one populate pass derives for the snapshot it rides on
-/// (parse-snapshot ADR §3): all `None` when populate was skipped (raced CAS)
-/// or the pool work-unit panicked — readers then fall back to inline
-/// resolution for that snapshot.
+/// (parse-snapshot ADR §3): all `None` when the pool work-unit panicked or
+/// populate's own epoch/lifetime guard committed nothing — readers then fall
+/// back to inline resolution for that snapshot.
 #[derive(Default)]
 struct PopulatedSnapshotRegions {
     discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
@@ -794,22 +794,15 @@ impl ParseCoordinator {
 
             let Some(tree) = parsed else { break };
 
-            // Persist FIRST through the non-inserting, tree-absent CAS —
-            // before the snapshot publish, so a legacy-store reader the
-            // publish wakes finds the tree already attached (see the
-            // parse_document ordering note). A closed (Vacant) document, one
-            // whose text moved (a concurrent `didChange`), or one a
-            // concurrent parse already gave a tree all drop this tree — the
-            // tree-absent check makes the "don't clobber a concurrent parse"
-            // guard atomic with the write. Only populate the injection caches
-            // when the tree actually landed, so a `didClose` racing this
-            // reparse can't leave stale injection entries for a gone
-            // document. (`Tree` clone is a cheap refcount bump.)
             // Populate BEFORE the install so the discovery rides the snapshot
             // (ADR §3); populate guards itself against a pass whose text or
             // lifetime moved on, and the install then lands the tree and the
-            // snapshot together — the cell still rejects a stale lifetime or
-            // an out-of-order version on its own.
+            // snapshot together — or neither: a closed (Vacant) document, one
+            // whose text moved (a concurrent `didChange`), and one a
+            // concurrent parse already gave a tree at this version (the cell
+            // refuses the equal-version swap, so the tree is not re-attached
+            // either) all drop this tree. (`Tree` clone is a cheap refcount
+            // bump.)
             let regions = self
                 .populate_injections_on_pool(
                     uri.clone(),
@@ -854,8 +847,9 @@ impl ParseCoordinator {
             if installed.attached {
                 break;
             }
-            // CAS rejected: the text moved under us (a concurrent `didChange`).
-            // Loop to re-read the latest text and try again.
+            // Install rejected: the text moved under us (a concurrent
+            // `didChange`), or a sibling parse already installed this
+            // version. Loop to re-read the latest text and try again.
         }
 
         // Covers the give-up exits of the retry loop (parser still
@@ -996,11 +990,11 @@ impl ParseCoordinator {
 
         let mut events = load_result.events;
         if let Some(tree) = parsed {
-            // Legacy tree CAS BEFORE the snapshot publish (see the
-            // parse_document ordering note): a legacy-store reader woken by
-            // the publish must find the tree already attached. Text +
-            // language + incarnation checked atomically under the tree-write
-            // shard lock: text rejects a within-lifetime stale parse (a
+            // Attach and publish happen in one `install_parse` under the
+            // entry guard, so a legacy-store reader woken by the publish
+            // always finds the tree already attached. Text + language +
+            // incarnation are checked atomically under that guard: text
+            // rejects a within-lifetime stale parse (a
             // `didChange` landed mid-parse); language rejects a reopen that
             // relabelled the URI; incarnation rejects a same-language,
             // identical-text reopen — the tree belongs to the prior lifetime

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -590,21 +590,14 @@ impl ParseCoordinator {
                 // `didClose` racing this off-ingress parse can't leave stale
                 // injection entries for a gone document. (`Tree` clone is a
                 // cheap refcount bump.)
-                let stored = self.documents.set_parse_result_if_inputs_unchanged(
-                    &uri,
-                    &text,
-                    incarnation,
-                    content_version,
-                    Some(&language_name),
-                    Some(tree.clone()),
-                );
-                // Populate BEFORE the publish so the derived discovery rides the
-                // snapshot (ADR §3 don't-discover-twice); readers keep serving
-                // the previous snapshot meanwhile. A rejected CAS (raced) skips
-                // populate — the snapshot then publishes without discovery and
-                // readers discover inline for that (already-superseded) snapshot.
-                let regions = if stored {
-                    self.populate_injections_on_pool(
+                // Populate BEFORE the install so the derived discovery rides
+                // the snapshot (ADR §3 don't-discover-twice); populate guards
+                // itself against a pass whose text or lifetime moved on (the
+                // tracker's epoch and incarnation), so it needs no confirmation
+                // from the store first, and the install below then lands the
+                // tree and the snapshot together or rejects both.
+                let regions = self
+                    .populate_injections_on_pool(
                         uri.clone(),
                         text.clone(),
                         tree.clone(),
@@ -613,13 +606,16 @@ impl ParseCoordinator {
                         content_version,
                         version_cancel.clone(),
                     )
-                    .await
-                } else {
-                    PopulatedSnapshotRegions::default()
-                };
-                self.publish_parse_snapshot(
+                    .await;
+                let installed = self.documents.install_parse(
                     &uri,
-                    crate::document::snapshot::ParseSnapshot {
+                    crate::document::ParseInputs {
+                        text: &text,
+                        language_id: None,
+                        incarnation,
+                        content_version,
+                    },
+                    std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
                         text: text.clone(),
                         tree: Some(tree.clone()),
                         language: Some(language_name.clone()),
@@ -629,24 +625,22 @@ impl ParseCoordinator {
                         bridge_regions: regions.bridge_regions,
                         resolved_regions: regions.resolved_regions,
                         layer_trees: std::sync::OnceLock::new(),
-                    },
+                    }),
                 );
-                if stored {
-                    // AFTER the publish: a downstream task woken by this mark
+                if installed.attached {
+                    // AFTER the install: a downstream task woken by this mark
                     // on another runtime thread must find the snapshot (and
-                    // its fast-path regions) already in the cell — marking
-                    // first let it read the previous snapshot and fall back
-                    // to inline resolution for one cycle.
+                    // its fast-path regions) already in the cell.
                     self.documents
                         .mark_parse_finished(&uri, parse_generation, true);
                 }
                 advance_watermark();
                 self.notifier().log_language_events(&events).await;
-                // `stored` is exactly "this call's CAS landed the tree": false when a
+                // `attached` is exactly "this call landed the tree": false when a
                 // racing `didChange`/reopen moved the text or incarnation on and the
                 // edit reparse won, in which case the open downstream must NOT re-run
                 // over the edit's tree.
-                return stored;
+                return installed.attached;
             }
 
             // Parse produced no tree (timeout / parser unavailable / join error) but
@@ -654,20 +648,15 @@ impl ParseCoordinator {
             // through to the no-language path below which would null it out. Host
             // bridging needs only text + language (never a tree), so preserving the
             // language keeps a host-bridged document working after a parse failure.
-            if self.documents.set_parse_result_if_inputs_unchanged(
+            let installed = self.documents.install_parse(
                 &uri,
-                &text,
-                incarnation,
-                content_version,
-                Some(&language_name),
-                None,
-            ) {
-                self.documents
-                    .mark_parse_finished(&uri, parse_generation, false);
-            }
-            self.publish_parse_snapshot(
-                &uri,
-                crate::document::snapshot::ParseSnapshot {
+                crate::document::ParseInputs {
+                    text: &text,
+                    language_id: None,
+                    incarnation,
+                    content_version,
+                },
+                std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
                     text: text.clone(),
                     tree: None,
                     language: Some(language_name.clone()),
@@ -677,28 +666,27 @@ impl ParseCoordinator {
                     bridge_regions: None,
                     resolved_regions: None,
                     layer_trees: std::sync::OnceLock::new(),
-                },
+                }),
             );
+            if installed.attached {
+                self.documents
+                    .mark_parse_finished(&uri, parse_generation, false);
+            }
             advance_watermark();
             self.notifier().log_language_events(&events).await;
             return false;
         }
 
         // No language detected at all → store no language, no tree.
-        if self.documents.set_parse_result_if_inputs_unchanged(
+        let installed = self.documents.install_parse(
             &uri,
-            &text,
-            incarnation,
-            content_version,
-            None,
-            None,
-        ) {
-            self.documents
-                .mark_parse_finished(&uri, parse_generation, false);
-        }
-        self.publish_parse_snapshot(
-            &uri,
-            crate::document::snapshot::ParseSnapshot {
+            crate::document::ParseInputs {
+                text: &text,
+                language_id: None,
+                incarnation,
+                content_version,
+            },
+            std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
                 text: text.clone(),
                 tree: None,
                 language: None,
@@ -708,8 +696,12 @@ impl ParseCoordinator {
                 bridge_regions: None,
                 resolved_regions: None,
                 layer_trees: std::sync::OnceLock::new(),
-            },
+            }),
         );
+        if installed.attached {
+            self.documents
+                .mark_parse_finished(&uri, parse_generation, false);
+        }
         advance_watermark();
         self.notifier().log_language_events(&events).await;
         false

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -539,8 +539,10 @@ impl ParseCoordinator {
                 // the snapshot (ADR §3 don't-discover-twice); populate guards
                 // itself against a pass whose text or lifetime moved on (the
                 // tracker's epoch and incarnation), so it needs no confirmation
-                // from the store first, and the install below then lands the
-                // tree and the snapshot together or rejects both.
+                // from the store first, and the install below then publishes
+                // the snapshot iff the cell admits it and attaches the tree
+                // only with an admitted snapshot and unchanged inputs (a
+                // language mismatch rejects both outright).
                 let regions = self
                     .populate_injections_on_pool(
                         uri.clone(),
@@ -797,13 +799,14 @@ impl ParseCoordinator {
 
             // Populate BEFORE the install so the discovery rides the snapshot
             // (ADR §3); populate guards itself against a pass whose text or
-            // lifetime moved on, and the install then lands the tree and the
-            // snapshot together — or neither: a closed (Vacant) document, one
-            // whose text moved (a concurrent `didChange`), and one a
-            // concurrent parse already gave a tree at this version (the cell
-            // refuses the equal-version swap, so the tree is not re-attached
-            // either) all drop this tree. (`Tree` clone is a cheap refcount
-            // bump.)
+            // lifetime moved on, and the install then attaches the tree only
+            // with an admitted snapshot and unchanged inputs: a closed
+            // (Vacant) document, one whose text moved (a concurrent
+            // `didChange` — its snapshot may still publish as an older
+            // version, the tree does not attach), and one a concurrent parse
+            // already gave a tree at this version (the cell refuses the
+            // equal-version swap, so the tree is not re-attached either) all
+            // drop this tree. (`Tree` clone is a cheap refcount bump.)
             let regions = self
                 .populate_injections_on_pool(
                     uri.clone(),
@@ -1006,7 +1009,7 @@ impl ParseCoordinator {
             // previous snapshot for populate's duration. Populate guards itself
             // against a pass whose text moved on mid-parse (the scheduler's
             // dirty loop is already reparsing the newer text), and the install
-            // then lands the tree and the snapshot together.
+            // then attaches the tree only with an admitted snapshot.
             let regions = self
                 .populate_injections_on_pool(
                     uri.clone(),

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -1892,7 +1892,7 @@ mod tests {
                 .documents
                 .get(&uri)
                 .map(|doc| {
-                    doc.publish_snapshot(std::sync::Arc::new(
+                    doc.publish_snapshot(&std::sync::Arc::new(
                         crate::document::snapshot::ParseSnapshot {
                             text: std::sync::Arc::from(text),
                             tree: None,
@@ -1984,7 +1984,7 @@ mod tests {
             .documents
             .get(&uri)
             .map(|doc| {
-                doc.publish_snapshot(std::sync::Arc::new(
+                doc.publish_snapshot(&std::sync::Arc::new(
                     crate::document::snapshot::ParseSnapshot {
                         text: std::sync::Arc::from("fn main() {}"),
                         tree: None,
@@ -2062,7 +2062,7 @@ mod tests {
             .documents
             .get(&uri)
             .map(|doc| {
-                doc.publish_snapshot(std::sync::Arc::new(
+                doc.publish_snapshot(&std::sync::Arc::new(
                     crate::document::snapshot::ParseSnapshot {
                         text: std::sync::Arc::from(text),
                         tree: Some(tree),
@@ -2247,7 +2247,7 @@ mod tests {
                 .documents
                 .get(&uri)
                 .unwrap()
-                .publish_snapshot(std::sync::Arc::new(
+                .publish_snapshot(&std::sync::Arc::new(
                     crate::document::snapshot::ParseSnapshot {
                         text: std::sync::Arc::from(source),
                         tree: Some(parse(source)),
@@ -2364,7 +2364,7 @@ mod tests {
                 .documents
                 .get(&uri)
                 .unwrap()
-                .publish_snapshot(std::sync::Arc::new(
+                .publish_snapshot(&std::sync::Arc::new(
                     crate::document::snapshot::ParseSnapshot {
                         text: std::sync::Arc::from(text),
                         tree: Some(tree),

--- a/src/lsp/lsp_impl/snapshot_read.rs
+++ b/src/lsp/lsp_impl/snapshot_read.rs
@@ -184,7 +184,7 @@ mod tests {
             .documents
             .get(uri)
             .map(|doc| {
-                doc.publish_snapshot(Arc::new(ParseSnapshot {
+                doc.publish_snapshot(&Arc::new(ParseSnapshot {
                     text: Arc::from(text),
                     tree: None,
                     language: Some("rust".to_string()),

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -599,41 +599,32 @@ print("hello")
 
         // The present-parser open parse now runs off the ingress ticket (#6), so the
         // tree + injection cache appear asynchronously after `did_open_impl` returns.
-        // The injection cache is populated BEFORE the tree is installed, so
-        // wait for the tree too.
+        // The injection cache (populated before the install) names the region
+        // whose eager open this test is about.
         wait_until(|| {
             server
                 .cache
                 .get_injections(&uri)
                 .is_some_and(|injections| injections.len() == 1)
-                && server
-                    .documents
-                    .get(&uri)
-                    .is_some_and(|doc| doc.tree().is_some())
         })
         .await;
-
-        assert!(
-            server
-                .documents
-                .get(&uri)
-                .is_some_and(|doc| doc.tree().is_some()),
-            "did_open should parse the document"
-        );
-
         let injections = server
             .cache
             .get_injections(&uri)
             .expect("parse should populate injection cache");
         assert_eq!(injections.len(), 1, "expected one fenced code injection");
-
         let virtual_uri = VirtualDocumentUri::new(&lsp_uri, "rust", &injections[0].region_id);
 
+        // Wait for the observable itself — the eager open — and only then
+        // check that the parse preceded it: the tree must already be
+        // installed the moment the virtual document is seen open.
         wait_until(|| server.bridge.pool().is_document_opened(&virtual_uri)).await;
-
         assert!(
-            server.bridge.pool().is_document_opened(&virtual_uri),
-            "did_open should eagerly open the parsed injection as a virtual document"
+            server
+                .documents
+                .get(&uri)
+                .is_some_and(|doc| doc.tree().is_some()),
+            "the eager open must not run before the parse is installed"
         );
     }
 

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -599,11 +599,17 @@ print("hello")
 
         // The present-parser open parse now runs off the ingress ticket (#6), so the
         // tree + injection cache appear asynchronously after `did_open_impl` returns.
+        // The injection cache is populated BEFORE the tree is installed, so
+        // wait for the tree too.
         wait_until(|| {
             server
                 .cache
                 .get_injections(&uri)
                 .is_some_and(|injections| injections.len() == 1)
+                && server
+                    .documents
+                    .get(&uri)
+                    .is_some_and(|doc| doc.tree().is_some())
         })
         .await;
 

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -1323,7 +1323,7 @@ mod tests {
             .documents
             .get(uri)
             .map(|doc| {
-                doc.publish_snapshot(std::sync::Arc::new(
+                doc.publish_snapshot(&std::sync::Arc::new(
                     crate::document::snapshot::ParseSnapshot {
                         text: std::sync::Arc::from(text),
                         tree: None,
@@ -1763,7 +1763,7 @@ mod tests {
             .documents
             .get(&uri)
             .map(|doc| {
-                doc.publish_snapshot(std::sync::Arc::new(
+                doc.publish_snapshot(&std::sync::Arc::new(
                     crate::document::snapshot::ParseSnapshot {
                         text: std::sync::Arc::from(text),
                         tree: None,


### PR DESCRIPTION
## Summary

A parse reached readers through two separate store writes: the legacy tree was attached by one of several CAS calls, the `ParseSnapshot` was published by another, with the populate pass awaited between them. Nothing prevented a path from attaching a tree without publishing a snapshot, and since #1054 the injection resolution reads the snapshot only, such a path would leave a document silently unlookable. Two of #1054's own tests fell into exactly that gap.

This PR folds the two writes into one store primitive and removes every other way to attach a tree.

- **`DocumentStore::install_parse(uri, ParseInputs, Arc<ParseSnapshot>) -> ParseInstall`** attaches the legacy tree (and language) iff the parse's inputs still describe the document — text, lifetime, revision, and optionally the stored language — and publishes the snapshot iff the cell admits it, both under the document's entry guard. `attached` and `published` are reported separately: a parse of text an edit has moved on from still publishes as stale-but-consistent when the cell admits it (the existing serve-stale contract), while the tree is dropped.
- **All four parse paths** (`parse_document` success and both give-up branches, `reparse_installed_document`, `reparse_latest`) install through it. **Populate now runs before the install**, on the tree value: it already guards its own cache commits by the tracker's epoch and the lifetime, so it needs no confirmation from the store first.
- **Removed:** `set_parse_result_if_inputs_unchanged`, `attach_tree_if_parse_inputs_unchanged`, `update_tree_if_parse_inputs_unchanged`, the four test-only attach variants, `Document::set_tree`, and the parse coordinator's separate `publish_parse_snapshot`. `update_document` stays as a `#[cfg(test)]` edit fixture.
- **Tests:** the primitive's contract is pinned (tree and snapshot land together or not at all; stale text, a relabelled or reopened lifetime, a language without a tree, and a closed document each reject the install); the removed CAS tests' cases are folded into those. One ordering test now waits for the tree as well as the injection cache, since populate precedes the install.
- **Docs:** the parse-snapshot and injection-token-cache ADRs and the coordinator's doc comments describe the single install instead of the dual-write; Stage 3 of the parse-decouple plan (removing `Document::tree` and its readers) is the follow-up.

## Verification

- `cargo fmt --check`, `cargo clippy -- -D warnings` clean
- `cargo test --lib` (3698 passed, 2 ignored); `--test integration --bins` (79 + 11)
- `cargo test --features e2e --test e2e`: 2 full runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhEfVnacTxTiURX5ftDwmn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Parsing results, snapshots, and trees now follow a unified installation flow for greater consistency.
  * Stale, incompatible, and duplicate parse results are handled more reliably while preserving valid document state.
  * Semantic-token refreshes and downstream updates occur only when appropriate results are published or attached.
  * Documents without a language or parse tree continue to be handled consistently.

* **Documentation**
  * Updated architecture documentation to reflect the unified parse and injection publication flow.

* **Tests**
  * Expanded coverage for stale results, language handling, duplicate installs, reopening, tree-less parses, and injection timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->