### PR TITLE
refactor(document): derive the tree and the incremental seed from the published cell

### DIFF
--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -238,7 +238,7 @@ preference order:
   from one atomic snapshot — physically one unit, so there is **no reader-side gate
   to get wrong**: a snapshot carries discovery (reuse) or does not (the
   on-demand-parse fallback tree → discover inline). The only gate is on the
-  *writer* side — the install below attaches discovery only to the tree it
+  *writer* side — the install below publishes discovery only with the tree it
   was built for. Realizability, given `populate_injections` runs *before* the
   install (`DocumentStore::install_parse`, invoked from
   `src/lsp/lsp_impl/coordinator/parse.rs`) on the tree value, guarding its own
@@ -260,7 +260,8 @@ preference order:
   - **Publication scheme:** build discovery on the tree value first, then install
     tree and discovery-carrying snapshot in one `install_parse`; there is no window
     in which the snapshot exists without its discovery, and discovery is never
-    attached to the wrong tree (the install rejects a tree whose inputs moved on).
+    served against the wrong tree (the cell admits one snapshot per version and
+    lifetime, and readers derive the tree from it).
 - **Alternative — a parse epoch.** If coupling into the parse result is too
   invasive, key a separate `DiscoveredInjectionCache` on a **fresh monotonic
   per-parse epoch** — *not* `incarnation` (preserved across edits, so it cannot

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -260,8 +260,10 @@ preference order:
   - **Publication scheme:** build discovery on the tree value first, then install
     tree and discovery-carrying snapshot in one `install_parse`; there is no window
     in which the snapshot exists without its discovery, and discovery is never
-    served against the wrong tree (the cell admits one snapshot per version and
-    lifetime, and readers derive the tree from it).
+    served against the wrong tree (the cell admits, per lifetime, a newer version
+    or a same-version tree upgrade over a tree-less placeholder, never a
+    same-version tree swap — so a given tree-bearing version has exactly one
+    tree, and readers derive theirs from it).
 - **Alternative — a parse epoch.** If coupling into the parse result is too
   invasive, key a separate `DiscoveredInjectionCache` on a **fresh monotonic
   per-parse epoch** — *not* `incarnation` (preserved across edits, so it cannot

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -14,7 +14,7 @@ large-paste races it set out to close, but two costs it did not address surfaced
 as a user-visible regression against v0.7.0 (which parsed inline on `didChange`):
 
 1. **Per-keystroke read latency on large documents.** `Document::apply_edit_and_seed`
-   does `self.tree.take()`: after an edit there is **no servable tree** until the
+   did `self.tree.take()`: after an edit there was **no servable tree** until the
    off-ingress reparse republishes one. So every tree reader —
    `textDocument/semanticTokens`, `kakehashi/captures`, `kakehashi/node/*`,
    `documentSymbol`, selection ranges — must **block** waiting for the reparse
@@ -49,10 +49,12 @@ internally-consistent snapshots that readers observe without blocking.
 
 ### 1. `Document` holds inputs only
 
-`Document` carries `text: Arc<str>`, `language_id`, `incarnation`, and a
-monotonic `content_version` (bumped on every edit, `0` at `didOpen`). It no
-longer holds `tree` or `pending_seed`, and `apply_edit` never clears a tree — it
-installs the new text and bumps the version. The document lifecycle
+`Document` carries `text: Arc<str>`, `language_id`, `incarnation`, a
+monotonic `content_version` (bumped on every edit, `0` at `didOpen`), and the
+input side of the incremental seed (`seed_edits`, each `InputEdit` tagged with
+the version it produced, and `seed_floor`). It no longer holds `tree` or
+`pending_seed`, and `apply_edit` never clears a tree — it installs the new text,
+bumps the version and logs the edit. The document lifecycle
 (`didOpen`/`didChange`/`didClose`) becomes independent of parsing: it mutates
 inputs and returns, never awaiting or gating on a parse. `content_version` is a
 **new input-side field** that threads into `DocumentSnapshot` and (as
@@ -187,19 +189,23 @@ check-then-act rather than a cross-map TOCTOU against `Document.incarnation`):
   gets from the watermark sender dropping, made explicit because the snapshot channel
   outlives more clones.
 
-The incremental-parse **seed** re-homes onto `ParseScheduler`'s per-document state
-(accumulated `InputEdit`s + the `base_version` they extend). Two obligations,
-enforced by co-location today, become explicit scheduler invariants:
+The incremental-parse **seed** is derived, not stored: `Document` keeps an edit
+log (`seed_edits`, each `InputEdit` tagged with the content version it produced)
+and a `seed_floor`; `Document::incremental_seed` hands the reparse a clone of
+the published tree plus the logged edits tagged after its `parsed_version`, and
+the replay (`IncrementalSeed::replay`) runs on the compute pool with the parse.
+Two obligations:
 
-- The seed is applied to the snapshot's tree **iff `snapshot.parsed_version ==
-  base_version` and `snapshot.tree` is `Some`**; on a version mismatch (a publish
-  raced) *or* a tree-less base snapshot (resolved-but-parser-less), there is nothing
-  to incrementally seed from, so it parses from scratch — it never applies edits to
-  a tree they do not match (the `#348` external-scanner corruption) nor to an absent
-  tree.
-- A full-text sync **resets** `(pending_edits, base_version)`, so it parses from
-  scratch. "Leaves no accumulated edits" is an explicit reset, not an emergent
-  property.
+- The seed is `None` when nothing is published, the published snapshot is
+  tree-less (resolved-but-parser-less), or `parsed_version < seed_floor` — it
+  never applies edits to a tree they do not match (the `#348` external-scanner
+  corruption) nor to an absent tree. Any eligible published version seeds: the
+  edits it has not seen are exactly the log entries tagged after it.
+- A full-text sync, a grammar reload, and an edit log that outgrows
+  `MAX_SEED_EDITS` raise `seed_floor` to the version they produce and clear the
+  log, so the next parse is from scratch. "Leaves no accumulated edits" is an
+  explicit cut, not an emergent property. Entries at or below the published
+  `parsed_version` are pruned on the next edit.
 
 A parse pass therefore has a **single version/incarnation-guarded commit sequence**, so no reader-visible publication or downstream emission ever escapes for a snapshot that lost the admission:
 compute the tree, region map, and tokens on the tree value (the populate pass
@@ -560,7 +566,7 @@ inside the existing safety contracts at each step:
   changes, not before. Per the repo's structural-vs-behavioral separation
   guideline, the **pure dead-code / doc-pruning** parts of this stage (dropping the
   now-unused fields, deleting the superseded ADR passages) land as **separate PRs**
-  from the behavioral collapse (the CAS→publish merge, scheduler seed re-homing),
+  from the behavioral collapse (the CAS→publish merge, the seed derivation from the cell),
   each shipped only after its behavioral prerequisite is in.
 
 ## Considered Options

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -197,9 +197,11 @@ the replay (`IncrementalSeed::replay`) runs on the compute pool with the parse.
 Two obligations:
 
 - The seed is `None` when nothing is published, the published snapshot is
-  tree-less (resolved-but-parser-less), or `parsed_version < seed_floor` — it
-  never applies edits to a tree they do not match (the `#348` external-scanner
-  corruption) nor to an absent tree. Any eligible published version seeds: the
+  tree-less (resolved-but-parser-less), `parsed_version < seed_floor`, or the
+  snapshot's `language` is not the grammar the reparse will use (detection on
+  the edited text may select another) — it never applies edits to a tree they
+  do not match (the `#348` external-scanner corruption), nor to an absent tree,
+  nor hands one grammar's tree to another's parser. Any eligible published version seeds: the
   edits it has not seen are exactly the log entries tagged after it.
 - A full-text sync, a grammar reload, and an edit log that outgrows
   `MAX_SEED_EDITS` raise `seed_floor` to the version they produce and clear the

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -156,10 +156,15 @@ check-then-act rather than a cross-map TOCTOU against `Document.incarnation`):
   still checks `incarnation == current_incarnation` (it is not an unconditional
   early-return), so a straggler publish from lifetime N is rejected against N+1 and
   the version compare is only ever within one lifetime.
-- **Language axis** is subsumed by incarnation: every reopen draws a fresh
-  incarnation (so a relabel across lifetimes is already rejected), and within one
-  lifetime the language does not change. The three-axis edit-path CAS
-  (`incarnation && text && language`) therefore reduces to `incarnation && version`.
+- **Language axis** is subsumed by incarnation for the *stored label*: every
+  reopen draws a fresh incarnation (so a relabel across lifetimes is already
+  rejected), and within one lifetime `Document::language_id` does not change —
+  the reparses' `LanguageCheck::Expect` guards exactly that. The *detected*
+  language a snapshot carries may still move within a lifetime (detection re-runs
+  on the edited text: a rewritten shebang), which is why the seed is bound to
+  the snapshot's grammar independently. The three-axis edit-path CAS
+  (`incarnation && text && language`) therefore reduces to `incarnation && version`
+  for admission, plus the language check on install.
 - **Isolation is per-request re-resolution + incarnation validation, not cell identity.** A `latest_snapshot(uri)` call resolves the *current* cell from the
   store each time and never caches a `Receiver` across requests, and it validates
   `snapshot.incarnation == <live document incarnation>` before serving. To keep that

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -117,10 +117,10 @@ mapping is not one-to-one and must be stated precisely:
   (which already owns the parse lifecycle), not onto the read-side slot. Deleting
   `parse_states` is contingent on those two moves.
 
-The store's tree writes are already collapsed into `DocumentStore::install_parse`
-(the snapshot publish below inside `send_if_modified`, then — only if it was
-admitted — the legacy tree attach, both under the document's entry guard); the
-two watermark advances `advance_watermark` / `advance_watermark_for_incarnation`
+The store's tree writes are collapsed into `DocumentStore::install_parse` (the
+snapshot publish below inside `send_if_modified`, under the document's entry
+guard; `Document::tree` is derived from the published cell, so there is no
+second write); the two watermark advances `advance_watermark` / `advance_watermark_for_incarnation`
 still remain to be folded into the **one publish primitive**, which is executed
 inside `send_if_modified` so the guard and the write are atomic under the
 channel's own lock (the co-location is what makes this a single atomic
@@ -205,8 +205,8 @@ A parse pass therefore has a **single version/incarnation-guarded commit sequenc
 compute the tree, region map, and tokens on the tree value (the populate pass
 commits its injection caches under its own tracker-epoch/lifetime guard, so a
 pass whose text moved on commits nothing there); run the one install
-(`install_parse`: the snapshot publish, then — only if admitted — the legacy tree
-attach, under one entry guard); and emit the downstream — `semanticTokens/refresh`,
+(`install_parse`: the snapshot publish under the entry guard, reported *current*
+iff the snapshot parsed the document's content version); and emit the downstream — `semanticTokens/refresh`,
 injected-language forwarding, diagnostic republish — gated on the install's
 result, in the order the per-document-parse-scheduler loop already uses
 (`populate → install → mark finished → downstream`). A rejected publish (a racing
@@ -214,17 +214,15 @@ edit or reopen advanced the slot) emits nothing and attaches nothing. (Two
 parses of the *same* version — an install reparse racing the edit reparse — may
 both commit their populate bookkeeping before one of them loses the equal-version
 admission; those commits are equivalent, keyed by the same tree coordinates under
-the same epoch, so the loser's cache entries are the winner's.) The two
-Stage-2 stores are written by one primitive but are not co-equal: the **snapshot
-publish is the sole commit point**; the legacy tree attach that accompanies it is
-a Stage-2-only compatibility shim feeding the incremental seed (which still reads
-`Document::tree` until Stage 3 removes it). `semanticTokens/refresh` gates on the
-publish; the legacy-tree-dependent downstream (`mark_parse_finished`, the open
-parse's tree-dependent follow-ups) gates on the attach until Stage 3, and an
-attach is refused only when the inputs moved on or an equal-version sibling
-already landed the same tree — in either case the next pass reseeds from the current snapshot instead of the legacy tree, a self-correcting
-perf blip, never a served inconsistency, since readers already read the snapshot,
-not the legacy tree. So no reader-visible divergence can arise from the ordering.
+the same epoch, so the loser's cache entries are the winner's.) There is one
+store: the **snapshot publish is the sole commit point**, and `Document::tree`
+and the incremental seed are derived from the published cell (Stage 3).
+`semanticTokens/refresh` gates on the publish; the tree-dependent downstream
+(`mark_parse_finished`, the open parse's follow-ups) gates on `current`, which is
+refused only when the inputs moved on or an equal-version sibling already landed
+the same tree — in either case the next pass seeds from the published snapshot, a
+self-correcting perf blip, never a served inconsistency. So no reader-visible
+divergence can arise.
 
 ### 3. Reader contract — non-blocking, three classes
 
@@ -510,26 +508,21 @@ inside the existing safety contracts at each step:
   Stage 1 only relocates the CPU. Delivers *the async runtime is never blocked by
   tree-CPU* (killing the cross-document freeze) and most of *high-performance
   parsing*; fair admission on the compute pool is a later stage. The
-  clear-tree-on-edit contract is untouched, so the stale-tree guarantee is not at
+  stale-on-edit contract is untouched, so the stale-tree guarantee is not at
   risk; a further obligation is that `populate` is **awaited** (not detached),
   preserving the `populate → finish` ordering the injection-map invalidation
   depends on.
 - **Stage 2 — versioned snapshot reads.** Introduce `SnapshotSlot` + the `watch`
-  channel + `latest_snapshot`. **The parse loop installs the legacy tree and the
-  snapshot through one store primitive** (`install_parse`): the legacy tree (the
-  incremental seed still reads `Document::tree`/`pending_seed`, which Stage 3
-  removes) is attached iff the parse's inputs still describe the document AND
-  the snapshot was admitted, the snapshot is published iff the language still
-  matches and the cell admits it, and both happen under the same entry guard —
-  there is no attach-only path, while publish-without-attach (a stale but
-  consistent parse) is allowed. The **snapshot publish is the sole commit point** —
-  `semanticTokens/refresh` gates on the publish result, and the legacy-tree-
-  dependent downstream (`mark_parse_finished`, the open parse's tree-dependent
-  follow-ups) gates on the attach until Stage 3 removes the legacy tree (§2). So
-  `latest_snapshot` retains a servable tree across an edit's `tree.take()`; the two
-  stores may transiently sit at different versions (a rejected attach just reseeds
-  next pass), but no **reader** sees the difference because every reader reads the
-  snapshot, not the legacy tree. The populate pass runs *before* the install, on
+  channel + `latest_snapshot`. **The parse loop installs the snapshot through one
+  store primitive** (`install_parse`): published iff the language still matches
+  and the cell admits it, reported *current* iff it parsed the document's content
+  version; a stale-but-consistent parse publishes as not current. The **snapshot
+  publish is the sole commit point** — `semanticTokens/refresh` gates on the
+  publish result, the tree-dependent downstream (`mark_parse_finished`, the open
+  parse's follow-ups) on `current` (§2). `latest_snapshot` retains a servable
+  (stale) tree across an edit, while `Document::tree` — derived from the same
+  cell — reads as absent until the reparse lands, so no reader sees a tree that
+  predates the text. The populate pass runs *before* the install, on
   the tree value; it guards its own cache commits by the tracker's epoch and the
   lifetime, so a pass whose text moved on commits nothing. `populate`'s split into geometry derivation and
   the latch-gated tracker reconciliation (§3) is **already in**. Take the
@@ -556,10 +549,12 @@ inside the existing safety contracts at each step:
   resurrection vector. Delivers *instant reads* and *lifecycle independent of
   parsing*. Without the single install this stage would reproduce the
   empty-after-edit regression, so it is mandatory here, not deferred.
-- **Stage 3 — consolidation.** Remove `Document::tree` / `pending_seed` (the seed
-  now lives on the scheduler) and the legacy readers, delete the watermark waits,
-  and prune the now-superseded passages (the CAS methods are already collapsed
-  into `install_parse`)
+- **Stage 3 — consolidation.** *Done for the tree and the seed:* `Document::tree`
+  is derived from the published cell and the incremental seed from the cell plus
+  the document's edit log (`Document::incremental_seed`), so the readers that
+  went through `Document::tree` / `snapshot()` read the cell. *Remaining:* delete
+  the watermark waits and `parse_states`, and prune the now-superseded passages
+  (the CAS methods are already collapsed into `install_parse`)
   from per-document-parse-scheduler (its tree-clear-on-edit and watermark/epoch
   sections) per delete-on-supersede — done **here**, when the behavior actually
   changes, not before. Per the repo's structural-vs-behavioral separation
@@ -736,11 +731,12 @@ Two Stage-2 pieces remain deliberately open:
   way to guarantee that until those readers consume snapshot-owned region
   identity instead of minting.
 - Several notification-path consumers (pull diagnostics, `did_save`,
-  `documentSymbol`/`documentColor`) still read the legacy store tree after the
-  bounded current-wait; they migrate to `latest_snapshot` with the Stage-3
-  consolidation.
+  `documentSymbol`/`documentColor`) read `Document::tree` / `snapshot()` after
+  the bounded current-wait — since Stage 3 a current-or-none view of the
+  published cell, so they serve the snapshot the cell holds, never a second copy.
 
-**Stage 3 is not started**: `Document::tree`/`pending_seed` removal, the
-CAS-methods → publish-primitive collapse, watermark deletion, and the
+**Stage 3 is partly done**: `Document::tree`/`pending_seed` are gone (derived
+from the cell as `Document::tree` / `Document::incremental_seed`) and the CAS
+methods are collapsed into `install_parse`; the watermark deletion and the
 delete-on-supersede pruning of the overtaken per-document-parse-scheduler
-passages all happen there (structural PRs separate from behavioral, per §5).
+passages remain (structural PRs separate from behavioral, per §5).

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -101,7 +101,10 @@ mapping is not one-to-one and must be stated precisely:
 
 - Two distinct predicates replace the old single `has_tree`: **`resolved`** =
   `slot.snapshot.is_some()` (a parse for this lifetime has completed at least once)
-  and **`has_tree`** = `slot.snapshot.as_ref().and_then(|s| s.tree.as_ref()).is_some()`. A
+  and **`has_tree`** = `slot.snapshot.as_ref().and_then(|s| s.tree.as_ref()).is_some()`
+  — the *published* tree, which after a `didChange` is the stale one; the
+  current-tree question adds `parsed_version == content_version`
+  (`Document::has_current_tree`, `snapshot_has_tree` in the injection coordinator). A
   **resolved-but-tree-less** outcome — a parse that completed with no usable tree
   (no parser installed, install failed, no usable tree reached the publish, or a
   settings-reload placeholder awaiting its reparse — see `ParseSnapshot`), distinct

--- a/docs/architecture-decisions/per-document-parse-scheduler.md
+++ b/docs/architecture-decisions/per-document-parse-scheduler.md
@@ -106,8 +106,9 @@ scheduler settles the same forces with less moving structure.
 ### Writes return at enqueue; the slow work runs off-ingress
 
 `didOpen`, `didChange`, and `didClose` record their effect and return without
-awaiting the parse. On `didChange` the edit is applied to the stored text, the
-reader-visible tree is cleared, and the document is handed to the scheduler, which
+awaiting the parse. On `didChange` the edit is applied to the stored text (which
+makes the published tree stale for readers — see parse-snapshot-architecture),
+and the document is handed to the scheduler, which
 runs the parse **off the ingress ticket**. The scheduler keeps **one parse in
 flight per document** and **coalesces a burst**: an edit arriving while a parse
 runs marks the document dirty rather than starting a second parse, so a run of
@@ -458,8 +459,9 @@ deadline — compilation re-execs a `__compile-parser` subprocess whose process 
 the installer kills when the deadline fires, with an in-subprocess watchdog that
 group-kills the compile even if the parent dies first. Readers wait on the
 `(incarnation, ticket)` epoch watermark rather than on tree presence. Every tree
-write is a non-inserting CAS that checks the captured incarnation alongside the
-text/language it parsed, and the watermark advance is incarnation-guarded, so a
+write is the one non-inserting `install_parse`: the cell admits a snapshot only
+for the captured incarnation and a newer version, the reparse's language check
+rejects a relabelled document, and the watermark advance is incarnation-guarded, so a
 close-then-reopen during an in-flight parse fails its epoch check at the write
 rather than resurrecting the closed document. Injection orchestration runs
 downstream of the parse, off the ingress path. The text-owning actor of Option 4 is

--- a/docs/architecture-decisions/per-document-parse-scheduler.md
+++ b/docs/architecture-decisions/per-document-parse-scheduler.md
@@ -460,7 +460,10 @@ the installer kills when the deadline fires, with an in-subprocess watchdog that
 group-kills the compile even if the parent dies first. Readers wait on the
 `(incarnation, ticket)` epoch watermark rather than on tree presence. Every tree
 write is the one non-inserting `install_parse`: the cell admits a snapshot only
-for the captured incarnation and a newer version, the reparse's language check
+for the captured incarnation and a newer version — or the same version when the
+incoming snapshot brings a tree the held one lacks, which is how a reparse fills
+in a reload placeholder or a give-up snapshot instead of leaving the document
+tree-less until the next edit — the reparse's language check
 rejects a relabelled document, and the watermark advance is incarnation-guarded, so a
 close-then-reopen during an in-flight parse fails its epoch check at the write
 rather than resurrecting the closed document. Injection orchestration runs

--- a/src/analysis/selection.rs
+++ b/src/analysis/selection.rs
@@ -638,7 +638,7 @@ array: ["xxxx"]"#;
         let document = store.get(&url).expect("document should exist");
         let ranges = handle_selection_range(
             document.text(),
-            document.tree(),
+            document.tree().as_ref(),
             document.language_id(),
             &positions,
             &coordinator,
@@ -817,7 +817,7 @@ array: ["xxxx"]"#;
         let document = store.get(&url).expect("document should exist");
         let ranges = handle_selection_range(
             document.text(),
-            document.tree(),
+            document.tree().as_ref(),
             document.language_id(),
             &positions,
             &coordinator,

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -40,7 +40,7 @@ pub(super) const INJECTION_CACHE_MIN_REGIONS: usize = 8;
 
 /// Test-only counter of how many times the discovery-reuse branch fired (skipped
 /// the injection query by reusing owned discovery). Lets an in-process server
-/// test assert reuse actually engages end-to-end after a real parse+attach —
+/// test assert reuse actually engages end-to-end after a real parse+publish —
 /// the latency benchmark cannot distinguish "reuse fired" from "reuse never
 /// fired, fell back inline" (both read as flat request latency).
 #[cfg(test)]
@@ -1044,7 +1044,7 @@ pub(crate) fn build_document_discovery_cancellable(
         // Producer: don't gate on the highlight query — store the region and let
         // reuse re-resolve the query (a load without a generation bump self-heals).
         // Producer path: called from populate_injections right after this
-        // parse's CAS landed, so the coordinates are current; the region id +
+        // parse's install landed, so the coordinates are current; the region id +
         // content hash are REUSED from the caller's just-built identity
         // (`prebuilt`), not recomputed.
         match discover_single_region(
@@ -1353,7 +1353,7 @@ pub(crate) fn collect_injection_tokens_parallel(
     // while the partial discovery's singles still feed the token-cache
     // read/store path and the eviction sweep). The reused
     // region ids were minted while their snapshot was current (populate runs
-    // behind the landed CAS), so rebuilding from them never writes the tracker —
+    // behind the landed install), so rebuilding from them never writes the tracker —
     // the `mint_regions` stale-serve latch only governs the inline branch.
     let reusable_discovery = cache_ctx.and_then(|c| {
         c.discovery

--- a/src/document.rs
+++ b/src/document.rs
@@ -14,4 +14,4 @@ pub(crate) use injections::{
 pub(crate) use model::Document;
 pub use store::DocumentStore;
 
-pub(crate) use store::ParseInputs;
+pub(crate) use store::LanguageCheck;

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -391,6 +391,128 @@ mod tests {
         parser.parse(text, None).unwrap()
     }
 
+    fn edit(start: usize, old_end: usize, new_end: usize) -> InputEdit {
+        InputEdit {
+            start_byte: start,
+            old_end_byte: old_end,
+            new_end_byte: new_end,
+            start_position: tree_sitter::Point::new(0, start),
+            old_end_position: tree_sitter::Point::new(0, old_end),
+            new_end_position: tree_sitter::Point::new(0, new_end),
+        }
+    }
+
+    fn incremental_parse_matches_fresh(seed: &Tree, text: &str) -> bool {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let incremental = parser.parse(text, Some(seed)).unwrap();
+        let fresh = parser.parse(text, None).unwrap();
+        incremental.root_node().to_sexp() == fresh.root_node().to_sexp()
+            && incremental.root_node().end_byte() == text.len()
+    }
+
+    /// The off-ingress reparse's seed is derived, not stored: the published
+    /// tree with every edit since its version replayed onto a clone, so a
+    /// burst of coalesced edits yields one correctly edited seed and the
+    /// published snapshot itself stays unedited.
+    #[test]
+    fn incremental_seed_is_the_published_tree_with_the_edits_since_replayed() {
+        let mut doc = Document::with_tree(
+            "fn main() {}".to_string(),
+            "rust".to_string(),
+            rust_tree("fn main() {}"),
+            3,
+        );
+        assert!(
+            doc.incremental_seed().is_some(),
+            "an unedited current tree seeds as is"
+        );
+
+        doc.apply_edit_and_seed("fn main() { }".to_string(), &[edit(11, 11, 12)]);
+        let seed = doc.incremental_seed().expect("one edit: seeded");
+        assert!(incremental_parse_matches_fresh(&seed, "fn main() { }"));
+        assert!(
+            doc.tree().is_none(),
+            "the edit made the published tree stale"
+        );
+
+        doc.apply_edit_and_seed("fn main() { x }".to_string(), &[edit(12, 12, 14)]);
+        let seed = doc
+            .incremental_seed()
+            .expect("coalesced edits: still seeded");
+        assert!(
+            incremental_parse_matches_fresh(&seed, "fn main() { x }"),
+            "both edits replayed, in order"
+        );
+        assert_eq!(
+            doc.latest_snapshot_slot()
+                .snapshot
+                .and_then(|s| s.tree.as_ref().map(|t| t.root_node().end_byte())),
+            Some("fn main() {}".len()),
+            "the published tree is not edited in place"
+        );
+    }
+
+    /// A full-text sync (no `InputEdit`s) invalidates seeding until a fresh
+    /// tree is published: seeding an unedited tree against wholly replaced
+    /// text violates tree-sitter's incremental contract (#348), and the edits
+    /// that follow before the reparse cannot be replayed onto it either.
+    #[test]
+    fn a_full_text_sync_disables_seeding_until_a_fresh_tree_is_published() {
+        let mut doc = Document::with_tree(
+            "fn main() {}".to_string(),
+            "rust".to_string(),
+            rust_tree("fn main() {}"),
+            3,
+        );
+        doc.apply_edit_and_seed("fn other() {}".to_string(), &[]);
+        assert!(
+            doc.incremental_seed().is_none(),
+            "full sync: parse from scratch"
+        );
+        doc.apply_edit_and_seed("fn other() { }".to_string(), &[edit(12, 12, 13)]);
+        assert!(
+            doc.incremental_seed().is_none(),
+            "an edit after the sync has no tree it can be replayed onto"
+        );
+
+        assert!(doc.publish_snapshot(doc.bare_snapshot(Some(rust_tree("fn other() { }")))));
+        assert!(
+            doc.incremental_seed().is_some(),
+            "a fresh published tree seeds again"
+        );
+        doc.apply_edit_and_seed("fn other() { y }".to_string(), &[edit(13, 13, 15)]);
+        let seed = doc.incremental_seed().expect("seeded from the fresh tree");
+        assert!(incremental_parse_matches_fresh(&seed, "fn other() { y }"));
+    }
+
+    /// Edits the published tree already saw are not replayed onto it: a
+    /// parse that landed at version N consumed the edits up to N, so only
+    /// the edits after N are applied to its clone.
+    #[test]
+    fn edits_the_published_tree_already_consumed_are_not_replayed() {
+        let mut doc = Document::with_tree(
+            "fn main() {}".to_string(),
+            "rust".to_string(),
+            rust_tree("fn main() {}"),
+            3,
+        );
+        doc.apply_edit_and_seed("fn main() { }".to_string(), &[edit(11, 11, 12)]);
+        doc.apply_edit_and_seed("fn main() { x }".to_string(), &[edit(12, 12, 14)]);
+        // The reparse of version 2 lands.
+        assert!(doc.publish_snapshot(doc.bare_snapshot(Some(rust_tree("fn main() { x }")))));
+        doc.apply_edit_and_seed("fn main() { xy }".to_string(), &[edit(13, 13, 14)]);
+        let seed = doc
+            .incremental_seed()
+            .expect("seeded from the version-2 tree");
+        assert!(
+            incremental_parse_matches_fresh(&seed, "fn main() { xy }"),
+            "only the edit after version 2 is replayed"
+        );
+    }
+
     /// A tree reaches readers only through a published, current snapshot:
     /// the document has no tree of its own.
     #[test]

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -185,26 +185,37 @@ impl Document {
     }
 
     /// The current parse's tree: the published snapshot's, iff that snapshot
-    /// is this lifetime's and parsed this content version. An edit or a
-    /// reload makes the published snapshot stale, so this is `None` until the
-    /// reparse lands — a reader never sees a tree that predates the text.
-    /// (`Tree` clone is a refcount bump.)
+    /// is this lifetime's and parsed this content version. An edit makes the
+    /// published snapshot stale and a reload replaces it with a tree-less
+    /// placeholder, so this is `None` until the reparse lands — a reader
+    /// never sees a tree that predates the text. (`Tree` clone is a retain
+    /// plus a small allocation; a presence probe should use
+    /// [`has_current_tree`](Self::has_current_tree).)
     pub(crate) fn tree(&self) -> Option<Tree> {
         self.current_snapshot()
             .and_then(|snapshot| snapshot.tree.clone())
     }
 
-    /// The published snapshot iff it is this lifetime's and parsed the
-    /// current content version (parse-snapshot ADR §2 currency).
-    pub(crate) fn current_snapshot(&self) -> Option<Arc<ParseSnapshot>> {
+    /// Whether [`tree`](Self::tree) would be `Some`, without cloning it.
+    pub(crate) fn has_current_tree(&self) -> bool {
         let slot = self.snapshot_tx.borrow();
         slot.snapshot
             .as_ref()
-            .filter(|snapshot| {
-                snapshot.incarnation == self.incarnation
-                    && snapshot.parsed_version == self.content_version
-            })
+            .is_some_and(|snapshot| self.is_current(snapshot) && snapshot.tree.is_some())
+    }
+
+    /// The published snapshot iff it is this lifetime's and parsed the
+    /// current content version (parse-snapshot ADR §2 currency).
+    fn current_snapshot(&self) -> Option<Arc<ParseSnapshot>> {
+        let slot = self.snapshot_tx.borrow();
+        slot.snapshot
+            .as_ref()
+            .filter(|snapshot| self.is_current(snapshot))
             .cloned()
+    }
+
+    fn is_current(&self, snapshot: &ParseSnapshot) -> bool {
+        snapshot.incarnation == self.incarnation && snapshot.parsed_version == self.content_version
     }
 
     /// A snapshot of the current inputs carrying `tree` and nothing derived —
@@ -299,12 +310,14 @@ impl Document {
     /// Create an immutable snapshot of current document state
     ///
     /// Returns None while the document has no current tree (see
-    /// [`tree`](Self::tree)). The snapshot clones text and tree to enable
-    /// lock-free processing.
+    /// [`tree`](Self::tree)). Text and tree both come from the published
+    /// snapshot — the text the tree was parsed from, by construction — so
+    /// their consistency is structural, not an invariant of the text writers.
     pub(crate) fn snapshot(&self) -> Option<DocumentSnapshot> {
+        let snapshot = self.current_snapshot()?;
         Some(DocumentSnapshot {
-            text: self.text.clone(),
-            tree: self.tree()?,
+            tree: snapshot.tree.clone()?,
+            text: Arc::clone(&snapshot.text),
             incarnation: self.incarnation,
         })
     }

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -364,6 +364,41 @@ impl Document {
 mod tests {
     use super::*;
 
+    fn rust_tree(text: &str) -> Tree {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        parser.parse(text, None).unwrap()
+    }
+
+    /// A tree reaches readers only through a published, current snapshot:
+    /// the document has no tree of its own.
+    #[test]
+    fn a_published_current_snapshot_is_the_readers_tree() {
+        let text = "fn main() {}";
+        let doc = Document::with_language(text.to_string(), "rust".to_string(), 7);
+        assert!(doc.tree().is_none(), "unparsed: no tree");
+        let tree = rust_tree(text);
+        assert!(doc.publish_snapshot(Arc::new(ParseSnapshot {
+            text: doc.text_arc(),
+            tree: Some(tree.clone()),
+            language: Some("rust".to_string()),
+            parsed_version: doc.content_version(),
+            incarnation: 7,
+            injection_regions: None,
+            bridge_regions: None,
+            resolved_regions: None,
+            layer_trees: std::sync::OnceLock::new(),
+        })));
+        assert_eq!(
+            doc.tree().map(|t| t.root_node().id()),
+            Some(tree.root_node().id()),
+            "the published snapshot's tree is the document's tree"
+        );
+        assert!(doc.snapshot().is_some());
+    }
+
     #[test]
     fn test_document_creation() {
         let doc = Document::new("hello world".to_string(), 0);

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -414,16 +414,22 @@ impl Document {
     /// allocation, and a copy of the edit tail), so the caller's store guard
     /// is released before the replay's per-edit path copies run — on the
     /// compute pool, with the parse. `None` when nothing is published, the
-    /// published snapshot is tree-less, or it predates a full-text sync or
-    /// reload (`seed_floor`). **Read only by `reparse_latest`** — readers go
-    /// through [`tree`](Self::tree), which never serves a pre-reparse tree.
-    pub(crate) fn incremental_seed(&self) -> Option<IncrementalSeed> {
+    /// published snapshot is tree-less, it predates a full-text sync or
+    /// reload (`seed_floor`), or its tree was produced by a grammar other
+    /// than `language` — detection on the edited text may select another
+    /// language, and tree-sitter does not check that an old tree belongs to
+    /// the parser it is handed. **Read only by `reparse_latest`** — readers
+    /// go through [`tree`](Self::tree), which never serves a pre-reparse
+    /// tree.
+    pub(crate) fn incremental_seed(&self, language: &str) -> Option<IncrementalSeed> {
         let slot = self.snapshot_tx.borrow();
         let snapshot = slot
             .snapshot
             .as_ref()
             .filter(|snapshot| snapshot.incarnation == self.incarnation)?;
-        if snapshot.parsed_version < self.seed_floor {
+        if snapshot.parsed_version < self.seed_floor
+            || snapshot.language.as_deref() != Some(language)
+        {
             return None;
         }
         let tree = snapshot.tree.clone()?;

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -101,6 +101,29 @@ pub struct Document {
 /// the next parse incrementally.
 const MAX_SEED_EDITS: usize = 1024;
 
+/// A published tree plus the edits it has not seen, in order — the
+/// incremental parse seed before its replay (see
+/// [`Document::incremental_seed`]).
+pub(crate) struct IncrementalSeed {
+    tree: Tree,
+    edits: Vec<InputEdit>,
+}
+
+impl IncrementalSeed {
+    /// Apply the edits to the tree, in order, yielding the seed tree-sitter's
+    /// incremental contract requires: the old tree with exactly the edits
+    /// between its text and the current text applied (#348). Editing the
+    /// clone leaves the published snapshot's own tree untouched (tree-sitter
+    /// copies the edited path on write).
+    pub(crate) fn replay(self) -> Tree {
+        let Self { mut tree, edits } = self;
+        for edit in &edits {
+            tree.edit(edit);
+        }
+        tree
+    }
+}
+
 impl Document {
     /// Create a new document with just text
     pub(crate) fn new(text: String, incarnation: u64) -> Self {
@@ -369,15 +392,18 @@ impl Document {
             .map_or(0, |snapshot| snapshot.parsed_version)
     }
 
-    /// The off-ingress incremental parse seed, if any: a clone of the
-    /// published tree with every logged edit after its version replayed via
-    /// `tree.edit()`, so the reparse can `parser.parse(text, Some(&seed))`
-    /// instead of parsing from scratch. `None` when nothing is published,
-    /// the published snapshot is tree-less, or it predates a full-text sync
-    /// or reload (`seed_floor`). **Read only by `reparse_latest`** — readers
-    /// go through [`tree`](Self::tree), which never serves a pre-reparse
-    /// tree. Editing the clone leaves the snapshot's own tree untouched.
-    pub(crate) fn incremental_seed(&self) -> Option<Tree> {
+    /// The inputs of the off-ingress incremental parse seed, if any: a clone
+    /// of the published tree and the logged edits after its version, for
+    /// [`IncrementalSeed::replay`] to apply via `tree.edit()` so the reparse
+    /// can `parser.parse(text, Some(&seed))` instead of parsing from scratch.
+    /// Only the cheap part happens here (a tree retain plus a small
+    /// allocation, and a copy of the edit tail), so the caller's store guard
+    /// is released before the replay's per-edit path copies run — on the
+    /// compute pool, with the parse. `None` when nothing is published, the
+    /// published snapshot is tree-less, or it predates a full-text sync or
+    /// reload (`seed_floor`). **Read only by `reparse_latest`** — readers go
+    /// through [`tree`](Self::tree), which never serves a pre-reparse tree.
+    pub(crate) fn incremental_seed(&self) -> Option<IncrementalSeed> {
         let slot = self.snapshot_tx.borrow();
         let snapshot = slot
             .snapshot
@@ -386,13 +412,14 @@ impl Document {
         if snapshot.parsed_version < self.seed_floor {
             return None;
         }
-        let mut tree = snapshot.tree.clone()?;
-        for (version, edit) in &self.seed_edits {
-            if *version > snapshot.parsed_version {
-                tree.edit(edit);
-            }
-        }
-        Some(tree)
+        let tree = snapshot.tree.clone()?;
+        let edits = self
+            .seed_edits
+            .iter()
+            .filter(|(version, _)| *version > snapshot.parsed_version)
+            .map(|(_, edit)| *edit)
+            .collect();
+        Some(IncrementalSeed { tree, edits })
     }
 
     /// Update text and clear layers/state
@@ -427,6 +454,10 @@ mod tests {
         }
     }
 
+    fn seed_tree(doc: &Document) -> Option<Tree> {
+        Document::incremental_seed(doc).map(IncrementalSeed::replay)
+    }
+
     fn incremental_parse_matches_fresh(seed: &Tree, text: &str) -> bool {
         let mut parser = tree_sitter::Parser::new();
         parser
@@ -451,12 +482,12 @@ mod tests {
             3,
         );
         assert!(
-            doc.incremental_seed().is_some(),
+            seed_tree(&doc).is_some(),
             "an unedited current tree seeds as is"
         );
 
         doc.apply_edit("fn main() { }".to_string(), &[edit(11, 11, 12)]);
-        let seed = doc.incremental_seed().expect("one edit: seeded");
+        let seed = seed_tree(&doc).expect("one edit: seeded");
         assert!(incremental_parse_matches_fresh(&seed, "fn main() { }"));
         assert!(
             doc.tree().is_none(),
@@ -464,9 +495,7 @@ mod tests {
         );
 
         doc.apply_edit("fn main() { x }".to_string(), &[edit(12, 12, 14)]);
-        let seed = doc
-            .incremental_seed()
-            .expect("coalesced edits: still seeded");
+        let seed = seed_tree(&doc).expect("coalesced edits: still seeded");
         assert!(
             incremental_parse_matches_fresh(&seed, "fn main() { x }"),
             "both edits replayed, in order"
@@ -493,23 +522,20 @@ mod tests {
             3,
         );
         doc.apply_edit("fn other() {}".to_string(), &[]);
-        assert!(
-            doc.incremental_seed().is_none(),
-            "full sync: parse from scratch"
-        );
+        assert!(seed_tree(&doc).is_none(), "full sync: parse from scratch");
         doc.apply_edit("fn other() { }".to_string(), &[edit(12, 12, 13)]);
         assert!(
-            doc.incremental_seed().is_none(),
+            seed_tree(&doc).is_none(),
             "an edit after the sync has no tree it can be replayed onto"
         );
 
         assert!(doc.publish_snapshot(&doc.bare_snapshot(Some(rust_tree("fn other() { }")))));
         assert!(
-            doc.incremental_seed().is_some(),
+            seed_tree(&doc).is_some(),
             "a fresh published tree seeds again"
         );
         doc.apply_edit("fn other() { y }".to_string(), &[edit(13, 13, 15)]);
-        let seed = doc.incremental_seed().expect("seeded from the fresh tree");
+        let seed = seed_tree(&doc).expect("seeded from the fresh tree");
         assert!(incremental_parse_matches_fresh(&seed, "fn other() { y }"));
     }
 
@@ -529,9 +555,7 @@ mod tests {
         // The reparse of version 2 lands.
         assert!(doc.publish_snapshot(&doc.bare_snapshot(Some(rust_tree("fn main() { x }")))));
         doc.apply_edit("fn main() { xy }".to_string(), &[edit(13, 13, 14)]);
-        let seed = doc
-            .incremental_seed()
-            .expect("seeded from the version-2 tree");
+        let seed = seed_tree(&doc).expect("seeded from the version-2 tree");
         assert!(
             incremental_parse_matches_fresh(&seed, "fn main() { xy }"),
             "only the edit after version 2 is replayed"
@@ -675,7 +699,7 @@ mod tests {
 
         assert!(doc.tree().is_none(), "reader-visible tree must be cleared");
         assert!(
-            doc.incremental_seed().is_some(),
+            seed_tree(&doc).is_some(),
             "incremental seed must be stashed"
         );
         assert_eq!(doc.text(), "fn main() { }");
@@ -698,7 +722,7 @@ mod tests {
 
         assert!(doc.tree().is_none());
         assert!(
-            doc.incremental_seed().is_none(),
+            seed_tree(&doc).is_none(),
             "full-text sync must not leave a stale seed (#348)"
         );
     }
@@ -739,7 +763,7 @@ mod tests {
 
         assert!(doc.tree().is_none());
         assert!(
-            doc.incremental_seed().is_some(),
+            seed_tree(&doc).is_some(),
             "coalesced edit must keep the accumulated seed"
         );
         assert_eq!(doc.text(), "fn main() {  }");

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -469,7 +469,7 @@ mod tests {
     }
 
     fn seed_tree(doc: &Document) -> Option<Tree> {
-        Document::incremental_seed(doc).map(IncrementalSeed::replay)
+        Document::incremental_seed(doc, "rust").map(IncrementalSeed::replay)
     }
 
     /// The seed's own geometry against `text`: tree-sitter's contract is
@@ -514,6 +514,29 @@ mod tests {
             resolved_regions: None,
             layer_trees: std::sync::OnceLock::new(),
         })
+    }
+
+    /// A seed is only good for the grammar that produced its tree: detection
+    /// on the edited text may select another language (a changed shebang),
+    /// and tree-sitter does not check that an old tree belongs to the parser
+    /// it is handed, so a seed for another grammar must parse from scratch.
+    #[test]
+    fn a_seed_is_refused_for_a_grammar_other_than_its_trees() {
+        let mut doc = Document::with_tree(
+            "fn main() {}".to_string(),
+            "rust".to_string(),
+            rust_tree("fn main() {}"),
+            3,
+        );
+        doc.apply_edit("fn main() { }".to_string(), &[edit(11, 11, 12)]);
+        assert!(
+            doc.incremental_seed("rust").is_some(),
+            "the grammar that parsed the published tree seeds"
+        );
+        assert!(
+            doc.incremental_seed("python").is_none(),
+            "another grammar must not reuse the tree"
+        );
     }
 
     /// A tree published for an older version than the log's newest entries

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -471,6 +471,24 @@ mod tests {
         Document::incremental_seed(doc).map(IncrementalSeed::replay)
     }
 
+    /// The seed's own geometry against `text`: tree-sitter's contract is
+    /// that the seed's byte positions already match the new text, so its
+    /// root spans the whole text and its closing brace sits where the text
+    /// has one. This tells a missing, duplicated or reordered edit apart —
+    /// the eventual incremental parse cannot, since tree-sitter recovers
+    /// the right tree from a wrong seed on inputs this small.
+    fn seed_matches_text(seed: &Tree, text: &str) -> bool {
+        let root = seed.root_node();
+        let close = root
+            .named_child(0)
+            .and_then(|function| function.child_by_field_name("body"))
+            .and_then(|body| body.child(body.child_count().saturating_sub(1) as u32));
+        root.end_byte() == text.len()
+            && close.is_some_and(|close| {
+                close.kind() == "}" && Some(close.start_byte()) == text.rfind('}')
+            })
+    }
+
     fn incremental_parse_matches_fresh(seed: &Tree, text: &str) -> bool {
         let mut parser = tree_sitter::Parser::new();
         parser
@@ -478,8 +496,84 @@ mod tests {
             .unwrap();
         let incremental = parser.parse(text, Some(seed)).unwrap();
         let fresh = parser.parse(text, None).unwrap();
-        incremental.root_node().to_sexp() == fresh.root_node().to_sexp()
+        seed_matches_text(seed, text)
+            && incremental.root_node().to_sexp() == fresh.root_node().to_sexp()
             && incremental.root_node().end_byte() == text.len()
+    }
+
+    fn snapshot_at(doc: &Document, text: &str, parsed_version: u64) -> Arc<ParseSnapshot> {
+        Arc::new(ParseSnapshot {
+            text: Arc::from(text),
+            tree: Some(rust_tree(text)),
+            language: Some("rust".to_string()),
+            parsed_version,
+            incarnation: doc.incarnation(),
+            injection_regions: None,
+            bridge_regions: None,
+            resolved_regions: None,
+            layer_trees: std::sync::OnceLock::new(),
+        })
+    }
+
+    /// A tree published for an older version than the log's newest entries
+    /// (a stale-but-consistent publish, the edit's own reparse still to come)
+    /// seeds with only the edits after its version — the filter alone, with
+    /// no edit in between to prune the log for it.
+    #[test]
+    fn a_tree_published_behind_the_log_replays_only_the_edits_after_it() {
+        let mut doc = Document::with_tree(
+            "fn main() {}".to_string(),
+            "rust".to_string(),
+            rust_tree("fn main() {}"),
+            3,
+        );
+        doc.apply_edit("fn main() { }".to_string(), &[edit(11, 11, 12)]);
+        doc.apply_edit("fn main() { x }".to_string(), &[edit(12, 12, 14)]);
+        // The reparse of version 1 lands while the document is at version 2.
+        assert!(doc.publish_snapshot(&snapshot_at(&doc, "fn main() { }", 1)));
+        let seed = seed_tree(&doc).expect("seeded from the version-1 tree");
+        assert!(
+            seed_matches_text(&seed, "fn main() { x }"),
+            "the version-1 edit is consumed; only the version-2 edit is replayed"
+        );
+    }
+
+    /// A burst that outgrows the edit log gives up on seeding: the log is
+    /// cleared and the floor raised to the burst's version, so a tree
+    /// published for an earlier version cannot seed (its edits are gone) and
+    /// only a tree at or past the floor seeds again.
+    #[test]
+    fn an_edit_burst_beyond_the_log_cap_gives_up_seeding_until_a_fresh_tree() {
+        let mut doc = Document::with_tree(
+            "fn main() {}".to_string(),
+            "rust".to_string(),
+            rust_tree("fn main() {}"),
+            3,
+        );
+        let text_after = |edits: usize| format!("fn main() {{{}}}", " ".repeat(edits));
+        for edits in 1..=MAX_SEED_EDITS {
+            doc.apply_edit(text_after(edits), &[edit(11, 11, 12)]);
+        }
+        let seed = seed_tree(&doc).expect("a log at the cap still seeds");
+        assert!(seed_matches_text(&seed, &text_after(MAX_SEED_EDITS)));
+
+        doc.apply_edit(text_after(MAX_SEED_EDITS + 1), &[edit(11, 11, 12)]);
+        assert!(seed_tree(&doc).is_none(), "one past the cap: no seed");
+        let floor = doc.content_version();
+
+        // A tree for the version just before the burst overflowed: below the
+        // floor, and the edit that would bring it up to date is gone.
+        assert!(doc.publish_snapshot(&snapshot_at(&doc, &text_after(MAX_SEED_EDITS), floor - 1)));
+        assert!(
+            seed_tree(&doc).is_none(),
+            "a tree older than the floor must not seed"
+        );
+        assert!(doc.publish_snapshot(&snapshot_at(&doc, &text_after(MAX_SEED_EDITS + 1), floor)));
+        let seed = seed_tree(&doc).expect("a tree at the floor seeds again");
+        assert!(seed_matches_text(&seed, &text_after(MAX_SEED_EDITS + 1)));
+        doc.apply_edit(text_after(MAX_SEED_EDITS + 2), &[edit(11, 11, 12)]);
+        let seed = seed_tree(&doc).expect("and the log fills again");
+        assert!(seed_matches_text(&seed, &text_after(MAX_SEED_EDITS + 2)));
     }
 
     /// The off-ingress reparse's seed is derived, not stored: the published
@@ -572,6 +666,11 @@ mod tests {
         assert!(
             incremental_parse_matches_fresh(&seed, "fn main() { xy }"),
             "only the edit after version 2 is replayed"
+        );
+        assert_eq!(
+            doc.seed_edits.iter().map(|(v, _)| *v).collect::<Vec<_>>(),
+            vec![3],
+            "the edits the published tree consumed were pruned from the log"
         );
     }
 
@@ -710,10 +809,13 @@ mod tests {
         };
         doc.apply_edit("fn main() { }".to_string(), &[edit]);
 
-        assert!(doc.tree().is_none(), "reader-visible tree must be cleared");
         assert!(
-            seed_tree(&doc).is_some(),
-            "incremental seed must be stashed"
+            doc.tree().is_none(),
+            "the published tree must read as stale"
+        );
+        assert!(
+            seed_tree(&doc).is_some_and(|seed| seed_matches_text(&seed, "fn main() { }")),
+            "an incremental seed with the edit replayed must be derivable"
         );
         assert_eq!(doc.text(), "fn main() { }");
     }
@@ -776,8 +878,8 @@ mod tests {
 
         assert!(doc.tree().is_none());
         assert!(
-            seed_tree(&doc).is_some(),
-            "coalesced edit must keep the accumulated seed"
+            seed_tree(&doc).is_some_and(|seed| seed_matches_text(&seed, "fn main() {  }")),
+            "coalesced edits must still yield a seed with both replayed"
         );
         assert_eq!(doc.text(), "fn main() {  }");
     }

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -43,23 +43,22 @@ pub struct Document {
     /// edit, paid back by the many cheap clones per edit.
     text: Arc<str>,
     language_id: Option<String>,
-    tree: Option<Tree>,
     /// Edited-but-not-yet-reparsed seed for the **off-ingress** incremental parse
     /// (per-document-parse-scheduler).
     ///
-    /// `didChange` clears the reader-visible `tree` (so a reader never sees a tree
-    /// that predates the edit — the flip's reader-safety invariant) but stashes the
-    /// pre-edit tree here with the edit's `InputEdit`s already applied
+    /// `didChange` bumps `content_version` (so a reader never sees a tree that
+    /// predates the edit — the published snapshot is stale from then on) and
+    /// stashes the pre-edit tree here with the edit's `InputEdit`s already applied
     /// (`tree.edit()`). The off-ingress `reparse_latest` consumes it as
     /// `parser.parse(text, Some(seed))` to parse incrementally instead of from
     /// scratch. Coalesced edits accumulate their `InputEdit`s onto this same seed,
     /// so a burst still produces one correctly-edited seed for the final reparse.
     ///
     /// **Read by `reparse_latest` only** — never by `tree()` / `snapshot()`, which
-    /// must stay `None` until the reparse lands. Cleared the moment a fresh tree is
-    /// attached (`set_parse_result`, reached only through
-    /// `DocumentStore::install_parse`) — a present tree means the seed is
-    /// consumed — and on a
+    /// stay `None` until the reparse lands. Cleared the moment a fresh parse is
+    /// recorded (`set_parse_result`, reached only through
+    /// `DocumentStore::install_parse`) — the published tree has consumed the
+    /// seed — and on a
     /// full-text sync (`apply_edit_and_seed` with no `InputEdit`s), where seeding an
     /// unedited tree against wholly-replaced text would violate tree-sitter's
     /// incremental contract and corrupt external scanners (#348).
@@ -108,7 +107,6 @@ impl Document {
         Self {
             text: Arc::from(text),
             language_id: None,
-            tree: None,
             pending_seed: None,
             incarnation,
             content_version: 0,
@@ -122,7 +120,6 @@ impl Document {
         Self {
             text: Arc::from(text),
             language_id: Some(language_id),
-            tree: None,
             pending_seed: None,
             incarnation,
             content_version: 0,
@@ -131,23 +128,18 @@ impl Document {
         }
     }
 
-    /// Create with language and tree
+    /// Create with language and an already-parsed tree: published as the
+    /// lifetime's first snapshot, at version 0.
     pub(crate) fn with_tree(
         text: String,
         language_id: String,
         tree: Tree,
         incarnation: u64,
     ) -> Self {
-        Self {
-            text: Arc::from(text),
-            language_id: Some(language_id),
-            tree: Some(tree),
-            pending_seed: None,
-            incarnation,
-            content_version: 0,
-            snapshot_tx: watch::Sender::new(SnapshotSlot::bootstrap(incarnation)),
-            version_cancel: crate::cancel::CancelToken::default(),
-        }
+        let doc = Self::with_language(text, language_id, incarnation);
+        doc.snapshot_tx
+            .send_replace(doc.slot_with(doc.bare_snapshot(Some(tree))));
+        doc
     }
 
     /// Get the text content
@@ -167,9 +159,50 @@ impl Document {
         self.language_id.as_deref()
     }
 
-    /// Get the tree
-    pub fn tree(&self) -> Option<&Tree> {
-        self.tree.as_ref()
+    /// The current parse's tree: the published snapshot's, iff that snapshot
+    /// is this lifetime's and parsed this content version. An edit or a
+    /// reload makes the published snapshot stale, so this is `None` until the
+    /// reparse lands — a reader never sees a tree that predates the text.
+    /// (`Tree` clone is a refcount bump.)
+    pub(crate) fn tree(&self) -> Option<Tree> {
+        self.current_snapshot()
+            .and_then(|snapshot| snapshot.tree.clone())
+    }
+
+    /// The published snapshot iff it is this lifetime's and parsed the
+    /// current content version (parse-snapshot ADR §2 currency).
+    pub(crate) fn current_snapshot(&self) -> Option<Arc<ParseSnapshot>> {
+        let slot = self.snapshot_tx.borrow();
+        slot.snapshot
+            .as_ref()
+            .filter(|snapshot| {
+                snapshot.incarnation == self.incarnation
+                    && snapshot.parsed_version == self.content_version
+            })
+            .cloned()
+    }
+
+    /// A snapshot of the current inputs carrying `tree` and nothing derived —
+    /// the reload placeholder and the test fixtures' published tree.
+    fn bare_snapshot(&self, tree: Option<Tree>) -> Arc<ParseSnapshot> {
+        Arc::new(ParseSnapshot {
+            text: Arc::clone(&self.text),
+            tree,
+            language: self.language_id.clone(),
+            parsed_version: self.content_version,
+            incarnation: self.incarnation,
+            injection_regions: None,
+            bridge_regions: None,
+            resolved_regions: None,
+            layer_trees: std::sync::OnceLock::new(),
+        })
+    }
+
+    fn slot_with(&self, snapshot: Arc<ParseSnapshot>) -> SnapshotSlot {
+        SnapshotSlot {
+            current_incarnation: self.incarnation,
+            snapshot: Some(snapshot),
+        }
     }
 
     /// The document's open incarnation (see the [`incarnation`](Self::incarnation)
@@ -240,12 +273,13 @@ impl Document {
 
     /// Create an immutable snapshot of current document state
     ///
-    /// Returns None if document is not fully initialized (missing tree).
-    /// The snapshot clones text and tree to enable lock-free processing.
+    /// Returns None while the document has no current tree (see
+    /// [`tree`](Self::tree)). The snapshot clones text and tree to enable
+    /// lock-free processing.
     pub(crate) fn snapshot(&self) -> Option<DocumentSnapshot> {
         Some(DocumentSnapshot {
             text: self.text.clone(),
-            tree: self.tree.as_ref()?.clone(),
+            tree: self.tree()?,
             incarnation: self.incarnation,
         })
     }
@@ -253,81 +287,67 @@ impl Document {
     /// Install a freshly parsed tree together with its text.
     ///
     /// Replaces the text, so it counts as an input mutation and bumps
-    /// `content_version` (its callers pass the text the tree was parsed from,
-    /// which may or may not equal the stored text; bumping unconditionally
-    /// keeps the version a safe upper bound — a spurious bump only marks a
-    /// snapshot stale early, never serves a wrong one).
+    /// `content_version`, then publishes the tree at that version (a newer
+    /// tree-bearing snapshot is always admitted).
     #[cfg(test)]
     pub(crate) fn update_tree_and_text(&mut self, new_tree: Tree, new_text: String) {
         self.text = Arc::from(new_text);
         self.advance_input_version();
-        self.tree = Some(new_tree);
         // Any pending incremental seed is for an edit superseded by this fresh
-        // tree+text; keep the invariant "visible tree present ⟹ no stale seed" so a
-        // later `reparse_latest` can't seed from a tree that predates this text
+        // tree+text; keep the invariant "current tree present ⟹ no stale seed" so
+        // a later `reparse_latest` can't seed from a tree that predates this text
         // (the #348 contract hazard).
         self.pending_seed = None;
+        self.publish_snapshot(&self.bare_snapshot(Some(new_tree)));
     }
 
-    /// Drop the tree and the seed on a settings/grammar reload and publish a
-    /// tree-less placeholder at the bumped version (see `ParseSnapshot`).
+    /// Drop the seed on a settings/grammar reload and publish a tree-less
+    /// placeholder at the bumped version (see `ParseSnapshot`), which is what
+    /// takes the tree away from readers.
     pub(crate) fn invalidate_parse(&mut self) {
-        self.tree = None;
         self.pending_seed = None;
         // Grammar/query settings are parse inputs even when text is unchanged.
         // Advancing the internal version makes every pre-reload parse result
         // stale and lets the scheduled current-generation snapshot supersede it.
         self.advance_input_version();
-        self.snapshot_tx.send_replace(SnapshotSlot {
-            current_incarnation: self.incarnation,
-            snapshot: Some(Arc::new(ParseSnapshot {
-                text: Arc::clone(&self.text),
-                tree: None,
-                language: self.language_id.clone(),
-                parsed_version: self.content_version,
-                incarnation: self.incarnation,
-                injection_regions: None,
-                bridge_regions: None,
-                resolved_regions: None,
-                layer_trees: std::sync::OnceLock::new(),
-            })),
-        });
+        self.snapshot_tx
+            .send_replace(self.slot_with(self.bare_snapshot(None)));
     }
 
-    /// Store a parse result — the `language` and the parsed `tree` (`None` for
-    /// a parsed-to-nothing / no-language parse) — **preserving the existing
-    /// text**. Reached only through `DocumentStore::install_parse`, for every
-    /// parse path (open, installed-grammar reparse, edit reparse); the text
-    /// was stored when the document was registered, so the result is recorded
-    /// in place rather than re-inserting a copy of the (potentially large)
-    /// text.
+    /// Record a parse result's `language` (`None` for a no-language parse)
+    /// **preserving the existing text**; the tree itself reaches readers only
+    /// through the published snapshot. Reached only through
+    /// `DocumentStore::install_parse`, for every parse path (open,
+    /// installed-grammar reparse, edit reparse).
     ///
-    /// Clears `pending_seed`: a present reader-visible tree means the
-    /// off-ingress reparse's seed has been consumed, so the next `didChange`
-    /// seeds from this fresh tree, not a stale seed.
-    pub(crate) fn set_parse_result(&mut self, language: Option<String>, tree: Option<Tree>) {
+    /// Clears `pending_seed`: the published current tree has consumed the
+    /// off-ingress reparse's seed, so the next `didChange` seeds from that
+    /// fresh tree, not a stale seed.
+    pub(crate) fn set_parse_result(&mut self, language: Option<String>) {
         self.language_id = language;
-        self.tree = tree;
         self.pending_seed = None;
     }
 
     /// Apply an edit's new text and stash an **incremental parse seed** for the
-    /// off-ingress reparse, clearing the reader-visible tree.
+    /// off-ingress reparse.
     ///
-    /// The reader-visible `tree` is cleared (a reader must never see a tree that
-    /// predates this edit). The pre-edit tree — or the seed already accumulated by
-    /// an earlier coalesced edit — has `edits` applied via `tree.edit()` and is
-    /// stashed in `pending_seed` for `reparse_latest` to parse incrementally.
+    /// Bumping the content version makes the published snapshot stale, so a
+    /// reader never sees a tree that predates this edit. The pre-edit tree — or
+    /// the seed already accumulated by an earlier coalesced edit — has `edits`
+    /// applied via `tree.edit()` and is stashed in `pending_seed` for
+    /// `reparse_latest` to parse incrementally.
     ///
     /// With **no** `edits` (a full-text sync) the seed is dropped to `None`: seeding
     /// an unedited tree against wholly-replaced text violates tree-sitter's
     /// incremental contract and corrupted external scanners in #348, so a full-text
     /// sync must parse from scratch.
     pub(crate) fn apply_edit_and_seed(&mut self, new_text: String, edits: &[InputEdit]) {
-        // Base the seed on the reader-visible tree if present, else the seed an
-        // earlier coalesced edit already accumulated (the visible tree is cleared
-        // on the first edit of a burst, so subsequent edits chain onto the seed).
-        let base = self.tree.take().or_else(|| self.pending_seed.take());
+        // Base the seed on the current tree if present (read before the
+        // version bump makes it stale), else the seed an earlier coalesced edit
+        // already accumulated (the first edit of a burst makes the tree stale,
+        // so subsequent edits chain onto the seed). Editing a clone of the
+        // published tree leaves the snapshot's own copy untouched.
+        let base = self.tree().or_else(|| self.pending_seed.take());
         self.pending_seed = match base {
             Some(mut tree) if !edits.is_empty() => {
                 for edit in edits {
@@ -353,8 +373,7 @@ impl Document {
     #[cfg(test)]
     pub(crate) fn update_text(&mut self, text: String) {
         self.text = Arc::from(text);
-        // Note: Tree needs to be rebuilt after text change
-        self.tree = None;
+        // The version bump makes the published tree stale: readers see none.
         self.pending_seed = None;
         self.advance_input_version();
     }
@@ -380,7 +399,7 @@ mod tests {
         let doc = Document::with_language(text.to_string(), "rust".to_string(), 7);
         assert!(doc.tree().is_none(), "unparsed: no tree");
         let tree = rust_tree(text);
-        assert!(doc.publish_snapshot(Arc::new(ParseSnapshot {
+        assert!(doc.publish_snapshot(&Arc::new(ParseSnapshot {
             text: doc.text_arc(),
             tree: Some(tree.clone()),
             language: Some("rust".to_string()),
@@ -391,9 +410,12 @@ mod tests {
             resolved_regions: None,
             layer_trees: std::sync::OnceLock::new(),
         })));
+        // `Tree` clones share their subtrees but not the root handle, so a
+        // child node's id is the identity that survives the clone.
+        let first_child = |t: &Tree| t.root_node().named_child(0).map(|n| n.id());
         assert_eq!(
-            doc.tree().map(|t| t.root_node().id()),
-            Some(tree.root_node().id()),
+            doc.tree().as_ref().and_then(first_child),
+            first_child(&tree),
             "the published snapshot's tree is the document's tree"
         );
         assert!(doc.snapshot().is_some());
@@ -440,14 +462,16 @@ mod tests {
         doc.update_text("fn main() { }".to_string());
         assert_eq!(doc.content_version(), 1);
 
-        // A parse-result write does not bump.
+        // A parse-result write (language record + published tree) does not bump.
         let tree = parser.parse("fn main() { }", None).unwrap();
-        doc.set_parse_result(Some("rust".to_string()), Some(tree));
+        doc.set_parse_result(Some("rust".to_string()));
+        assert!(doc.publish_snapshot(&doc.bare_snapshot(Some(tree))));
         assert_eq!(
             doc.content_version(),
             1,
-            "set_parse_result is not an input mutation"
+            "a parse result is not an input mutation"
         );
+        assert!(doc.tree().is_some());
 
         // An incremental edit bumps.
         doc.apply_edit_and_seed("fn main() {  }".to_string(), &[]);
@@ -596,12 +620,13 @@ mod tests {
         assert!(doc.pending_seed().is_some());
 
         let reparsed = parser.parse("fn main() { }", None).unwrap();
-        doc.set_parse_result(Some("rust".to_string()), Some(reparsed));
+        assert!(doc.publish_snapshot(&doc.bare_snapshot(Some(reparsed))));
+        doc.set_parse_result(Some("rust".to_string()));
 
         assert!(doc.tree().is_some());
         assert!(
             doc.pending_seed().is_none(),
-            "attaching a fresh tree must consume the seed"
+            "recording a fresh parse must consume the seed"
         );
     }
 

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -53,16 +53,17 @@ pub struct Document {
     /// seeding (a full parse is cheaper than an unbounded log).
     seed_edits: Vec<(u64, InputEdit)>,
     /// The content version below which no published tree may seed a parse.
-    /// A full-text sync (`apply_edit` with no `InputEdit`s) and a
-    /// grammar reload set it to the version they produce: seeding an unedited
-    /// tree against wholly-replaced text violates tree-sitter's incremental
-    /// contract and corrupted external scanners (#348), and the edits that
-    /// follow cannot be replayed onto a tree from before the sync either.
+    /// A full-text sync (`apply_edit` with no `InputEdit`s), a grammar
+    /// reload, and an edit log that outgrows [`MAX_SEED_EDITS`] set it to the
+    /// version they produce: seeding an unedited tree against wholly-replaced
+    /// text violates tree-sitter's incremental contract and corrupted
+    /// external scanners (#348), and the edits that follow cannot be replayed
+    /// onto a tree from before the cut either.
     seed_floor: u64,
     /// The document's **open incarnation** — a process-wide-unique number drawn
     /// from [`DocumentStore`](crate::document::store::DocumentStore)'s monotonic
     /// counter at every construction (so a `didClose` + reopen of the same URI
-    /// yields a fresh value). Stored *on the document* so a tree-write CAS or a
+    /// yields a fresh value). Stored *on the document* so `install_parse` or a
     /// watermark advance can check it **atomically with the document state**
     /// under the same shard lock — closing the residual where an in-flight
     /// off-ingress parse from a prior lifetime publishes against the reopened
@@ -787,7 +788,7 @@ mod tests {
         assert!(doc.tree().is_none());
     }
 
-    /// A non-empty edit stashes an incremental parse seed and clears the
+    /// A non-empty edit logs its `InputEdit` for the seed and stales the
     /// reader-visible tree (readers must not see a pre-reparse tree).
     #[test]
     fn apply_edit_logs_the_edit_for_the_seed_and_stales_the_tree() {
@@ -842,8 +843,8 @@ mod tests {
         );
     }
 
-    /// Coalesced edits accumulate onto the same seed: after a first edit clears the
-    /// visible tree, a second edit chains its `InputEdit` onto the stashed seed.
+    /// Coalesced edits accumulate in the log: after a first edit stales the
+    /// published tree, a second edit's `InputEdit` is replayed after the first.
     #[test]
     fn apply_edit_coalesces_across_edits() {
         let mut parser = tree_sitter::Parser::new();
@@ -864,8 +865,8 @@ mod tests {
         doc.apply_edit("fn main() { }".to_string(), &[edit1]);
         assert!(doc.tree().is_none());
 
-        // Second edit lands while the visible tree is still cleared: it must chain
-        // onto the accumulated seed, not silently drop incrementality.
+        // Second edit lands while the published tree is still stale: it must
+        // join the log, not silently drop incrementality.
         let edit2 = InputEdit {
             start_byte: 12,
             old_end_byte: 12,

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -53,7 +53,7 @@ pub struct Document {
     /// seeding (a full parse is cheaper than an unbounded log).
     seed_edits: Vec<(u64, InputEdit)>,
     /// The content version below which no published tree may seed a parse.
-    /// A full-text sync (`apply_edit_and_seed` with no `InputEdit`s) and a
+    /// A full-text sync (`apply_edit` with no `InputEdit`s) and a
     /// grammar reload set it to the version they produce: seeding an unedited
     /// tree against wholly-replaced text violates tree-sitter's incremental
     /// contract and corrupted external scanners (#348), and the edits that
@@ -321,7 +321,7 @@ impl Document {
     /// through the published snapshot. Reached only through
     /// `DocumentStore::install_parse`, for every parse path (open,
     /// installed-grammar reparse, edit reparse).
-    pub(crate) fn set_parse_result(&mut self, language: Option<String>) {
+    pub(crate) fn record_language(&mut self, language: Option<String>) {
         self.language_id = language;
     }
 
@@ -338,7 +338,7 @@ impl Document {
     /// an unedited tree against wholly-replaced text violates tree-sitter's
     /// incremental contract and corrupted external scanners in #348, so a full-text
     /// sync must parse from scratch.
-    pub(crate) fn apply_edit_and_seed(&mut self, new_text: String, edits: &[InputEdit]) {
+    pub(crate) fn apply_edit(&mut self, new_text: String, edits: &[InputEdit]) {
         self.text = Arc::from(new_text);
         self.advance_input_version();
         if edits.is_empty() {
@@ -400,7 +400,7 @@ impl Document {
     pub(crate) fn update_text(&mut self, text: String) {
         // A full-text sync: the version bump makes the published tree stale
         // for readers, and nothing may seed against the replaced text.
-        self.apply_edit_and_seed(text, &[]);
+        self.apply_edit(text, &[]);
     }
 }
 
@@ -455,7 +455,7 @@ mod tests {
             "an unedited current tree seeds as is"
         );
 
-        doc.apply_edit_and_seed("fn main() { }".to_string(), &[edit(11, 11, 12)]);
+        doc.apply_edit("fn main() { }".to_string(), &[edit(11, 11, 12)]);
         let seed = doc.incremental_seed().expect("one edit: seeded");
         assert!(incremental_parse_matches_fresh(&seed, "fn main() { }"));
         assert!(
@@ -463,7 +463,7 @@ mod tests {
             "the edit made the published tree stale"
         );
 
-        doc.apply_edit_and_seed("fn main() { x }".to_string(), &[edit(12, 12, 14)]);
+        doc.apply_edit("fn main() { x }".to_string(), &[edit(12, 12, 14)]);
         let seed = doc
             .incremental_seed()
             .expect("coalesced edits: still seeded");
@@ -492,12 +492,12 @@ mod tests {
             rust_tree("fn main() {}"),
             3,
         );
-        doc.apply_edit_and_seed("fn other() {}".to_string(), &[]);
+        doc.apply_edit("fn other() {}".to_string(), &[]);
         assert!(
             doc.incremental_seed().is_none(),
             "full sync: parse from scratch"
         );
-        doc.apply_edit_and_seed("fn other() { }".to_string(), &[edit(12, 12, 13)]);
+        doc.apply_edit("fn other() { }".to_string(), &[edit(12, 12, 13)]);
         assert!(
             doc.incremental_seed().is_none(),
             "an edit after the sync has no tree it can be replayed onto"
@@ -508,7 +508,7 @@ mod tests {
             doc.incremental_seed().is_some(),
             "a fresh published tree seeds again"
         );
-        doc.apply_edit_and_seed("fn other() { y }".to_string(), &[edit(13, 13, 15)]);
+        doc.apply_edit("fn other() { y }".to_string(), &[edit(13, 13, 15)]);
         let seed = doc.incremental_seed().expect("seeded from the fresh tree");
         assert!(incremental_parse_matches_fresh(&seed, "fn other() { y }"));
     }
@@ -524,11 +524,11 @@ mod tests {
             rust_tree("fn main() {}"),
             3,
         );
-        doc.apply_edit_and_seed("fn main() { }".to_string(), &[edit(11, 11, 12)]);
-        doc.apply_edit_and_seed("fn main() { x }".to_string(), &[edit(12, 12, 14)]);
+        doc.apply_edit("fn main() { }".to_string(), &[edit(11, 11, 12)]);
+        doc.apply_edit("fn main() { x }".to_string(), &[edit(12, 12, 14)]);
         // The reparse of version 2 lands.
         assert!(doc.publish_snapshot(&doc.bare_snapshot(Some(rust_tree("fn main() { x }")))));
-        doc.apply_edit_and_seed("fn main() { xy }".to_string(), &[edit(13, 13, 14)]);
+        doc.apply_edit("fn main() { xy }".to_string(), &[edit(13, 13, 14)]);
         let seed = doc
             .incremental_seed()
             .expect("seeded from the version-2 tree");
@@ -611,7 +611,7 @@ mod tests {
 
         // A parse-result write (language record + published tree) does not bump.
         let tree = parser.parse("fn main() { }", None).unwrap();
-        doc.set_parse_result(Some("rust".to_string()));
+        doc.record_language(Some("rust".to_string()));
         assert!(doc.publish_snapshot(&doc.bare_snapshot(Some(tree))));
         assert_eq!(
             doc.content_version(),
@@ -621,7 +621,7 @@ mod tests {
         assert!(doc.tree().is_some());
 
         // An incremental edit bumps.
-        doc.apply_edit_and_seed("fn main() {  }".to_string(), &[]);
+        doc.apply_edit("fn main() {  }".to_string(), &[]);
         assert_eq!(doc.content_version(), 2);
     }
 
@@ -631,7 +631,7 @@ mod tests {
         let obsolete = doc.version_cancel.clone();
         assert!(!obsolete.is_cancelled());
 
-        doc.apply_edit_and_seed("fn main() { }".to_string(), &[]);
+        doc.apply_edit("fn main() { }".to_string(), &[]);
 
         assert!(
             obsolete.is_cancelled(),
@@ -654,7 +654,7 @@ mod tests {
     /// A non-empty edit stashes an incremental parse seed and clears the
     /// reader-visible tree (readers must not see a pre-reparse tree).
     #[test]
-    fn apply_edit_and_seed_stashes_seed_and_clears_tree() {
+    fn apply_edit_logs_the_edit_for_the_seed_and_stales_the_tree() {
         let mut parser = tree_sitter::Parser::new();
         parser
             .set_language(&tree_sitter_rust::LANGUAGE.into())
@@ -671,7 +671,7 @@ mod tests {
             old_end_position: tree_sitter::Point::new(0, 11),
             new_end_position: tree_sitter::Point::new(0, 12),
         };
-        doc.apply_edit_and_seed("fn main() { }".to_string(), &[edit]);
+        doc.apply_edit("fn main() { }".to_string(), &[edit]);
 
         assert!(doc.tree().is_none(), "reader-visible tree must be cleared");
         assert!(
@@ -685,7 +685,7 @@ mod tests {
     /// tree against wholly-replaced text is the tree-sitter contract violation that
     /// caused the #348 heap corruption.
     #[test]
-    fn apply_edit_and_seed_drops_seed_on_full_text_sync() {
+    fn apply_edit_forbids_seeding_on_full_text_sync() {
         let mut parser = tree_sitter::Parser::new();
         parser
             .set_language(&tree_sitter_rust::LANGUAGE.into())
@@ -694,7 +694,7 @@ mod tests {
         let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree, 0);
 
         // Full-text sync carries no InputEdits.
-        doc.apply_edit_and_seed("totally different content".to_string(), &[]);
+        doc.apply_edit("totally different content".to_string(), &[]);
 
         assert!(doc.tree().is_none());
         assert!(
@@ -706,7 +706,7 @@ mod tests {
     /// Coalesced edits accumulate onto the same seed: after a first edit clears the
     /// visible tree, a second edit chains its `InputEdit` onto the stashed seed.
     #[test]
-    fn apply_edit_and_seed_coalesces_across_edits() {
+    fn apply_edit_coalesces_across_edits() {
         let mut parser = tree_sitter::Parser::new();
         parser
             .set_language(&tree_sitter_rust::LANGUAGE.into())
@@ -722,7 +722,7 @@ mod tests {
             old_end_position: tree_sitter::Point::new(0, 11),
             new_end_position: tree_sitter::Point::new(0, 12),
         };
-        doc.apply_edit_and_seed("fn main() { }".to_string(), &[edit1]);
+        doc.apply_edit("fn main() { }".to_string(), &[edit1]);
         assert!(doc.tree().is_none());
 
         // Second edit lands while the visible tree is still cleared: it must chain
@@ -735,7 +735,7 @@ mod tests {
             old_end_position: tree_sitter::Point::new(0, 12),
             new_end_position: tree_sitter::Point::new(0, 13),
         };
-        doc.apply_edit_and_seed("fn main() {  }".to_string(), &[edit2]);
+        doc.apply_edit("fn main() {  }".to_string(), &[edit2]);
 
         assert!(doc.tree().is_none());
         assert!(

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -43,26 +43,22 @@ pub struct Document {
     /// edit, paid back by the many cheap clones per edit.
     text: Arc<str>,
     language_id: Option<String>,
-    /// Edited-but-not-yet-reparsed seed for the **off-ingress** incremental parse
-    /// (per-document-parse-scheduler).
-    ///
-    /// `didChange` bumps `content_version` (so a reader never sees a tree that
-    /// predates the edit — the published snapshot is stale from then on) and
-    /// stashes the pre-edit tree here with the edit's `InputEdit`s already applied
-    /// (`tree.edit()`). The off-ingress `reparse_latest` consumes it as
-    /// `parser.parse(text, Some(seed))` to parse incrementally instead of from
-    /// scratch. Coalesced edits accumulate their `InputEdit`s onto this same seed,
-    /// so a burst still produces one correctly-edited seed for the final reparse.
-    ///
-    /// **Read by `reparse_latest` only** — never by `tree()` / `snapshot()`, which
-    /// stay `None` until the reparse lands. Cleared the moment a fresh parse is
-    /// recorded (`set_parse_result`, reached only through
-    /// `DocumentStore::install_parse`) — the published tree has consumed the
-    /// seed — and on a
-    /// full-text sync (`apply_edit_and_seed` with no `InputEdit`s), where seeding an
-    /// unedited tree against wholly-replaced text would violate tree-sitter's
-    /// incremental contract and corrupt external scanners (#348).
-    pending_seed: Option<Tree>,
+    /// The edits since the published tree, each tagged with the content
+    /// version it produced — the inputs of the **off-ingress** incremental
+    /// parse's seed (per-document-parse-scheduler), which
+    /// [`incremental_seed`](Self::incremental_seed) derives by replaying
+    /// them onto a clone of the published tree. Entries the published tree
+    /// already consumed (tagged at or below its `parsed_version`) are pruned
+    /// on the next edit; a burst that outgrows [`MAX_SEED_EDITS`] gives up on
+    /// seeding (a full parse is cheaper than an unbounded log).
+    seed_edits: Vec<(u64, InputEdit)>,
+    /// The content version below which no published tree may seed a parse.
+    /// A full-text sync (`apply_edit_and_seed` with no `InputEdit`s) and a
+    /// grammar reload set it to the version they produce: seeding an unedited
+    /// tree against wholly-replaced text violates tree-sitter's incremental
+    /// contract and corrupted external scanners (#348), and the edits that
+    /// follow cannot be replayed onto a tree from before the sync either.
+    seed_floor: u64,
     /// The document's **open incarnation** — a process-wide-unique number drawn
     /// from [`DocumentStore`](crate::document::store::DocumentStore)'s monotonic
     /// counter at every construction (so a `didClose` + reopen of the same URI
@@ -101,13 +97,18 @@ pub struct Document {
     version_cancel: crate::cancel::CancelToken,
 }
 
+/// The most edits `seed_edits` keeps before the document gives up on seeding
+/// the next parse incrementally.
+const MAX_SEED_EDITS: usize = 1024;
+
 impl Document {
     /// Create a new document with just text
     pub(crate) fn new(text: String, incarnation: u64) -> Self {
         Self {
             text: Arc::from(text),
             language_id: None,
-            pending_seed: None,
+            seed_edits: Vec::new(),
+            seed_floor: 0,
             incarnation,
             content_version: 0,
             snapshot_tx: watch::Sender::new(SnapshotSlot::bootstrap(incarnation)),
@@ -120,7 +121,8 @@ impl Document {
         Self {
             text: Arc::from(text),
             language_id: Some(language_id),
-            pending_seed: None,
+            seed_edits: Vec::new(),
+            seed_floor: 0,
             incarnation,
             content_version: 0,
             snapshot_tx: watch::Sender::new(SnapshotSlot::bootstrap(incarnation)),
@@ -293,23 +295,23 @@ impl Document {
     pub(crate) fn update_tree_and_text(&mut self, new_tree: Tree, new_text: String) {
         self.text = Arc::from(new_text);
         self.advance_input_version();
-        // Any pending incremental seed is for an edit superseded by this fresh
-        // tree+text; keep the invariant "current tree present ⟹ no stale seed" so
-        // a later `reparse_latest` can't seed from a tree that predates this text
-        // (the #348 contract hazard).
-        self.pending_seed = None;
+        // The text was replaced wholesale: no earlier tree may seed against it
+        // (#348); the tree published here, at this version, may.
+        self.seed_edits.clear();
+        self.seed_floor = self.content_version;
         self.publish_snapshot(&self.bare_snapshot(Some(new_tree)));
     }
 
-    /// Drop the seed on a settings/grammar reload and publish a tree-less
-    /// placeholder at the bumped version (see `ParseSnapshot`), which is what
-    /// takes the tree away from readers.
+    /// Publish a tree-less placeholder at the bumped version on a
+    /// settings/grammar reload (see `ParseSnapshot`), which is what takes the
+    /// tree away from readers, and forbid seeding from any pre-reload tree.
     pub(crate) fn invalidate_parse(&mut self) {
-        self.pending_seed = None;
         // Grammar/query settings are parse inputs even when text is unchanged.
         // Advancing the internal version makes every pre-reload parse result
         // stale and lets the scheduled current-generation snapshot supersede it.
         self.advance_input_version();
+        self.seed_edits.clear();
+        self.seed_floor = self.content_version;
         self.snapshot_tx
             .send_replace(self.slot_with(self.bare_snapshot(None)));
     }
@@ -319,63 +321,86 @@ impl Document {
     /// through the published snapshot. Reached only through
     /// `DocumentStore::install_parse`, for every parse path (open,
     /// installed-grammar reparse, edit reparse).
-    ///
-    /// Clears `pending_seed`: the published current tree has consumed the
-    /// off-ingress reparse's seed, so the next `didChange` seeds from that
-    /// fresh tree, not a stale seed.
     pub(crate) fn set_parse_result(&mut self, language: Option<String>) {
         self.language_id = language;
-        self.pending_seed = None;
     }
 
-    /// Apply an edit's new text and stash an **incremental parse seed** for the
-    /// off-ingress reparse.
+    /// Apply an edit's new text and log its `InputEdit`s for the off-ingress
+    /// reparse's **incremental parse seed**.
     ///
     /// Bumping the content version makes the published snapshot stale, so a
-    /// reader never sees a tree that predates this edit. The pre-edit tree — or
-    /// the seed already accumulated by an earlier coalesced edit — has `edits`
-    /// applied via `tree.edit()` and is stashed in `pending_seed` for
-    /// `reparse_latest` to parse incrementally.
+    /// reader never sees a tree that predates this edit. The edits are logged
+    /// under the new version; [`incremental_seed`](Self::incremental_seed)
+    /// replays them (and those of any coalesced edit before the reparse) onto
+    /// a clone of the published tree.
     ///
     /// With **no** `edits` (a full-text sync) the seed is dropped to `None`: seeding
     /// an unedited tree against wholly-replaced text violates tree-sitter's
     /// incremental contract and corrupted external scanners in #348, so a full-text
     /// sync must parse from scratch.
     pub(crate) fn apply_edit_and_seed(&mut self, new_text: String, edits: &[InputEdit]) {
-        // Base the seed on the current tree if present (read before the
-        // version bump makes it stale), else the seed an earlier coalesced edit
-        // already accumulated (the first edit of a burst makes the tree stale,
-        // so subsequent edits chain onto the seed). Editing a clone of the
-        // published tree leaves the snapshot's own copy untouched.
-        let base = self.tree().or_else(|| self.pending_seed.take());
-        self.pending_seed = match base {
-            Some(mut tree) if !edits.is_empty() => {
-                for edit in edits {
-                    tree.edit(edit);
-                }
-                Some(tree)
-            }
-            // Full-text sync (no edits) or no base tree: parse from scratch (#348).
-            _ => None,
-        };
         self.text = Arc::from(new_text);
         self.advance_input_version();
+        if edits.is_empty() {
+            // Full-text sync: parse from scratch (#348), and nothing published
+            // before this version may seed the edits that follow either.
+            self.seed_edits.clear();
+            self.seed_floor = self.content_version;
+            return;
+        }
+        // Entries the published tree already consumed are dead weight: a
+        // seed replays only edits after that tree's version.
+        let consumed = self.published_parsed_version();
+        self.seed_edits.retain(|(version, _)| *version > consumed);
+        self.seed_edits
+            .extend(edits.iter().map(|edit| (self.content_version, *edit)));
+        if self.seed_edits.len() > MAX_SEED_EDITS {
+            self.seed_edits.clear();
+            self.seed_floor = self.content_version;
+        }
     }
 
-    /// The off-ingress incremental parse seed, if any. **Read only by
-    /// `reparse_latest`** — `tree()` / `snapshot()` deliberately ignore it so a
-    /// reader never observes a pre-reparse tree. See [`pending_seed`](Self::pending_seed).
-    pub(crate) fn pending_seed(&self) -> Option<&Tree> {
-        self.pending_seed.as_ref()
+    /// The version the published snapshot (this lifetime's) parsed, if any.
+    fn published_parsed_version(&self) -> u64 {
+        let slot = self.snapshot_tx.borrow();
+        slot.snapshot
+            .as_ref()
+            .filter(|snapshot| snapshot.incarnation == self.incarnation)
+            .map_or(0, |snapshot| snapshot.parsed_version)
+    }
+
+    /// The off-ingress incremental parse seed, if any: a clone of the
+    /// published tree with every logged edit after its version replayed via
+    /// `tree.edit()`, so the reparse can `parser.parse(text, Some(&seed))`
+    /// instead of parsing from scratch. `None` when nothing is published,
+    /// the published snapshot is tree-less, or it predates a full-text sync
+    /// or reload (`seed_floor`). **Read only by `reparse_latest`** — readers
+    /// go through [`tree`](Self::tree), which never serves a pre-reparse
+    /// tree. Editing the clone leaves the snapshot's own tree untouched.
+    pub(crate) fn incremental_seed(&self) -> Option<Tree> {
+        let slot = self.snapshot_tx.borrow();
+        let snapshot = slot
+            .snapshot
+            .as_ref()
+            .filter(|snapshot| snapshot.incarnation == self.incarnation)?;
+        if snapshot.parsed_version < self.seed_floor {
+            return None;
+        }
+        let mut tree = snapshot.tree.clone()?;
+        for (version, edit) in &self.seed_edits {
+            if *version > snapshot.parsed_version {
+                tree.edit(edit);
+            }
+        }
+        Some(tree)
     }
 
     /// Update text and clear layers/state
     #[cfg(test)]
     pub(crate) fn update_text(&mut self, text: String) {
-        self.text = Arc::from(text);
-        // The version bump makes the published tree stale: readers see none.
-        self.pending_seed = None;
-        self.advance_input_version();
+        // A full-text sync: the version bump makes the published tree stale
+        // for readers, and nothing may seed against the replaced text.
+        self.apply_edit_and_seed(text, &[]);
     }
 }
 
@@ -478,7 +503,7 @@ mod tests {
             "an edit after the sync has no tree it can be replayed onto"
         );
 
-        assert!(doc.publish_snapshot(doc.bare_snapshot(Some(rust_tree("fn other() { }")))));
+        assert!(doc.publish_snapshot(&doc.bare_snapshot(Some(rust_tree("fn other() { }")))));
         assert!(
             doc.incremental_seed().is_some(),
             "a fresh published tree seeds again"
@@ -502,7 +527,7 @@ mod tests {
         doc.apply_edit_and_seed("fn main() { }".to_string(), &[edit(11, 11, 12)]);
         doc.apply_edit_and_seed("fn main() { x }".to_string(), &[edit(12, 12, 14)]);
         // The reparse of version 2 lands.
-        assert!(doc.publish_snapshot(doc.bare_snapshot(Some(rust_tree("fn main() { x }")))));
+        assert!(doc.publish_snapshot(&doc.bare_snapshot(Some(rust_tree("fn main() { x }")))));
         doc.apply_edit_and_seed("fn main() { xy }".to_string(), &[edit(13, 13, 14)]);
         let seed = doc
             .incremental_seed()
@@ -650,7 +675,7 @@ mod tests {
 
         assert!(doc.tree().is_none(), "reader-visible tree must be cleared");
         assert!(
-            doc.pending_seed().is_some(),
+            doc.incremental_seed().is_some(),
             "incremental seed must be stashed"
         );
         assert_eq!(doc.text(), "fn main() { }");
@@ -673,7 +698,7 @@ mod tests {
 
         assert!(doc.tree().is_none());
         assert!(
-            doc.pending_seed().is_none(),
+            doc.incremental_seed().is_none(),
             "full-text sync must not leave a stale seed (#348)"
         );
     }
@@ -714,73 +739,10 @@ mod tests {
 
         assert!(doc.tree().is_none());
         assert!(
-            doc.pending_seed().is_some(),
+            doc.incremental_seed().is_some(),
             "coalesced edit must keep the accumulated seed"
         );
         assert_eq!(doc.text(), "fn main() {  }");
-    }
-
-    /// Attaching a fresh tree consumes (clears) the pending seed.
-    #[test]
-    fn set_parse_result_clears_pending_seed() {
-        let mut parser = tree_sitter::Parser::new();
-        parser
-            .set_language(&tree_sitter_rust::LANGUAGE.into())
-            .unwrap();
-        let tree = parser.parse("fn main() {}", None).unwrap();
-        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree, 0);
-
-        let edit = InputEdit {
-            start_byte: 11,
-            old_end_byte: 11,
-            new_end_byte: 12,
-            start_position: tree_sitter::Point::new(0, 11),
-            old_end_position: tree_sitter::Point::new(0, 11),
-            new_end_position: tree_sitter::Point::new(0, 12),
-        };
-        doc.apply_edit_and_seed("fn main() { }".to_string(), &[edit]);
-        assert!(doc.pending_seed().is_some());
-
-        let reparsed = parser.parse("fn main() { }", None).unwrap();
-        assert!(doc.publish_snapshot(&doc.bare_snapshot(Some(reparsed))));
-        doc.set_parse_result(Some("rust".to_string()));
-
-        assert!(doc.tree().is_some());
-        assert!(
-            doc.pending_seed().is_none(),
-            "recording a fresh parse must consume the seed"
-        );
-    }
-
-    /// Every method that installs a fresh visible tree must clear `pending_seed`,
-    /// upholding "visible tree present ⟹ no stale seed" — else a later
-    /// `reparse_latest` could seed from a tree predating the new text (#348).
-    #[test]
-    fn fresh_tree_updates_clear_pending_seed() {
-        let mut parser = tree_sitter::Parser::new();
-        parser
-            .set_language(&tree_sitter_rust::LANGUAGE.into())
-            .unwrap();
-        let edit = InputEdit {
-            start_byte: 11,
-            old_end_byte: 11,
-            new_end_byte: 12,
-            start_position: tree_sitter::Point::new(0, 11),
-            old_end_position: tree_sitter::Point::new(0, 11),
-            new_end_position: tree_sitter::Point::new(0, 12),
-        };
-
-        // update_tree_and_text clears the seed.
-        let tree = parser.parse("fn main() {}", None).unwrap();
-        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree, 0);
-        doc.apply_edit_and_seed("fn main() { }".to_string(), &[edit]);
-        assert!(doc.pending_seed().is_some());
-        let t2 = parser.parse("fn main() { }", None).unwrap();
-        doc.update_tree_and_text(t2, "fn main() { }".to_string());
-        assert!(
-            doc.pending_seed().is_none(),
-            "update_tree_and_text must clear the pending seed"
-        );
     }
 
     #[test]

--- a/src/document/snapshot.rs
+++ b/src/document/snapshot.rs
@@ -48,7 +48,7 @@ pub(crate) struct ParseSnapshot {
     pub(crate) text: Arc<str>,
     pub(crate) tree: Option<Tree>,
     /// The parse's own content-detected language — the snapshot architecture's
-    /// reader-facing refinement, independent of whether the legacy store-backed
+    /// reader-facing refinement, independent of whether the open parse
     /// path also writes the detection back to `Document::language_id` (ADR §1).
     pub(crate) language: Option<String>,
     /// The `Document::content_version` the parse consumed.

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -678,63 +678,50 @@ pub(crate) struct SnapshotView {
     pub(crate) content_version: u64,
 }
 
-/// What a parse pass expects the document to still be when its result is
-/// installed: the exact inputs it parsed. A relabelled language rejects the
-/// whole install; otherwise the cell's admission rule decides the publish,
-/// and the legacy tree is attached only when the snapshot was admitted AND
-/// the text, incarnation and content version are unchanged — so a document
-/// that moved on (an edit, a close and reopen) can still publish an older
-/// snapshot without attaching its tree, and an equal-version sibling parse
-/// attaches nothing even with unchanged inputs.
-pub(crate) struct ParseInputs<'a> {
-    /// The exact text allocation the parse read (`Document::text_arc`);
-    /// compared by identity, not content — this is the large-document open
-    /// path and the compare runs under the shard's write guard.
-    pub(crate) text: &'a Arc<str>,
-    /// `Some(expected)` requires the document's stored language to still be
-    /// `expected` (`Some(None)`: still unlabelled) — an off-ingress reparse
-    /// must not attach to a relabelled reopen — and leaves the stored
-    /// language as it is; the tree alone is attached. `None` lets the
-    /// snapshot's language (first-parse detection) become the stored one.
-    pub(crate) language_id: Option<Option<&'a str>>,
-    pub(crate) incarnation: u64,
-    pub(crate) content_version: u64,
+/// How `install_parse` treats the document's stored language.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum LanguageCheck<'a> {
+    /// The open parse: the snapshot's detected language becomes the stored
+    /// one when the parse is current.
+    Record,
+    /// An off-ingress reparse: the stored language must still be the one
+    /// the parse was run for (`None`: still unlabelled) or the whole install
+    /// is rejected — a tree from the old grammar must not reach a relabelled
+    /// reopen — and the stored language is left as it is.
+    Expect(Option<&'a str>),
 }
 
 /// The outcome of [`DocumentStore::install_parse`].
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ParseInstall {
-    /// The legacy tree (and language) were attached: the inputs were
-    /// unchanged and the snapshot was admitted (implies `published`).
-    pub(crate) attached: bool,
+    /// The snapshot is the document's current parse: it was admitted and its
+    /// `parsed_version` is the document's content version (implies
+    /// `published`). Gates the tree-dependent downstream (`has_tree`, the
+    /// open parse's follow-ups); a stale-but-consistent parse publishes
+    /// without it.
+    pub(crate) current: bool,
     /// The snapshot landed in the document's cell: the language matched and
     /// the slot admitted it.
     pub(crate) published: bool,
 }
 
 impl DocumentStore {
-    /// Install a parse result: attach its tree (and language) to the legacy
-    /// document iff `expected` still describes the document, and publish
-    /// `snapshot` iff the cell admits it — both under the document's entry
-    /// lock, as the one way a parse reaches readers. The `parse_states`
-    /// `has_tree` flip runs after that guard is released (a different map);
-    /// it is non-inserting, so a `didClose` between the two leaves no ghost
-    /// entry.
-    ///
-    /// The two writes share one `get_mut` guard, and the tree is attached
-    /// only when the snapshot was admitted, so no reader can observe a tree
-    /// whose snapshot is not in the cell and no path can attach a tree
-    /// without publishing: this is the only attach entry point. The reverse
-    /// is allowed — the snapshot may land while the tree does not, when the
-    /// inputs moved on: a parse of text an edit has moved on from is stale
-    /// but consistent, which serve-stale readers consume (parse-snapshot
-    /// ADR), and the cell's admission rule rejects an out-of-order version on
-    /// its own. A language check that fails rejects both: the tree belongs
-    /// to a language the document no longer has, and so does the snapshot.
+    /// Install a parse result: publish `snapshot` iff the stored language
+    /// passes `language` and the cell admits it, under the document's entry
+    /// lock — the one way a parse reaches readers (`Document::tree` is the
+    /// published snapshot's tree). Whether the parse is *current* is the
+    /// snapshot's own stamps against the document: the cell already requires
+    /// its lifetime, and its `parsed_version` must be the content version.
+    /// A stale-but-consistent parse (an edit landed since) still publishes,
+    /// which serve-stale readers consume (parse-snapshot ADR); the cell
+    /// rejects an out-of-order version on its own; a failed language check
+    /// rejects the install outright. The `parse_states` `has_tree` flip runs
+    /// after the guard is released (a different map); it is non-inserting,
+    /// so a `didClose` between the two leaves no ghost entry.
     pub(crate) fn install_parse(
         &self,
         uri: &Url,
-        expected: ParseInputs<'_>,
+        language: LanguageCheck<'_>,
         snapshot: Arc<super::snapshot::ParseSnapshot>,
     ) -> ParseInstall {
         let has_tree = snapshot.tree.is_some();
@@ -749,32 +736,22 @@ impl DocumentStore {
             .get_mut(uri)
             .map_or_else(ParseInstall::default, |mut doc| {
                 evicted = doc.latest_snapshot_slot().snapshot;
-                if expected
-                    .language_id
-                    .is_some_and(|language_id| doc.language_id() != language_id)
+                if let LanguageCheck::Expect(expected) = language
+                    && doc.language_id() != expected
                 {
                     return ParseInstall::default();
                 }
-                let inputs_unchanged = doc.incarnation() == expected.incarnation
-                    && doc.content_version() == expected.content_version
-                    && Arc::ptr_eq(&doc.text_arc(), expected.text);
-                // A checked language is kept as stored: the reparses attach
-                // a tree, they do not relabel (the snapshot carries the
-                // detected name for its own readers). Only the open parse
-                // (`language_id: None`) records what it detected.
-                let language = match expected.language_id {
-                    None => snapshot.language.clone(),
-                    Some(_) => doc.language_id().map(String::from),
-                };
+                let parsed_current_version = snapshot.parsed_version == doc.content_version();
+                let detected = snapshot.language.clone();
                 let published = doc.publish_snapshot(&snapshot);
-                let attached = inputs_unchanged && published;
-                if attached {
-                    doc.set_parse_result(language);
+                let current = published && parsed_current_version;
+                // The reparses do not relabel (the snapshot carries the
+                // detected name for its own readers); only the open parse
+                // records what it detected.
+                if current && matches!(language, LanguageCheck::Record) {
+                    doc.set_parse_result(detected);
                 }
-                ParseInstall {
-                    attached,
-                    published,
-                }
+                ParseInstall { current, published }
             });
         // Likewise a rejected `snapshot` (still owned here: the publish
         // borrows) — destroyed only after the guard is released.
@@ -788,7 +765,7 @@ impl DocumentStore {
         }
         // A different map (`parse_states`): touched only after the document
         // guard above is released.
-        if outcome.attached && has_tree {
+        if outcome.current && has_tree {
             self.mark_tree_available_if_tracked(uri);
         }
         outcome
@@ -849,12 +826,7 @@ mod tests {
         store.update_document(uri.clone(), "# doc edited\n".to_string(), None);
         let outcome = store.install_parse(
             &uri,
-            ParseInputs {
-                text: &expected_text,
-                language_id: Some(Some("markdown")),
-                incarnation,
-                content_version,
-            },
+            LanguageCheck::Expect(Some("markdown")),
             parse_snapshot(
                 &expected_text,
                 Some(markdown_tree(text)),
@@ -865,7 +837,7 @@ mod tests {
         assert_eq!(
             outcome,
             ParseInstall {
-                attached: false,
+                current: false,
                 published: true
             }
         );
@@ -898,12 +870,7 @@ mod tests {
         };
         let reparse = store.install_parse(
             &uri,
-            ParseInputs {
-                text: &expected_text,
-                language_id: Some(Some("sh")),
-                incarnation,
-                content_version,
-            },
+            LanguageCheck::Expect(Some("sh")),
             Arc::new(super::super::snapshot::ParseSnapshot {
                 text: Arc::clone(&expected_text),
                 tree: Some(markdown_tree(text)),
@@ -916,7 +883,7 @@ mod tests {
                 layer_trees: std::sync::OnceLock::new(),
             }),
         );
-        assert!(reparse.attached && reparse.published);
+        assert!(reparse.current && reparse.published);
         assert_eq!(
             store.get(&uri).unwrap().language_id(),
             Some("sh"),
@@ -931,12 +898,7 @@ mod tests {
         };
         let open = store.install_parse(
             &uri2,
-            ParseInputs {
-                text: &expected_text2,
-                language_id: None,
-                incarnation: incarnation2,
-                content_version: content_version2,
-            },
+            LanguageCheck::Record,
             parse_snapshot(
                 &expected_text2,
                 Some(markdown_tree(text)),
@@ -944,7 +906,7 @@ mod tests {
                 incarnation2,
             ),
         );
-        assert!(open.attached && open.published);
+        assert!(open.current && open.published);
         assert_eq!(
             store.get(&uri2).unwrap().language_id(),
             Some("markdown"),
@@ -988,15 +950,13 @@ mod tests {
         // parse holding the reopened text (a re-read that raced the close)
         // must still be told apart by the lifetime alone.
         let reopened_text = store.get(&uri).unwrap().text_arc();
-        for language_id in [Some(Some("markdown")), None] {
+        for language in [
+            LanguageCheck::Expect(Some("markdown")),
+            LanguageCheck::Record,
+        ] {
             let stale = store.install_parse(
                 &uri,
-                ParseInputs {
-                    text: &reopened_text,
-                    language_id,
-                    incarnation,
-                    content_version,
-                },
+                language,
                 parse_snapshot(
                     &reopened_text,
                     Some(markdown_tree(text)),
@@ -1007,7 +967,7 @@ mod tests {
             assert_eq!(
                 stale,
                 ParseInstall::default(),
-                "the prior lifetime's parse must land nothing (mode {language_id:?})"
+                "the prior lifetime's parse must land nothing (mode {language:?})"
             );
             assert!(store.get(&uri).unwrap().tree().is_none());
         }
@@ -1035,12 +995,7 @@ mod tests {
         store.parse_states.remove(&uri);
         let installed = store.install_parse(
             &uri,
-            ParseInputs {
-                text: &expected_text,
-                language_id: None,
-                incarnation,
-                content_version,
-            },
+            LanguageCheck::Record,
             parse_snapshot(
                 &expected_text,
                 Some(markdown_tree(text)),
@@ -1048,7 +1003,7 @@ mod tests {
                 incarnation,
             ),
         );
-        assert!(installed.attached, "the document itself is still there");
+        assert!(installed.current, "the document itself is still there");
         assert!(
             !store.parse_states.contains_key(&uri),
             "a parse state the close already dropped must not be recreated"
@@ -1085,12 +1040,7 @@ mod tests {
         assert_ne!(reopened, incarnation);
         let stale = store.install_parse(
             &uri,
-            ParseInputs {
-                text: &expected_text,
-                language_id: Some(Some("markdown")),
-                incarnation,
-                content_version,
-            },
+            LanguageCheck::Expect(Some("markdown")),
             parse_snapshot(
                 &expected_text,
                 Some(markdown_tree(text)),
@@ -1110,12 +1060,7 @@ mod tests {
         let cell_before = store.latest_snapshot(&uri).and_then(|v| v.slot.snapshot);
         let mismatched = store.install_parse(
             &uri,
-            ParseInputs {
-                text: &reopened_text,
-                language_id: Some(Some("markdown")),
-                incarnation: reopened,
-                content_version: reopened_version,
-            },
+            LanguageCheck::Expect(Some("markdown")),
             parse_snapshot(
                 &reopened_text,
                 Some(markdown_tree(text)),
@@ -1159,12 +1104,7 @@ mod tests {
         );
         let outcome = store.install_parse(
             &uri,
-            ParseInputs {
-                text: &other_allocation,
-                language_id: Some(Some("markdown")),
-                incarnation,
-                content_version,
-            },
+            LanguageCheck::Expect(Some("markdown")),
             parse_snapshot(
                 &other_allocation,
                 Some(markdown_tree(text)),
@@ -1175,7 +1115,7 @@ mod tests {
         assert_eq!(
             outcome,
             ParseInstall {
-                attached: true,
+                current: true,
                 published: true
             },
             "same version, same lifetime: the current parse, whichever allocation it read"
@@ -1198,18 +1138,13 @@ mod tests {
         };
         let installed = store.install_parse(
             &uri,
-            ParseInputs {
-                text: &expected_text,
-                language_id: None,
-                incarnation,
-                content_version,
-            },
+            LanguageCheck::Record,
             parse_snapshot(&expected_text, None, content_version, incarnation),
         );
         assert_eq!(
             installed,
             ParseInstall {
-                attached: true,
+                current: true,
                 published: true
             }
         );
@@ -1221,12 +1156,7 @@ mod tests {
         store.remove(&uri);
         store.install_parse(
             &uri,
-            ParseInputs {
-                text: &expected_text,
-                language_id: None,
-                incarnation,
-                content_version,
-            },
+            LanguageCheck::Record,
             parse_snapshot(
                 &expected_text,
                 Some(markdown_tree(text)),
@@ -1261,12 +1191,7 @@ mod tests {
 
         let outcome = store.install_parse(
             &uri,
-            ParseInputs {
-                text: &expected_text,
-                language_id: Some(Some("markdown")),
-                incarnation,
-                content_version,
-            },
+            LanguageCheck::Expect(Some("markdown")),
             parse_snapshot(
                 &expected_text,
                 Some(markdown_tree(text)),
@@ -1277,7 +1202,7 @@ mod tests {
         assert_eq!(
             outcome,
             ParseInstall {
-                attached: true,
+                current: true,
                 published: true
             }
         );
@@ -1297,16 +1222,19 @@ mod tests {
         // snapshot. Identity, not just the reported outcome: the stored tree
         // and the cell's snapshot must be the very ones the first install
         // landed.
-        let landed_tree = store.get(&uri).unwrap().tree().map(|t| t.root_node().id());
+        // `Tree` clones share subtrees but not the root handle: a child node's
+        // id is the identity that survives the clone.
+        let first_child = |t: &tree_sitter::Tree| t.root_node().named_child(0).map(|n| n.id());
+        let landed_tree = store
+            .get(&uri)
+            .unwrap()
+            .tree()
+            .as_ref()
+            .and_then(first_child);
         let landed_snapshot = store.latest_snapshot(&uri).and_then(|v| v.slot.snapshot);
         let again = store.install_parse(
             &uri,
-            ParseInputs {
-                text: &expected_text,
-                language_id: Some(Some("markdown")),
-                incarnation,
-                content_version,
-            },
+            LanguageCheck::Expect(Some("markdown")),
             parse_snapshot(
                 &expected_text,
                 Some(markdown_tree(text)),
@@ -1320,7 +1248,12 @@ mod tests {
             "an equal-version duplicate lands neither tree nor snapshot"
         );
         assert_eq!(
-            store.get(&uri).unwrap().tree().map(|t| t.root_node().id()),
+            store
+                .get(&uri)
+                .unwrap()
+                .tree()
+                .as_ref()
+                .and_then(first_child),
             landed_tree,
             "the duplicate must not swap the attached tree"
         );
@@ -1338,12 +1271,7 @@ mod tests {
         store.update_document(uri.clone(), "# doc edited\n".to_string(), None);
         let stale = store.install_parse(
             &uri,
-            ParseInputs {
-                text: &expected_text,
-                language_id: Some(Some("markdown")),
-                incarnation,
-                content_version,
-            },
+            LanguageCheck::Expect(Some("markdown")),
             parse_snapshot(
                 &expected_text,
                 Some(markdown_tree(text)),
@@ -1361,12 +1289,7 @@ mod tests {
         store.remove(&uri);
         let gone = store.install_parse(
             &uri,
-            ParseInputs {
-                text: &expected_text,
-                language_id: None,
-                incarnation,
-                content_version,
-            },
+            LanguageCheck::Record,
             parse_snapshot(
                 &expected_text,
                 Some(markdown_tree(text)),
@@ -1403,12 +1326,7 @@ mod tests {
         let stale_tree = parser.parse("fn main() {}", None).unwrap();
         let stale = store.install_parse(
             &uri,
-            ParseInputs {
-                text: &pre_reload_text,
-                language_id: Some(Some("rust")),
-                incarnation,
-                content_version: 0,
-            },
+            LanguageCheck::Expect(Some("rust")),
             Arc::new(super::super::snapshot::ParseSnapshot {
                 text: Arc::clone(&pre_reload_text),
                 tree: Some(stale_tree),
@@ -1422,7 +1340,7 @@ mod tests {
             }),
         );
         assert!(
-            !stale.attached && !stale.published,
+            !stale.current && !stale.published,
             "a pre-reload parse must neither restore the legacy tree nor land its snapshot"
         );
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -307,17 +307,15 @@ impl DocumentStore {
         self.ensure_watermark_entry(&uri, incarnation);
     }
 
-    /// Apply a `didChange`'s new text and stash an **incremental parse seed**,
-    /// clearing the reader-visible tree — the per-document-parse-scheduler flip's edit
-    /// path.
+    /// Apply a `didChange`'s new text and log its edits for the **incremental
+    /// parse seed** — the per-document-parse-scheduler flip's edit path.
     ///
-    /// Replaces the prior `update_document(uri, text, None)`: it still clears the
-    /// reader-visible tree (so a reader never sees a tree predating this edit) and
-    /// keeps the same side effects (tree-availability → false, watermark entry
-    /// ensured), but additionally stashes the pre-edit tree — with `edits` applied —
-    /// as the seed for the off-ingress `reparse_latest`'s incremental parse. With no
-    /// `edits` (full-text sync) no seed is kept (#348). Coalesced edits accumulate
-    /// onto the seed (see [`Document::apply_edit_and_seed`]).
+    /// The version bump makes the published tree stale (so a reader never sees a
+    /// tree predating this edit); the side effects are tree-availability → false
+    /// and the watermark entry ensured; and the `edits` are logged for the
+    /// off-ingress `reparse_latest`'s incremental seed. With no `edits` (full-text
+    /// sync) seeding is forbidden until a fresh tree is published (#348).
+    /// Coalesced edits accumulate in the log (see [`Document::apply_edit_and_seed`]).
     ///
     /// Called under the per-URI edit lock with the document known to exist; the
     /// `Vacant` branch (a reordered notification for an unopened URI) inserts a

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -1140,12 +1140,12 @@ mod tests {
         );
     }
 
-    /// The text is compared by allocation identity, not content: a parse that
-    /// read a different `Arc<str>` with the same bytes did not read the
-    /// document's own text, so its tree is not attached — while the snapshot,
-    /// judged only by the cell's admission rule, still publishes.
+    /// Currency is judged by the snapshot's own stamps — its version and
+    /// lifetime against the document's — not by which allocation the parse
+    /// read: within a lifetime one content version has one text, so a parse
+    /// of equal bytes from another allocation is the current parse.
     #[test]
-    fn install_parse_compares_the_text_by_identity_not_content() {
+    fn install_parse_judges_currency_by_version_not_text_identity() {
         let store = DocumentStore::new();
         let uri = Url::parse("file:///identity.md").unwrap();
         let text = "# doc\n";
@@ -1175,15 +1175,12 @@ mod tests {
         assert_eq!(
             outcome,
             ParseInstall {
-                attached: false,
+                attached: true,
                 published: true
             },
-            "equal bytes from another allocation are not the document's text"
+            "same version, same lifetime: the current parse, whichever allocation it read"
         );
-        assert!(
-            store.get(&uri).unwrap().tree().is_some(),
-            "readers see the published current tree regardless of the legacy attach"
-        );
+        assert!(store.get(&uri).unwrap().tree().is_some());
     }
 
     /// A parse that found a language but produced no tree still records the

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -768,11 +768,10 @@ impl DocumentStore {
                     None => snapshot.language.clone(),
                     Some(_) => doc.language_id().map(String::from),
                 };
-                let tree = snapshot.tree.clone();
                 let published = doc.publish_snapshot(&snapshot);
                 let attached = inputs_unchanged && published;
                 if attached {
-                    doc.set_parse_result(language, tree);
+                    doc.set_parse_result(language);
                 }
                 ParseInstall {
                     attached,
@@ -1183,7 +1182,10 @@ mod tests {
             },
             "equal bytes from another allocation are not the document's text"
         );
-        assert!(store.get(&uri).unwrap().tree().is_none());
+        assert!(
+            store.get(&uri).unwrap().tree().is_some(),
+            "readers see the published current tree regardless of the legacy attach"
+        );
     }
 
     /// A parse that found a language but produced no tree still records the

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -32,7 +32,7 @@ pub struct DocumentStore {
     /// [`next_incarnation`](Self::next_incarnation)). Starts at 1, so a document
     /// built outside the store (incarnation `0`) is always distinguishable from
     /// one this store owns. The incarnation lives *on the document* rather than
-    /// in a side map, so a tree-write CAS or a watermark advance can check it
+    /// in a side map, so `install_parse` or a watermark advance can check it
     /// atomically with the document state under the same shard lock; a consumer
     /// that captured a snapshot detects a close-then-reopen by comparing the
     /// snapshot's incarnation against the URI's current one. See
@@ -1384,7 +1384,7 @@ mod tests {
         );
         assert!(
             !stale.current && !stale.published,
-            "a pre-reload parse must neither restore the legacy tree nor land its snapshot"
+            "a pre-reload parse must not land its snapshot"
         );
 
         let document = store.get(&uri).unwrap();

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -251,7 +251,7 @@ impl DocumentStore {
         // Hot path (the document already exists): `get_mut` borrows the key, so no
         // `Url` clone. Only a miss falls back to `entry` (owned key), which re-checks
         // for a document a concurrent insert added between the `get_mut` and here —
-        // matching `apply_edit_clearing_tree`.
+        // matching `apply_edit`.
         let (has_tree, incarnation) = if let Some(mut doc) = self.documents.get_mut(&uri) {
             // Update in place, preserving the incarnation (an edit is the same lifetime).
             let has_tree = if let Some(tree) = new_tree {
@@ -315,12 +315,12 @@ impl DocumentStore {
     /// and the watermark entry ensured; and the `edits` are logged for the
     /// off-ingress `reparse_latest`'s incremental seed. With no `edits` (full-text
     /// sync) seeding is forbidden until a fresh tree is published (#348).
-    /// Coalesced edits accumulate in the log (see [`Document::apply_edit_and_seed`]).
+    /// Coalesced edits accumulate in the log (see [`Document::apply_edit`]).
     ///
     /// Called under the per-URI edit lock with the document known to exist; the
     /// `Vacant` branch (a reordered notification for an unopened URI) inserts a
     /// tree-less document to mirror the prior `update_document` behavior.
-    pub(crate) fn apply_edit_clearing_tree(&self, uri: &Url, text: String, edits: &[InputEdit]) {
+    pub(crate) fn apply_edit(&self, uri: &Url, text: String, edits: &[InputEdit]) {
         // Hot path (a live document being edited): `get_mut` borrows the key, so no
         // `Url` clone per keystroke. Only a miss falls back to `entry` (owned key),
         // which also re-checks for a document a concurrent open inserted between the
@@ -329,13 +329,13 @@ impl DocumentStore {
         // parse-state and watermark updates below (separate maps), keeping the
         // `documents` shard lock held no longer than `update_document` did.
         let incarnation = if let Some(mut doc) = self.documents.get_mut(uri) {
-            doc.apply_edit_and_seed(text, edits);
+            doc.apply_edit(text, edits);
             doc.incarnation()
         } else {
             match self.documents.entry(uri.clone()) {
                 Entry::Occupied(mut entry) => {
                     let doc = entry.get_mut();
-                    doc.apply_edit_and_seed(text, edits);
+                    doc.apply_edit(text, edits);
                     doc.incarnation()
                 }
                 Entry::Vacant(entry) => {
@@ -749,7 +749,7 @@ impl DocumentStore {
                 // detected name for its own readers); only the open parse
                 // records what it detected.
                 if current && matches!(language, LanguageCheck::Record) {
-                    doc.set_parse_result(detected);
+                    doc.record_language(detected);
                 }
                 ParseInstall { current, published }
             });
@@ -805,10 +805,10 @@ mod tests {
 
     /// A parse of text an edit has moved on from — before that edit's own
     /// reparse published — lands its snapshot as stale but consistent (the
-    /// cell admits a newer version than it holds) while the tree, which
-    /// would be a reader-visible tree of the wrong text, does not attach.
+    /// cell admits a newer version than it holds) but not current: readers,
+    /// who serve only the current tree, see none.
     #[test]
-    fn install_parse_publishes_a_stale_but_consistent_snapshot_without_attaching() {
+    fn install_parse_publishes_a_stale_but_consistent_snapshot_as_not_current() {
         let store = DocumentStore::new();
         let uri = Url::parse("file:///stale.md").unwrap();
         let text = "# doc\n";
@@ -853,7 +853,7 @@ mod tests {
         );
     }
 
-    /// A reparse checks the stored language and attaches the tree without
+    /// A reparse checks the stored language and publishes the tree without
     /// relabelling the document: detection may resolve a stored `sh` to its
     /// `bash` base, and the stored id stays `sh` (the snapshot carries the
     /// detected name). The open parse, which checks nothing, records what it
@@ -1071,7 +1071,7 @@ mod tests {
         assert_eq!(
             mismatched,
             ParseInstall::default(),
-            "a language the document no longer has must neither attach nor publish"
+            "a language the document no longer has must not publish"
         );
         assert!(store.get(&uri).unwrap().tree().is_none());
         let cell_after = store.latest_snapshot(&uri).and_then(|v| v.slot.snapshot);
@@ -1170,11 +1170,13 @@ mod tests {
         );
     }
 
-    /// The one way a parse reaches readers: the legacy tree and the snapshot
-    /// land together, or — when the document moved on — neither the tree
-    /// (inputs changed) nor a snapshot the cell does not admit.
+    /// One publish per version and lifetime, and currency reported from the
+    /// snapshot's stamps: the first install at a version lands and is current;
+    /// an equal-version duplicate lands nothing and is not current; a parse of
+    /// text an edit moved on from is not current and, being older than the
+    /// cell, not admitted; a closed document takes nothing.
     #[test]
-    fn install_parse_lands_tree_and_snapshot_together_or_not_at_all() {
+    fn install_parse_publishes_once_per_version_and_reports_currency() {
         let store = DocumentStore::new();
         let uri = Url::parse("file:///install.md").unwrap();
         let text = "# doc\n";
@@ -1206,7 +1208,7 @@ mod tests {
                 published: true
             }
         );
-        assert!(store.get(&uri).unwrap().tree().is_some(), "tree attached");
+        assert!(store.get(&uri).unwrap().tree().is_some(), "tree visible");
         assert!(
             store.latest_snapshot(&uri).is_some_and(|view| view
                 .slot
@@ -1217,11 +1219,10 @@ mod tests {
         );
 
         // The same parse installed again (a sibling reparse of the same
-        // revision): the cell refuses an equal-version tree swap, and the
-        // tree must not be re-attached either — nothing lands without its
-        // snapshot. Identity, not just the reported outcome: the stored tree
-        // and the cell's snapshot must be the very ones the first install
-        // landed.
+        // revision): the cell refuses an equal-version tree swap, so nothing
+        // lands and nothing is current. Identity, not just the reported
+        // outcome: the visible tree and the cell's snapshot must be the very
+        // ones the first install landed.
         // `Tree` clones share subtrees but not the root handle: a child node's
         // id is the identity that survives the clone.
         let first_child = |t: &tree_sitter::Tree| t.root_node().named_child(0).map(|n| n.id());
@@ -1255,7 +1256,7 @@ mod tests {
                 .as_ref()
                 .and_then(first_child),
             landed_tree,
-            "the duplicate must not swap the attached tree"
+            "the duplicate must not swap the visible tree"
         );
         assert!(
             store
@@ -1266,8 +1267,8 @@ mod tests {
             "the duplicate must not swap the published snapshot"
         );
 
-        // An edit moved the document on: the parse of the old text attaches
-        // nothing, and its snapshot (an older version) is not admitted.
+        // An edit moved the document on: the parse of the old text is not
+        // current, and its snapshot (an older version) is not admitted.
         store.update_document(uri.clone(), "# doc edited\n".to_string(), None);
         let stale = store.install_parse(
             &uri,
@@ -1282,7 +1283,7 @@ mod tests {
         assert_eq!(stale, ParseInstall::default());
         assert!(
             store.get(&uri).unwrap().tree().is_none(),
-            "a stale parse must not attach to the edited document"
+            "a stale parse must not become the edited document's tree"
         );
 
         // A closed document: nothing to install into.
@@ -1545,7 +1546,7 @@ mod tests {
         let before = store.get(&uri).unwrap().incarnation();
 
         // An edit is the same lifetime — the incarnation must not move.
-        store.apply_edit_clearing_tree(&uri, "xy".to_string(), &[]);
+        store.apply_edit(&uri, "xy".to_string(), &[]);
         let after = store.get(&uri).unwrap().incarnation();
 
         assert_eq!(
@@ -1697,7 +1698,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_edit_clearing_tree_preserves_the_watermark_ticket() {
+    fn apply_edit_preserves_the_watermark_ticket() {
         let store = DocumentStore::new();
         let uri = Url::parse("file:///wm.rs").unwrap();
         seed_document(&store, &uri);
@@ -1708,7 +1709,7 @@ mod tests {
         // An edit is the same lifetime: `ensure_watermark_entry` must hit its
         // matching-incarnation fast path and leave the live ticket untouched (a
         // reset to 0 would prematurely release readers gated behind ticket 7).
-        store.apply_edit_clearing_tree(&uri, "xy".to_string(), &[]);
+        store.apply_edit(&uri, "xy".to_string(), &[]);
         assert_eq!(
             watermark_of(&store, &uri),
             Some(7),

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -853,6 +853,48 @@ mod tests {
         );
     }
 
+    /// The open parse records its detected language only when it is current:
+    /// one that lost the race to a `didChange` publishes as stale but must
+    /// not relabel the document under the edit's reparse, which was captured
+    /// against the stored label.
+    #[test]
+    fn install_parse_records_the_language_only_when_current() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///relabel.md").unwrap();
+        let text = "# doc\n";
+        let incarnation = store.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let (expected_text, content_version) = {
+            let doc = store.get(&uri).unwrap();
+            (doc.text_arc(), doc.content_version())
+        };
+        store.update_document(uri.clone(), "# doc edited\n".to_string(), None);
+        let mut snapshot = parse_snapshot(
+            &expected_text,
+            Some(markdown_tree(text)),
+            content_version,
+            incarnation,
+        );
+        Arc::get_mut(&mut snapshot).unwrap().language = Some("relabelled".to_string());
+        let outcome = store.install_parse(&uri, LanguageCheck::Record, snapshot);
+        assert_eq!(
+            outcome,
+            ParseInstall {
+                current: false,
+                published: true
+            }
+        );
+        assert_eq!(
+            store.get(&uri).unwrap().language_id(),
+            Some("markdown"),
+            "a stale open parse must not relabel the document"
+        );
+    }
+
     /// A reparse checks the stored language and publishes the tree without
     /// relabelling the document: detection may resolve a stored `sh` to its
     /// `bash` base, and the stored id stays `sh` (the snapshot carries the

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -712,7 +712,7 @@ impl Kakehashi {
     /// (injected-language processing + bridge `didChange` forwarding, then the
     /// diagnostic geometry re-merge), then loops if another edit arrived.
     ///
-    /// Resurrection-safe with no teardown: the parse's non-inserting CAS no-ops
+    /// Resurrection-safe with no teardown: the parse's non-inserting `install_parse` no-ops
     /// once a `didClose` removed the document, so a `Close` needs no actor
     /// coordination.
     pub(crate) fn schedule_reparse(&self, uri: Url, ticket: Option<u64>) {

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -704,7 +704,7 @@ impl Kakehashi {
     }
 
     /// Schedule the **off-ingress** (re)parse of `uri` after a `did_change` applied
-    /// the edit and cleared the tree (per-document-parse-scheduler ADR). The parse runs
+    /// the edit and made the current tree stale (per-document-parse-scheduler ADR). The parse runs
     /// in a spawned loop off the writer ticket, so `did_change` returns without
     /// waiting on it; the [`ParseScheduler`](parse_scheduler::ParseScheduler)
     /// coalesces a burst of edits into a single follow-up reparse over the latest
@@ -812,9 +812,9 @@ impl Kakehashi {
                     publisher.request_pull_diagnostic_refresh(true);
                 }
 
-                // Schedule the debounced diagnostic HERE, after the reparse restored
-                // the tree — NOT in the did_change handler, where the tree has just
-                // been cleared. `prepare_diagnostic_snapshot` returns `None` without
+                // Schedule the debounced diagnostic HERE, after the reparse published
+                // a current tree — NOT in the did_change handler, where the tree has
+                // just gone stale. `prepare_diagnostic_snapshot` returns `None` without
                 // a tree (`Document::snapshot()` requires one), and a `None` snapshot
                 // makes the debounce a no-op — skipping the on-edit host re-sync
                 // (#431) that keeps a push-only `_self` host server's diagnostics

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -681,12 +681,7 @@ mod tests {
         let tree = parser.parse(text, None).unwrap();
         let installed = documents.install_parse(
             &uri,
-            crate::document::ParseInputs {
-                text: &expected_text,
-                language_id: Some(Some("markdown")),
-                incarnation,
-                content_version,
-            },
+            crate::document::LanguageCheck::Expect(Some("markdown")),
             std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
                 text: std::sync::Arc::clone(&expected_text),
                 tree: Some(tree),
@@ -699,7 +694,7 @@ mod tests {
                 layer_trees: std::sync::OnceLock::new(),
             }),
         );
-        assert!(installed.attached && installed.published);
+        assert!(installed.current && installed.published);
 
         assert!(
             tokio::time::timeout(std::time::Duration::from_secs(1), &mut wait)
@@ -734,12 +729,7 @@ mod tests {
                 .documents
                 .install_parse(
                     &uri,
-                    crate::document::ParseInputs {
-                        text: &expected_text,
-                        language_id: Some(Some("markdown")),
-                        incarnation,
-                        content_version,
-                    },
+                    crate::document::LanguageCheck::Expect(Some("markdown")),
                     std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
                         text: std::sync::Arc::clone(&expected_text),
                         tree: Some(tree),
@@ -752,7 +742,7 @@ mod tests {
                         layer_trees: std::sync::OnceLock::new(),
                     }),
                 )
-                .attached
+                .current
         );
 
         assert!(document_matches_lineage(

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -761,7 +761,7 @@ mod tests {
         );
         server
             .documents
-            .apply_edit_clearing_tree(&uri, "# edited\n".to_string(), &[]);
+            .apply_edit(&uri, "# edited\n".to_string(), &[]);
         assert!(!document_matches_lineage(
             &server.documents.get(&uri).unwrap(),
             incarnation,

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -421,7 +421,7 @@ impl DiagnosticPublisher {
                 if self
                     .documents
                     .get(&uri)
-                    .is_some_and(|doc| doc.snapshot().is_none())
+                    .is_some_and(|doc| !doc.has_current_tree())
                 {
                     summary.coverage_incomplete = true;
                 }

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1681,10 +1681,12 @@ impl DiagnosticPublisher {
         // guard is dropped before any further store lookup: a second lookup
         // under a held guard could queue behind a writer on the same shard
         // that is itself waiting for this guard.
-        // Language, tree, text and lifetime from ONE current snapshot: a
-        // replacement parse of a re-detected document attaches its tree to
-        // the legacy document before it publishes, and the old query over
-        // the new tree would anchor region diagnostics wrongly. The view is
+        // Language, tree, text and lifetime from ONE current snapshot: the
+        // reload reparse publishes the re-detected language on the snapshot
+        // only (`Document::language_id` is recorded by the open parse alone),
+        // so pairing the store's language with the snapshot's tree would run
+        // the old query over the new tree and anchor region diagnostics
+        // wrongly. The view is
         // an owned clone; no store guard is held across the lookups below.
         let Some(view) = self.documents.latest_snapshot(host) else {
             return Some(offsets); // closed host: nothing to anchor against

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -777,7 +777,7 @@ impl InjectionCoordinator {
     /// Wait (bounded by `budget`) for `uri`'s tree to be current before its
     /// injections are resolved.
     ///
-    /// `didChange` clears the tree and reparses off-ingress, so a re-open
+    /// `didChange` stales the tree and reparses off-ingress, so a re-open
     /// landing right after an edit would resolve ZERO injections and silently
     /// open nothing — the same reason every request path waits for a fresh tree
     /// (execute-command-routing-token). This NARROWS that window rather than

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -1189,7 +1189,7 @@ mod tests {
             .insert(uri.clone(), text.to_string(), Some("rust".into()), None);
         server
             .documents
-            .update_document(uri.clone(), text.to_string(), Some(tree.clone()));
+            .update_document(uri.clone(), text.to_string(), None);
 
         let injection = server.injection_coordinator();
 
@@ -1249,7 +1249,7 @@ mod tests {
         let bridge_regions = populated.bridge_regions.expect("gate was true");
         server
             .documents
-            .update_document(uri.clone(), text.to_string(), Some(tree.clone()));
+            .update_document(uri.clone(), text.to_string(), None);
         let content_version = server.documents.get(&uri).unwrap().content_version();
         publish(
             Some((populated.generation, std::sync::Arc::new(bridge_regions))),
@@ -1386,7 +1386,7 @@ mod tests {
             .insert(uri.clone(), text.to_string(), Some("rust".into()), None);
         server
             .documents
-            .update_document(uri.clone(), text.to_string(), Some(tree.clone()));
+            .update_document(uri.clone(), text.to_string(), None);
         publish_test_snapshot(server, &uri, text, tree, "rust");
         let injection = server.injection_coordinator();
 
@@ -1439,11 +1439,9 @@ mod tests {
         let bridge_regions = populated.bridge_regions.expect("gate was true");
         // A new revision, so the fast-path snapshot below is admitted (a
         // second publish at the same revision is refused).
-        server.documents.update_document(
-            uri.clone(),
-            text.to_string(),
-            Some(parser.parse(text, None).expect("parse rust")),
-        );
+        server
+            .documents
+            .update_document(uri.clone(), text.to_string(), None);
         let content_version = server.documents.get(&uri).unwrap().content_version();
         let incarnation = server.documents.get(&uri).unwrap().incarnation();
         let landed = server
@@ -1566,7 +1564,7 @@ mod tests {
             .insert(uri.clone(), text.to_string(), Some("rust".into()), None);
         server
             .documents
-            .update_document(uri.clone(), text.to_string(), Some(tree.clone()));
+            .update_document(uri.clone(), text.to_string(), None);
         publish_test_snapshot(server, &uri, text, tree, "rust");
         let injection = server.injection_coordinator();
 

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -400,7 +400,7 @@ impl InstallCoordinator {
                 || self
                     .documents
                     .get(uri)
-                    .is_some_and(|document| document.tree().is_some()))
+                    .is_some_and(|document| document.has_current_tree()))
     }
 
     fn parse_coordinator(&self) -> ParseCoordinator {

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -343,7 +343,7 @@ impl InstallCoordinator {
         if global_loaded && !is_injection {
             // Resurrection-safe, off-ingress reparse: re-detects the language from
             // the current document lifetime and persists through a non-inserting
-            // CAS, so a didClose/reopen during the install can't receive a tree for
+            // `install_parse`, so a didClose/reopen during the install can't receive a tree for
             // the old language. A host waiter whose install claim was won by an
             // injection reaches this same per-URI path after the claim completes.
             self.parse_coordinator()
@@ -832,7 +832,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reload_does_not_attach_installed_language_tree_to_relabelled_document() {
+    async fn reload_does_not_publish_installed_language_tree_for_relabelled_document() {
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
         server

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -556,12 +556,7 @@ impl ParseCoordinator {
                     .await;
                 let installed = self.documents.install_parse(
                     &uri,
-                    crate::document::ParseInputs {
-                        text: &text,
-                        language_id: None,
-                        incarnation,
-                        content_version,
-                    },
+                    crate::document::LanguageCheck::Record,
                     std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
                         text: text.clone(),
                         tree: Some(tree.clone()),
@@ -574,7 +569,7 @@ impl ParseCoordinator {
                         layer_trees: std::sync::OnceLock::new(),
                     }),
                 );
-                if installed.attached {
+                if installed.current {
                     // AFTER the install: a downstream task woken by this mark
                     // on another runtime thread must find the snapshot (and
                     // its fast-path regions) already in the cell.
@@ -587,7 +582,7 @@ impl ParseCoordinator {
                 // racing `didChange`/reopen moved the text or incarnation on and the
                 // edit reparse won, in which case the open downstream must NOT re-run
                 // over the edit's tree.
-                return installed.attached;
+                return installed.current;
             }
 
             // Parse produced no tree (timeout / parser unavailable / join error) but
@@ -597,12 +592,7 @@ impl ParseCoordinator {
             // language keeps a host-bridged document working after a parse failure.
             let installed = self.documents.install_parse(
                 &uri,
-                crate::document::ParseInputs {
-                    text: &text,
-                    language_id: None,
-                    incarnation,
-                    content_version,
-                },
+                crate::document::LanguageCheck::Record,
                 std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
                     text: text.clone(),
                     tree: None,
@@ -615,7 +605,7 @@ impl ParseCoordinator {
                     layer_trees: std::sync::OnceLock::new(),
                 }),
             );
-            if installed.attached {
+            if installed.current {
                 self.documents
                     .mark_parse_finished(&uri, parse_generation, false);
             }
@@ -627,12 +617,7 @@ impl ParseCoordinator {
         // No language detected at all → store no language, no tree.
         let installed = self.documents.install_parse(
             &uri,
-            crate::document::ParseInputs {
-                text: &text,
-                language_id: None,
-                incarnation,
-                content_version,
-            },
+            crate::document::LanguageCheck::Record,
             std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
                 text: text.clone(),
                 tree: None,
@@ -645,7 +630,7 @@ impl ParseCoordinator {
                 layer_trees: std::sync::OnceLock::new(),
             }),
         );
-        if installed.attached {
+        if installed.current {
             self.documents
                 .mark_parse_finished(&uri, parse_generation, false);
         }
@@ -820,12 +805,7 @@ impl ParseCoordinator {
                 .await;
             let installed = self.documents.install_parse(
                 &uri,
-                crate::document::ParseInputs {
-                    text: &text,
-                    language_id: Some(expected_language_id.as_deref()),
-                    incarnation: expected_incarnation,
-                    content_version,
-                },
+                crate::document::LanguageCheck::Expect(expected_language_id.as_deref()),
                 std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
                     text: text.clone(),
                     tree: Some(tree.clone()),
@@ -848,7 +828,7 @@ impl ParseCoordinator {
                     language_name.clone(),
                 ));
             }
-            if installed.attached {
+            if installed.current {
                 break;
             }
             // Install rejected: the text moved under us (a concurrent
@@ -1029,12 +1009,7 @@ impl ParseCoordinator {
             });
             let installed = self.documents.install_parse(
                 uri,
-                crate::document::ParseInputs {
-                    text: &text,
-                    language_id: Some(language_id.as_deref()),
-                    incarnation,
-                    content_version,
-                },
+                crate::document::LanguageCheck::Expect(language_id.as_deref()),
                 std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
                     text: text.clone(),
                     tree: Some(tree.clone()),

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -892,7 +892,6 @@ impl ParseCoordinator {
             // (#498) — cheap on this reparse hot path.
             let text = doc.text_arc();
             let language_id = doc.language_id().map(|s| s.to_string());
-            let seed = doc.incremental_seed();
             // The lifetime this parse is for: a close+reopen before the install
             // changes it, and the cell rejects on the mismatch (so a tree from
             // this lifetime never reaches a reopened document).
@@ -900,6 +899,12 @@ impl ParseCoordinator {
             let language_name =
                 self.language
                     .detect_language(uri.path(), &text, None, language_id.as_deref());
+            // The seed is bound to the grammar that produced its tree: a
+            // detection that moved with the edit (a changed shebang) parses
+            // from scratch rather than reusing another grammar's tree.
+            let seed = language_name
+                .as_deref()
+                .and_then(|language| doc.incremental_seed(language));
             (
                 language_name,
                 language_id,

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -506,7 +506,7 @@ impl ParseCoordinator {
             // This is the document-open parse: there is no prior tree to seed an
             // incremental parse from, so it is always a full parse. (The off-ingress
             // edit reparse — `reparse_latest` — is the incremental path, seeded from
-            // `Document::pending_seed`.) A full parse is also the only safe option
+            // `Document::incremental_seed`.) A full parse is also the only safe option
             // without an edited old tree: reusing an unedited tree against different
             // text violates tree-sitter's incremental contract and corrupts external
             // scanners (#348).
@@ -868,11 +868,12 @@ impl ParseCoordinator {
     /// Re-parse `uri`'s **latest** store text off the ingress path, for the
     /// per-document parse scheduler (`Kakehashi::schedule_reparse`).
     ///
-    /// `did_change` clears the reader-visible tree synchronously and schedules this;
-    /// it runs in a spawned loop, *not* on the writer ticket. When the edit stashed a
-    /// `pending_seed` (the pre-edit tree with this edit's `InputEdit`s applied) the
-    /// parse is **incremental**, seeded from it; a full-text sync stashes no seed and
-    /// parses from scratch (which keeps #348 closed). The tree write is the
+    /// `did_change` bumps the content version synchronously (which makes the
+    /// published tree stale for readers) and schedules this; it runs in a spawned
+    /// loop, *not* on the writer ticket. When the document can derive an
+    /// `incremental_seed` (the published tree with the edits since replayed) the
+    /// parse is **incremental**, seeded from it; after a full-text sync there is no
+    /// seed and it parses from scratch (which keeps #348 closed). The tree write is the
     /// non-inserting, text **and language** guarded
     /// [`install_parse`](crate::document::DocumentStore::install_parse): a closed (Vacant) document is
     /// left gone (resurrection-safe), a text that moved on (a `didChange` landed
@@ -897,9 +898,9 @@ impl ParseCoordinator {
         // needed: only the post-read paths below (which captured it) advance, and
         // they gate on it. `language_id` is captured so the tree write can reject a
         // reopen that changed the language while this parse was in flight. The
-        // `pending_seed` (a cheap `Tree` refcount-clone) is the edit's incremental
-        // parse seed stashed by `didChange`; `None` for a full-text sync / freshly
-        // installed parse, in which case we parse from scratch.
+        // `incremental_seed` is the published tree (a cheap `Tree` clone) with the
+        // edits logged since replayed; `None` after a full-text sync or for a
+        // never-parsed document, in which case we parse from scratch.
         let (language_name, language_id, text, seed, incarnation, content_version, version_cancel) = {
             let Some(doc) = self.documents.get(uri) else {
                 return;
@@ -908,7 +909,7 @@ impl ParseCoordinator {
             // (#498) — cheap on this reparse hot path.
             let text = doc.text_arc();
             let language_id = doc.language_id().map(|s| s.to_string());
-            let seed = doc.pending_seed().cloned();
+            let seed = doc.incremental_seed();
             // The lifetime this parse is for: a close+reopen before the tree write
             // changes it, and the CAS below rejects on the mismatch (so a tree from
             // this lifetime never attaches to a reopened document).

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -660,8 +660,9 @@ impl ParseCoordinator {
     /// Because the install is now off-ingress, a `didChange` can run *concurrently*
     /// with this reparse (it is no longer gated behind the install). A `didChange`
     /// that lands while the parser is still loading stores its new text with **no
-    /// tree** (the parser wasn't available), and would then CAS-reject this
-    /// reparse's now-stale tree — leaving the document tree-less. To converge, this
+    /// tree** (the parser wasn't available), and would then make this reparse's
+    /// tree not current (it publishes as stale; `tree()` stays `None`) — leaving
+    /// the document tree-less. To converge, this
     /// re-reads the latest text and retries a bounded number of times until the
     /// tree lands (or another parse wins). Sustained editing falls back to the
     /// reader's on-demand parse; the parse actor replaces this with a proper
@@ -735,7 +736,7 @@ impl ParseCoordinator {
             // already has a tree => a concurrent parse won; a changed incarnation =>
             // a close+reopen, whose new lifetime drives its own parse — stop rather
             // than parse its text with this lifetime's (possibly relabelled-away)
-            // grammar (the CAS would reject it anyway; this just avoids the wasted
+            // grammar (the cell would reject it anyway; this just avoids the wasted
             // parses).
             let (text, content_version, version_cancel) = {
                 let Some(doc) = self.documents.get(&uri) else {
@@ -748,7 +749,7 @@ impl ParseCoordinator {
                     break;
                 }
                 // `text_arc()` is a refcount bump, not a full copy (#498) — the
-                // original stays here for the CAS while a cheap clone goes to the
+                // original stays here for the install while a cheap clone goes to the
                 // blocking parse closure.
                 (
                     doc.text_arc(),
@@ -759,7 +760,7 @@ impl ParseCoordinator {
 
             let text_len = text.len();
             // Hand a cheap `Arc<str>` clone (refcount bump) to the blocking closure;
-            // the original stays here for the CAS below, so the (potentially large)
+            // the original stays here for the install below, so the (potentially large)
             // document text is never copied.
             let text_for_parse = text.clone();
             let parsed = self
@@ -832,9 +833,10 @@ impl ParseCoordinator {
             if installed.current {
                 break;
             }
-            // Install rejected: the text moved under us (a concurrent
-            // `didChange`), or a sibling parse already installed this
-            // version. Loop to re-read the latest text and try again.
+            // Not current: the text moved under us (a concurrent `didChange`
+            // — the snapshot may still have published as stale-but-
+            // consistent), or a sibling parse already installed this version.
+            // Loop to re-read the latest text and try again.
         }
 
         // Covers the give-up exits of the retry loop (parser still

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -1,4 +1,5 @@
 use crate::document::DocumentStore;
+use crate::document::model::IncrementalSeed;
 use crate::language::{DocumentParserPool, LanguageCoordinator};
 use crate::lsp::bridge::BridgeCoordinator;
 use crate::lsp::cache::CacheCoordinator;
@@ -943,13 +944,16 @@ impl ParseCoordinator {
 
         let text_len = text.len();
         // Hand a cheap `Arc<str>` clone (refcount bump) to the blocking closure; the
-        // original stays here for the CAS + injection populate below. The seed (also
-        // a cheap `Tree` refcount-clone) makes this an **incremental** parse when an
-        // edit stashed one: tree-sitter reuses the unchanged subtrees and reparses
-        // only the edited region. `None` (full-text sync / install) parses from
-        // scratch. The seed already has this edit's `InputEdit`s applied
-        // (`didChange` → `apply_edit`), satisfying tree-sitter's contract.
+        // original stays here for the install + injection populate below. The seed
+        // makes this an **incremental** parse when the document could derive one:
+        // its edit replay (`IncrementalSeed::replay`, the per-edit path copies)
+        // runs here on the pool with the parse — not under the store guard the
+        // seed was read under — and tree-sitter then reuses the unchanged
+        // subtrees and reparses only the edited region. `None` (full-text sync /
+        // never parsed) parses from scratch.
         let text_for_parse = text.clone();
+        let mut seed = seed;
+        let mut replayed: Option<tree_sitter::Tree> = None;
         let parsed = self
             .parse_with_pool(
                 &language_name,
@@ -957,14 +961,18 @@ impl ParseCoordinator {
                 text_len,
                 Some(version_cancel.clone()),
                 move |mut parser, deadline, generation_retry, cancel| {
+                    let seed_tree = if generation_retry {
+                        None
+                    } else {
+                        if replayed.is_none() {
+                            replayed = seed.take().map(IncrementalSeed::replay);
+                        }
+                        replayed.as_ref()
+                    };
                     let result = parse_text_with_deadline(
                         &mut parser,
                         &text_for_parse,
-                        if generation_retry {
-                            None
-                        } else {
-                            seed.as_ref()
-                        },
+                        seed_tree,
                         deadline,
                         cancel,
                     );

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -419,7 +419,7 @@ impl ParseCoordinator {
     /// calling this, so the parse re-reads that stored text (a cheap `Arc<str>`
     /// refcount bump, [`text_arc`](crate::document::Document::text_arc)) rather than
     /// carrying a second owned `String`, and records the detected language + tree
-    /// **in place** through the non-inserting, text + incarnation guarded
+    /// **in place** through the non-inserting, cell-admitted
     /// [`install_parse`](crate::document::DocumentStore::install_parse) instead of
     /// re-inserting a fresh copy of the text. Net: zero full-document text copies
     /// in the open parse.

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -694,7 +694,7 @@ impl ParseCoordinator {
             let Some(doc) = self.documents.get(&uri) else {
                 return;
             };
-            if doc.tree().is_some() {
+            if doc.has_current_tree() {
                 return;
             }
             if required_incarnation.is_some_and(|required| doc.incarnation() != required) {
@@ -741,7 +741,7 @@ impl ParseCoordinator {
                 let Some(doc) = self.documents.get(&uri) else {
                     break;
                 };
-                if doc.tree().is_some() {
+                if doc.has_current_tree() {
                     break;
                 }
                 if doc.incarnation() != expected_incarnation {

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -441,10 +441,10 @@ impl ParseCoordinator {
     /// tree-dependent downstream (`process_injections(forward=false)`, the deferred
     /// refresh, the synthetic diagnostic) on this — **not** on "the document has a
     /// tree": a `didChange` racing this parse can move the text on and let the edit
-    /// reparse attach the newer tree (and run `process_injections(forward=true)`)
-    /// first; this parse's CAS then rejects, and re-checking `tree().is_some()` would
+    /// reparse publish the newer tree (and run `process_injections(forward=true)`)
+    /// first; this parse's install then reports not current, and re-checking `tree().is_some()` would
     /// wrongly see the edit's tree and re-run the *open* downstream over it,
-    /// superseding the edit's eager-open batch. Gating on the own-CAS result is the
+    /// superseding the edit's eager-open batch. Gating on the own-install result is the
     /// same discipline `reparse_latest` follows for its `populate_injections`.
     pub(crate) async fn parse_document(
         &self,
@@ -540,9 +540,9 @@ impl ParseCoordinator {
                 // itself against a pass whose text or lifetime moved on (the
                 // tracker's epoch and incarnation), so it needs no confirmation
                 // from the store first, and the install below then publishes
-                // the snapshot iff the cell admits it and attaches the tree
-                // only with an admitted snapshot and unchanged inputs (a
-                // language mismatch rejects both outright).
+                // the snapshot iff the cell admits it and reports it current
+                // iff it parsed the document's content version (a language
+                // mismatch rejects it outright).
                 let regions = self
                     .populate_injections_on_pool(
                         uri.clone(),
@@ -578,7 +578,7 @@ impl ParseCoordinator {
                 }
                 advance_watermark();
                 self.notifier().log_language_events(&events).await;
-                // `attached` is exactly "this call landed the tree": false when a
+                // `current` is exactly "this call published the current tree": false when a
                 // racing `didChange`/reopen moved the text or incarnation on and the
                 // edit reparse won, in which case the open downstream must NOT re-run
                 // over the edit's tree.
@@ -682,11 +682,11 @@ impl ParseCoordinator {
         // text (synchronous, no `.await` and no document write under the `Ref`).
         // Capture the grammar **and** the (language_id, incarnation) it is resolved
         // for, together under one read guard. `language_name` is fixed for the whole
-        // loop, so the CAS must check against the language_id/incarnation captured
-        // *here* — not re-read per attempt. Otherwise a relabelling reopen mid-loop
-        // would have its new language_id captured per attempt, satisfy the CAS's
-        // language check, and let a tree parsed by the *old* grammar attach to the
-        // relabelled document. The incarnation is likewise lifetime-stable; only the
+        // loop, so the install must check against the language_id/incarnation
+        // captured *here* — not re-read per attempt. Otherwise a relabelling reopen
+        // mid-loop would have its new language_id captured per attempt, satisfy the
+        // install's language check, and let a tree parsed by the *old* grammar reach
+        // the relabelled document. The incarnation is likewise lifetime-stable; only the
         // text legitimately changes within a lifetime (a `didChange`), so only the
         // text is re-read per attempt.
         let (language_name, expected_language_id, expected_incarnation) = {
@@ -784,14 +784,14 @@ impl ParseCoordinator {
 
             // Populate BEFORE the install so the discovery rides the snapshot
             // (ADR §3); populate guards itself against a pass whose text or
-            // lifetime moved on, and the install then attaches the tree only
-            // with an admitted snapshot and unchanged inputs: a closed
-            // (Vacant) document, one whose text moved (a concurrent
-            // `didChange` — its snapshot may still publish as an older
-            // version, the tree does not attach), and one a concurrent parse
-            // already gave a tree at this version (the cell refuses the
-            // equal-version swap, so the tree is not re-attached either) all
-            // drop this tree. (`Tree` clone is a cheap refcount bump.)
+            // lifetime moved on, and the install then reports the tree
+            // current only when its snapshot was admitted at the document's
+            // content version: a closed (Vacant) document, one whose text
+            // moved (a concurrent `didChange` — its snapshot may still
+            // publish as an older version, not current), and one a
+            // concurrent parse already gave a tree at this version (the cell
+            // refuses the equal-version swap) all leave this tree out.
+            // (`Tree` clone is a cheap refcount bump.)
             let regions = self
                 .populate_injections_on_pool(
                     uri.clone(),
@@ -890,9 +890,9 @@ impl ParseCoordinator {
             let text = doc.text_arc();
             let language_id = doc.language_id().map(|s| s.to_string());
             let seed = doc.incremental_seed();
-            // The lifetime this parse is for: a close+reopen before the tree write
-            // changes it, and the CAS below rejects on the mismatch (so a tree from
-            // this lifetime never attaches to a reopened document).
+            // The lifetime this parse is for: a close+reopen before the install
+            // changes it, and the cell rejects on the mismatch (so a tree from
+            // this lifetime never reaches a reopened document).
             let incarnation = doc.incarnation();
             let language_name =
                 self.language
@@ -948,7 +948,7 @@ impl ParseCoordinator {
         // edit stashed one: tree-sitter reuses the unchanged subtrees and reparses
         // only the edited region. `None` (full-text sync / install) parses from
         // scratch. The seed already has this edit's `InputEdit`s applied
-        // (`didChange` → `apply_edit_and_seed`), satisfying tree-sitter's contract.
+        // (`didChange` → `apply_edit`), satisfying tree-sitter's contract.
         let text_for_parse = text.clone();
         let parsed = self
             .parse_with_pool(
@@ -975,22 +975,22 @@ impl ParseCoordinator {
 
         let mut events = load_result.events;
         if let Some(tree) = parsed {
-            // Attach and publish happen in one `install_parse` under the
-            // entry guard, so a legacy-store reader woken by the publish
-            // always finds the tree already attached. Text + language +
-            // incarnation are checked atomically under that guard: text
-            // rejects a within-lifetime stale parse (a
-            // `didChange` landed mid-parse); language rejects a reopen that
-            // relabelled the URI; incarnation rejects a same-language,
-            // identical-text reopen — the tree belongs to the prior lifetime
-            // and must not attach to the reopened document (nor let the
-            // watermark advance below run on the old lifetime's ticket).
+            // The publish is the one `install_parse` under the entry guard;
+            // readers derive the tree from it. Language + the snapshot's own
+            // stamps are checked under that guard: language rejects a reopen
+            // that relabelled the URI; the cell rejects a same-language,
+            // identical-text reopen by incarnation — the tree belongs to the
+            // prior lifetime and must not reach the reopened document (nor
+            // let the watermark advance below run on the old lifetime's
+            // ticket); a within-lifetime stale parse (a `didChange` landed
+            // mid-parse) publishes as stale-but-consistent and is reported
+            // not current.
             // Populate BEFORE the install so the derived discovery rides the
             // snapshot (ADR §3, don't-discover-twice); readers keep serving the
             // previous snapshot for populate's duration. Populate guards itself
             // against a pass whose text moved on mid-parse (the scheduler's
             // dirty loop is already reparsing the newer text), and the install
-            // then attaches the tree only with an admitted snapshot.
+            // then publishes it.
             let regions = self
                 .populate_injections_on_pool(
                     uri.clone(),

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -437,8 +437,8 @@ impl ParseCoordinator {
     /// advance is a document already gone (a `didClose` removed it): its watermark
     /// channel is gone too, so its readers have already fallen back.
     ///
-    /// Returns `true` iff **this** call's CAS landed a tree (i.e. it is the parse
-    /// whose tree is now current). The off-ingress open caller gates its
+    /// Returns `true` iff **this** call's install published the current tree
+    /// (i.e. it is the parse whose tree is now current). The off-ingress open caller gates its
     /// tree-dependent downstream (`process_injections(forward=false)`, the deferred
     /// refresh, the synthetic diagnostic) on this — **not** on "the document has a
     /// tree": a `didChange` racing this parse can move the text on and let the edit

--- a/src/lsp/lsp_impl/kakehashi/node/children.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/children.rs
@@ -67,12 +67,6 @@ impl Kakehashi {
             return Ok(Value::Null);
         };
 
-        // Ensure the document is parsed before snapshotting — same race as in
-        // `kakehashi/node` and `kakehashi/node/parent`: didOpen schedules an
-        // async parse, and a `didChange` mid-flight can briefly leave
-        // `Document::tree()` populated with a stale tree while NodeTracker has
-        // already been adjusted. The helper waits on the parse-state watch
-        // channel and re-parses on demand so the snapshot below is consistent.
         // Resolve a CURRENT parse snapshot (parse-snapshot ADR §3): a node id
         // names a live-position node, so a trailing snapshot rejects
         // immediately with the protocol's universal null; only the bounded

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -141,7 +141,7 @@ impl Kakehashi {
         // spawned, coalescing parse loop instead of holding the writer ticket.
         //
         // The debounced diagnostic in particular MUST run post-parse, not here: this
-        // handler just cleared the tree, and `prepare_diagnostic_snapshot` returns
+        // handler just made the tree stale, and `prepare_diagnostic_snapshot` returns
         // `None` without one (`Document::snapshot()` requires a tree). A `None`
         // snapshot makes the debounce a no-op, skipping the on-edit host re-sync
         // (#431) that keeps a push-only `_self` host server's diagnostics following

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -74,8 +74,9 @@ impl Kakehashi {
         // fall back to diff-based approach for full document sync.
         //
         // This must be called AFTER content changes are applied (so we have new
-        // text) but BEFORE the tree is cleared and the off-ingress reparse is
-        // scheduled (so node-position sync happens against the pre-edit state).
+        // text) but BEFORE the version bump stales the tree and the off-ingress
+        // reparse is scheduled (so node-position sync happens against the
+        // pre-edit state).
         let invalidated_ulids = if edits.is_empty() {
             // Full document sync: no InputEdits available, reconstruct from diff
             self.bridge.apply_text_diff(&uri, &old_text, &text)
@@ -89,15 +90,15 @@ impl Kakehashi {
         // content-addressed, so an edited region simply misses under its new
         // content hash and the old entry is swept by the reparse's populate.
 
-        // Apply the edit to the store and CLEAR the reader-visible tree
-        // synchronously, here under the edit lock (per-document-parse-scheduler ADR).
-        // Clearing the visible tree (rather than leaving the pre-edit one) is what
-        // keeps readers safe once the parse is off-ingress: a virt/native reader now
-        // sees *no* tree until the reparse lands (empty / on-demand fallback) instead
-        // of a stale tree that predates this edit — turning the #342/#374 stale-tree
-        // race into benign emptiness. The document exists (checked above) and the
-        // edit lock serializes didClose, so this update is in-place, not a
-        // resurrection.
+        // Apply the edit to the store synchronously, here under the edit lock
+        // (per-document-parse-scheduler ADR). The content-version bump makes the
+        // published snapshot non-current, so `Document::tree` / `snapshot()` read
+        // as absent until the reparse lands: a virt/native reader sees *no* tree
+        // (empty fallback) rather than a stale one that predates this edit —
+        // turning the #342/#374 stale-tree race into benign emptiness — while
+        // `latest_snapshot` readers keep serving the stale-but-consistent
+        // snapshot. The document exists (checked above) and the edit lock
+        // serializes didClose, so this update is in-place, not a resurrection.
         //
         // The pre-edit tree is NOT discarded: `edits` are logged so the off-ingress
         // reparse's incremental seed (`Document::incremental_seed`, read only by

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -106,7 +106,7 @@ impl Kakehashi {
         // A full-text sync (`edits` empty) forbids seeding and parses from
         // scratch (#348).
         let ticket = crate::lsp::current_writer_ticket();
-        self.documents.apply_edit_clearing_tree(&uri, text, &edits);
+        self.documents.apply_edit(&uri, text, &edits);
 
         // NOTE: We intentionally do NOT invalidate the semantic token cache here.
         // The cached tokens (with their result_id) are needed for delta calculations.

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -99,11 +99,12 @@ impl Kakehashi {
         // edit lock serializes didClose, so this update is in-place, not a
         // resurrection.
         //
-        // The pre-edit tree is NOT discarded: with `edits` applied it is stashed as
-        // the off-ingress reparse's incremental seed (`pending_seed`, read only by
-        // `reparse_latest`, never by readers), so a single edit reparses
-        // incrementally rather than from scratch. A full-text sync (`edits` empty)
-        // keeps no seed and parses from scratch (#348).
+        // The pre-edit tree is NOT discarded: `edits` are logged so the off-ingress
+        // reparse's incremental seed (`Document::incremental_seed`, read only by
+        // `reparse_latest`, never by readers) can replay them onto the published
+        // tree, so a single edit reparses incrementally rather than from scratch.
+        // A full-text sync (`edits` empty) forbids seeding and parses from
+        // scratch (#348).
         let ticket = crate::lsp::current_writer_ticket();
         self.documents.apply_edit_clearing_tree(&uri, text, &edits);
 

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -22,7 +22,7 @@ async fn spawn_synthetic_diagnostic_for_incarnation<F>(
         documents.remove_edit_lock_if_unshared(&uri, &edit_lock);
         return;
     };
-    let eligible = document.incarnation() == incarnation && document.tree().is_some();
+    let eligible = document.incarnation() == incarnation && document.has_current_tree();
     drop(document);
     if eligible {
         diagnostic_scheduler.spawn_synthetic_diagnostic_task(uri);
@@ -167,7 +167,7 @@ impl Kakehashi {
                         // process_injections would otherwise cancel the eager-open
                         // for a still-tree-less document.
                         let has_tree = documents.get(&install_uri).is_some_and(|doc| {
-                            doc.incarnation() == incarnation && doc.tree().is_some()
+                            doc.incarnation() == incarnation && doc.has_current_tree()
                         });
                         if has_tree {
                             let same_lifetime = injection
@@ -623,7 +623,7 @@ print("hello")
             server
                 .documents
                 .get(&uri)
-                .is_some_and(|doc| doc.tree().is_some()),
+                .is_some_and(|doc| doc.has_current_tree()),
             "the eager open must not run before the parse is installed"
         );
     }

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -1398,6 +1398,73 @@ print("hello")
         // with the snapshot conversion (parse-snapshot ADR Stage 2).
     }
 
+    /// `reparse_latest` parses incrementally from the derived seed: after an
+    /// edit inside one item, the reparse's tree reuses the untouched item's
+    /// subtree (a reused subtree keeps its node identities; a parse from
+    /// scratch allocates new ones).
+    #[tokio::test]
+    async fn reparse_latest_reuses_untouched_subtrees_through_the_seed() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+
+        let uri = Url::parse("file:///test/incremental.rs").unwrap();
+        let before = "fn keep() {}\nfn edit() {}\n";
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let tree = parser.parse(before, None).unwrap();
+        // The identity of a node *inside* the untouched item: a reused subtree
+        // keeps its children array, so the identifier's id survives the reparse.
+        let keep_name = |t: &tree_sitter::Tree| {
+            t.root_node()
+                .named_child(0)
+                .and_then(|item| item.child_by_field_name("name"))
+                .map(|name| name.id())
+        };
+        let before_id = keep_name(&tree).expect("fn keep has a name");
+        server.documents.insert(
+            uri.clone(),
+            before.to_string(),
+            Some("rust".to_string()),
+            Some(tree),
+        );
+
+        // Insert a space inside `fn edit`'s body: byte 24 is the `}` of line 2.
+        let after = "fn keep() {}\nfn edit() { }\n";
+        let edit = tree_sitter::InputEdit {
+            start_byte: 24,
+            old_end_byte: 24,
+            new_end_byte: 25,
+            start_position: tree_sitter::Point::new(1, 11),
+            old_end_position: tree_sitter::Point::new(1, 11),
+            new_end_position: tree_sitter::Point::new(1, 12),
+        };
+        server
+            .documents
+            .apply_edit(&uri, after.to_string(), &[edit]);
+        assert!(server.documents.get(&uri).unwrap().tree().is_none());
+
+        server
+            .parse_coordinator()
+            .reparse_latest(&uri, Some(1))
+            .await;
+
+        let reparsed = server
+            .documents
+            .get(&uri)
+            .unwrap()
+            .tree()
+            .expect("the reparse published a tree");
+        assert_eq!(&*server.documents.get(&uri).unwrap().text(), after);
+        assert_eq!(
+            keep_name(&reparsed),
+            Some(before_id),
+            "the untouched item's subtree must be reused from the seed"
+        );
+    }
+
     /// If a concurrent `didChange` already parsed the document (a tree is
     /// present), the install reparse must short-circuit and not redundantly
     /// reparse / clobber it.

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -1158,7 +1158,7 @@ print("hello")
             "sanity: host context resolves with a tree present"
         );
 
-        // did_change clears the tree synchronously.
+        // did_change stales the tree synchronously (the version bump).
         server
             .documents
             .update_document(uri.clone(), "fn changed() {}".to_string(), None);
@@ -1262,7 +1262,7 @@ print("hello")
             "a parsed self-host doc yields a diagnostic snapshot"
         );
 
-        // What did_change does synchronously: apply the edit and CLEAR the tree.
+        // What did_change does synchronously: apply the edit, which stales the tree.
         server
             .documents
             .update_document(uri.clone(), "fn changed() {}".to_string(), None);
@@ -1374,8 +1374,8 @@ print("hello")
         configure_rust_self_host(server);
 
         let uri = Url::parse("file:///test/edited.rs").unwrap();
-        // The edit applied new text and cleared the tree (tree = None), exactly as
-        // did_change does before scheduling the reparse.
+        // The edit applied new text with no tree published for it (tree = None),
+        // exactly what did_change leaves behind before scheduling the reparse.
         server.documents.insert(
             uri.clone(),
             "fn edited() {}".to_string(),

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -291,11 +291,11 @@ impl Kakehashi {
                 let landed = parse
                     .parse_document(parse_uri.clone(), Some(parse_language_id.as_str()), ticket)
                     .await;
-                // Run the open downstream only when THIS parse's CAS landed the tree —
-                // not merely when "a tree exists". A `didChange` racing this open parse
-                // can move the text on and let the edit reparse attach the newer tree
-                // (and run `process_injections(forward=true)`) first; this parse then
-                // loses its CAS (`landed == false`). Re-running the open downstream
+                // Run the open downstream only when THIS parse's install published the
+                // current tree — not merely when "a tree exists". A `didChange` racing
+                // this open parse can move the text on and let the edit reparse publish
+                // the newer tree (and run `process_injections(forward=true)`) first;
+                // this parse is then reported not current (`landed == false`). Re-running the open downstream
                 // (`process_injections(forward=false)`) over the edit's tree would
                 // supersede the edit's eager-open batch. When `landed` is false the
                 // edit reparse owns the current tree and already ran the correct
@@ -1312,8 +1312,8 @@ print("hello")
         );
     }
 
-    /// The off-ingress install reparse re-reads the latest store text and attaches
-    /// a tree to the still-open document.
+    /// The off-ingress install reparse re-reads the latest store text and publishes
+    /// a tree for the still-open document.
     #[tokio::test]
     async fn reparse_installed_document_parses_the_open_document() {
         let (service, _socket) = LspService::new(Kakehashi::new);
@@ -1338,7 +1338,7 @@ print("hello")
 
         assert!(
             server.documents.get(&uri).unwrap().tree().is_some(),
-            "the reparse must attach a tree to the open document"
+            "the reparse must publish a tree for the open document"
         );
     }
 
@@ -1365,8 +1365,8 @@ print("hello")
         );
     }
 
-    /// `reparse_latest` attaches a fresh tree to the open document (whose tree was
-    /// cleared by the edit) and advances the watermark to the edit's ticket.
+    /// `reparse_latest` publishes a fresh tree for the open document (whose tree the
+    /// edit made stale) and advances the watermark to the edit's ticket.
     #[tokio::test]
     async fn reparse_latest_parses_and_advances_watermark() {
         let (service, _socket) = LspService::new(Kakehashi::new);
@@ -1391,7 +1391,7 @@ print("hello")
 
         assert!(
             server.documents.get(&uri).unwrap().tree().is_some(),
-            "the off-ingress reparse attaches a tree to the edited document"
+            "the off-ingress reparse publishes a tree for the edited document"
         );
         // The watermark advance itself is still exercised by the store's own
         // watermark tests; the reader-side wait (`wait_for_epoch`) was removed

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -1129,7 +1129,7 @@ print("hello")
 
     /// Regression (parse-actor flip): the host bridge context needs only the
     /// document text, never the parse tree (parse-decoupled ADR), so it must keep
-    /// resolving after `did_change` clears the tree — otherwise every host-bridged
+    /// resolving after `did_change` stales the tree — otherwise every host-bridged
     /// request (hover / definition / formatting / diagnostics) would bail for the
     /// whole reparse window after each edit.
     #[tokio::test]

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -1413,7 +1413,9 @@ print("hello")
             .set_language(&tree_sitter_rust::LANGUAGE.into())
             .unwrap();
         let tree = parser.parse("fn already() {}", None).unwrap();
-        let tree_id = tree.root_node().id();
+        // A child node's id survives `Tree` clones (the root handle does not).
+        let first_child = |t: &tree_sitter::Tree| t.root_node().named_child(0).map(|n| n.id());
+        let tree_id = first_child(&tree);
         server.documents.insert(
             uri.clone(),
             "fn already() {}".to_string(),
@@ -1428,7 +1430,7 @@ print("hello")
 
         let doc = server.documents.get(&uri).unwrap();
         assert_eq!(
-            doc.tree().unwrap().root_node().id(),
+            doc.tree().as_ref().and_then(first_child),
             tree_id,
             "the existing tree must be left untouched (no redundant reparse)"
         );

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -1231,7 +1231,7 @@ print("hello")
     /// Regression (parse-actor flip): the debounced diagnostic — which drives the
     /// on-edit host re-sync (#431) that keeps a push host's diagnostics following
     /// edits — must be scheduled AFTER the off-ingress reparse, not in the
-    /// `did_change` handler. The handler clears the tree, and
+    /// `did_change` handler. The handler makes the tree stale, and
     /// `prepare_diagnostic_snapshot` returns `None` without a tree, so scheduling
     /// the debounce there would capture a `None` snapshot and silently skip the
     /// re-sync (the diagnostics-don't-follow-edits bug). This pins the mechanism:

--- a/src/lsp/lsp_impl/text_document/native_bindings.rs
+++ b/src/lsp/lsp_impl/text_document/native_bindings.rs
@@ -101,7 +101,7 @@ impl Kakehashi {
         let Some((text, tree, content_version, incarnation)) = ({
             let doc = self.documents.get(&uri);
             doc.and_then(|doc| {
-                let tree = doc.tree()?.clone();
+                let tree = doc.tree()?;
                 Some((
                     doc.text_arc(),
                     tree,


### PR DESCRIPTION
Follows #1062 (merged); rebased onto the latest `main`. Stage 3 of the parse-snapshot plan, first half: the document keeps no tree and no seed of its own; both are derived from the published cell.

## What changes

- **`Document.tree` is gone.** `Document::tree()` (and the `DocumentSnapshot` view over it) returns the published snapshot's tree iff that snapshot belongs to this lifetime and parsed the current content version. An edit or a reload makes the published snapshot stale, so readers lose the tree exactly when the old field used to be cleared, and a publish is the only way a tree becomes visible. An attach without a publish is no longer a thing that can happen: there is nothing to attach to.
- **`pending_seed` is gone.** `Document` logs each edit under the content version it produced; `incremental_seed()` replays the entries after the published tree's version onto a clone of that tree. The snapshot stays unedited, a coalesced burst yields one correctly edited seed, a full-text sync or a grammar reload raises a floor that no earlier tree may seed across (#348), and a burst that outgrows the log (1024 edits) gives up on seeding. Nothing has to be cleared when a parse lands.
- **`install_parse` takes a `LanguageCheck`, not `ParseInputs`.** `Record` (the open parse stores the detected language when current) or `Expect(stored)` (the reparses; a relabelled reopen rejects the install). Currency is the snapshot's own stamps against the document: the cell admits only this lifetime, and `parsed_version` must equal the content version. The allocation-identity text compare is gone; within a lifetime one version has one text. `ParseInstall { current, published }` replaces `{ attached, published }`.
- **Renames for honesty:** `apply_edit_clearing_tree` / `apply_edit_and_seed` are `apply_edit`; `set_parse_result` is `record_language`. Comments that still described an attach guarded by a CAS describe the publish and its currency.
- **ADR:** the parse-snapshot ADR's commit sequence, Stage 2 and Stage 3 passages and the Gap section record what is done (tree, seed, CAS collapse) and what of Stage 3 remains (watermark deletion, `parse_states`, scheduler-ADR pruning).

## Why

With `Document.tree` and its readers gone, the failure class #1054 fixed at the source (a parse that attached but did not publish) cannot recur silently: a reader that needs a tree can only get the published one, so a missing publish shows up as a missing tree in the first test that exercises the feature.

## Test notes

- `Tree` clones share subtrees but not the root handle, so tests that pin tree identity across the store compare a child node's id rather than `root_node().id()`.
- Injection tests that attached a tree through the edit fixture and then published the same version again now bump without a tree; the cell refuses an equal-version tree swap.
- Three new model tests pin the derived seed (replay, full-sync floor, no replay of consumed edits); one store test pins currency-by-version.

Gate: `cargo fmt --check`, `cargo clippy -- -D warnings`, lib 3705, integration 79, e2e 445 ×2, all green on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhEfVnacTxTiURX5ftDwmn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved incremental parsing after edits by reusing unchanged syntax information.
  - Preserved the last consistent document view while updated syntax is being processed.
  - Strengthened version and language checks to keep parsed results consistent.

- **Bug Fixes**
  - Improved diagnostics and reload handling when no current syntax tree is available.
  - Ensured document text, language, and syntax data come from the same snapshot.

- **Documentation**
  - Updated architecture and implementation guidance for parsing and snapshot behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
