### PR TITLE
perf(language): memoize syntect's token and first-line lookups

### DIFF
--- a/src/language/heuristic.rs
+++ b/src/language/heuristic.rs
@@ -87,6 +87,7 @@ pub(crate) fn detect_from_token(token: &str) -> Option<String> {
     if TOKEN_MEMO.len() >= TOKEN_MEMO_CAP {
         TOKEN_MEMO.clear();
     }
+    TOKEN_MEMO.insert(token.to_string(), detected.clone());
     detected
 }
 

--- a/src/language/heuristic.rs
+++ b/src/language/heuristic.rs
@@ -66,10 +66,37 @@ fn token_memo_len() -> usize {
     TOKEN_MEMO.len()
 }
 
-/// Held by every test that clears or fills the process-wide memo, so two of
+/// Held by every test that clears or fills a process-wide memo, so two of
 /// them cannot race each other's reset.
 #[cfg(test)]
-static TOKEN_MEMO_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+static MEMO_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// First line → canonical name memo for [`detect_from_first_line`]. The
+/// lookup runs every syntax's first-line regex (shebangs, mode lines); the
+/// canonicalization falls through to it for every region whose identifier
+/// syntect does not know — `markdown_inline` for every paragraph of a
+/// markdown document, `comment` for every comment of a rust one — and a
+/// keystroke changes the first line of one region at most, so the others
+/// repeat. Misses are remembered (prose first lines are all misses). Bounded
+/// like [`TOKEN_MEMO`]; a line longer than [`FIRST_LINE_MEMO_MAX_LEN`] is
+/// not memoized at all (its lookup is paid each time, never answered wrong),
+/// so the memo's memory is bounded by the cap times that length.
+static FIRST_LINE_MEMO: LazyLock<dashmap::DashMap<String, Option<String>>> =
+    LazyLock::new(dashmap::DashMap::new);
+
+/// Longest first line the memo keys on. Shebangs and mode lines are short;
+/// a longer line is the start of prose or code, looked up each time.
+const FIRST_LINE_MEMO_MAX_LEN: usize = 512;
+
+#[cfg(test)]
+fn clear_first_line_memo() {
+    FIRST_LINE_MEMO.clear();
+}
+
+#[cfg(test)]
+fn first_line_memo_len() -> usize {
+    FIRST_LINE_MEMO.len()
+}
 
 /// Detect language from a token (e.g., "py", "js", "bash").
 ///
@@ -97,8 +124,18 @@ pub(crate) fn detect_from_token(token: &str) -> Option<String> {
 /// Returns the syntax name in lowercase if found, None otherwise.
 pub(crate) fn detect_from_first_line(content: &str) -> Option<String> {
     let first_line = content.lines().next()?;
-    let syntax = SYNTAX_SET.find_syntax_by_first_line(first_line)?;
-    Some(normalize_syntax_name(&syntax.name))
+    let memoized = first_line.len() <= FIRST_LINE_MEMO_MAX_LEN;
+    if memoized && let Some(known) = FIRST_LINE_MEMO.get(first_line) {
+        return known.clone();
+    }
+    record_syntax_scan(first_line);
+    let detected = SYNTAX_SET
+        .find_syntax_by_first_line(first_line)
+        .map(|syntax| normalize_syntax_name(&syntax.name));
+    if FIRST_LINE_MEMO.len() >= TOKEN_MEMO_CAP {
+        FIRST_LINE_MEMO.clear();
+    }
+    detected
 }
 
 /// Extract a token from a file path for language detection.
@@ -199,9 +236,7 @@ mod tests {
     /// and the identifier that crossed the cap is kept.
     #[test]
     fn detect_from_token_scans_the_syntax_set_once_per_identifier() {
-        let _serial = TOKEN_MEMO_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let _serial = MEMO_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Tokens no other test looks up, so their scan counts are this
         // test's alone (the memo is process-wide). A token is matched as a
         // whole extension or syntax name, so the hit must be a real one.
@@ -238,6 +273,53 @@ mod tests {
             syntax_scans(&crossed),
             1,
             "the identifier that crossed the cap is kept by the reset"
+        );
+    }
+
+    /// The first-line lookup — every syntax's shebang / mode-line regex —
+    /// is where canonicalization ends up for every region whose identifier
+    /// syntect does not know (`markdown_inline` for each paragraph, `comment`
+    /// for each comment), and a keystroke changes one region's first line at
+    /// most. The memo answers repeats, misses included; a line longer than
+    /// the memo's key limit is looked up each time instead of being kept.
+    #[test]
+    fn detect_from_first_line_scans_the_syntax_set_once_per_line() {
+        let _serial = MEMO_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let hit = "#!/usr/bin/env python  # memo-probe";
+        let miss = "memo-probe: a prose line no syntax claims";
+        let long = format!("memo-probe {}", "x".repeat(FIRST_LINE_MEMO_MAX_LEN));
+        clear_first_line_memo();
+        let content = |line: &str| format!("{line}\nsecond line\n");
+        assert_eq!(
+            detect_from_first_line(&content(hit)).as_deref(),
+            Some("python")
+        );
+        assert_eq!(
+            detect_from_first_line(&content(hit)).as_deref(),
+            Some("python")
+        );
+        assert_eq!(detect_from_first_line(&content(miss)).as_deref(), None);
+        assert_eq!(detect_from_first_line(&content(miss)).as_deref(), None);
+        assert_eq!(
+            (syntax_scans(hit), syntax_scans(miss)),
+            (1, 1),
+            "one scan per distinct first line, hits and misses alike"
+        );
+        assert_eq!(detect_from_first_line(&content(&long)).as_deref(), None);
+        assert_eq!(detect_from_first_line(&content(&long)).as_deref(), None);
+        assert_eq!(
+            syntax_scans(&long),
+            2,
+            "a line past the key limit is looked up each time, not kept"
+        );
+
+        clear_first_line_memo();
+        for i in 0..=TOKEN_MEMO_CAP {
+            let _ = detect_from_first_line(&content(&format!("memo-probe-line-{i}")));
+        }
+        assert!(
+            first_line_memo_len() < TOKEN_MEMO_CAP,
+            "the memo is bounded: crossing the cap resets it instead of growing"
         );
     }
 

--- a/src/language/heuristic.rs
+++ b/src/language/heuristic.rs
@@ -46,15 +46,24 @@ fn syntax_scans(key: &str) -> usize {
 /// asks it once per region, and a document repeats a handful of identifiers
 /// thousands of times. Misses are remembered too (an unknown fence
 /// identifier is the common case for prose fences). Bounded by
-/// [`TOKEN_MEMO_CAP`]: identifiers come from document content, so a hostile
-/// document could otherwise grow it without limit.
+/// [`TOKEN_MEMO_CAP`] entries of at most [`MEMO_KEY_MAX_LEN`] bytes:
+/// identifiers come from document content (a dynamic capture can be any
+/// text), so a hostile document could otherwise grow it without limit.
 static TOKEN_MEMO: LazyLock<dashmap::DashMap<String, Option<String>>> =
     LazyLock::new(dashmap::DashMap::new);
 
-/// Distinct identifiers the memo holds before it resets. Far above any real
-/// vocabulary of fence identifiers (a few dozen), far below anything that
-/// costs memory: a reset re-scans, it never answers wrong.
+/// Distinct keys a memo holds before it resets. Far above any real
+/// vocabulary of fence identifiers or shebang lines (a few dozen), far below
+/// anything that costs memory at [`MEMO_KEY_MAX_LEN`] bytes per key: a reset
+/// re-scans, it never answers wrong.
 const TOKEN_MEMO_CAP: usize = 4096;
+
+/// Longest key either memo keeps. Syntax names, extensions, shebangs and
+/// mode lines are short; a longer identifier or first line is the start of
+/// prose or code — and an injection capture can be arbitrary document text
+/// — so it is looked up each time instead of retained. Bounds each memo's
+/// memory by the cap times this length.
+const MEMO_KEY_MAX_LEN: usize = 512;
 
 #[cfg(test)]
 fn clear_token_memo() {
@@ -78,15 +87,11 @@ static MEMO_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 /// markdown document, `comment` for every comment of a rust one — and a
 /// keystroke changes the first line of one region at most, so the others
 /// repeat. Misses are remembered (prose first lines are all misses). Bounded
-/// like [`TOKEN_MEMO`]; a line longer than [`FIRST_LINE_MEMO_MAX_LEN`] is
+/// like [`TOKEN_MEMO`]; a line longer than [`MEMO_KEY_MAX_LEN`] is
 /// not memoized at all (its lookup is paid each time, never answered wrong),
 /// so the memo's memory is bounded by the cap times that length.
 static FIRST_LINE_MEMO: LazyLock<dashmap::DashMap<String, Option<String>>> =
     LazyLock::new(dashmap::DashMap::new);
-
-/// Longest first line the memo keys on. Shebangs and mode lines are short;
-/// a longer line is the start of prose or code, looked up each time.
-const FIRST_LINE_MEMO_MAX_LEN: usize = 512;
 
 #[cfg(test)]
 fn clear_first_line_memo() {
@@ -104,17 +109,20 @@ fn first_line_memo_len() -> usize {
 /// Uses syntect's find_syntax_by_token which searches extension list then name.
 /// Returns the syntax name in lowercase if found, None otherwise.
 pub(crate) fn detect_from_token(token: &str) -> Option<String> {
-    if let Some(known) = TOKEN_MEMO.get(token) {
+    let memoized = token.len() <= MEMO_KEY_MAX_LEN;
+    if memoized && let Some(known) = TOKEN_MEMO.get(token) {
         return known.clone();
     }
     record_syntax_scan(token);
     let detected = SYNTAX_SET
         .find_syntax_by_token(token)
         .map(|syntax| normalize_syntax_name(&syntax.name));
-    if TOKEN_MEMO.len() >= TOKEN_MEMO_CAP {
-        TOKEN_MEMO.clear();
+    if memoized {
+        if TOKEN_MEMO.len() >= TOKEN_MEMO_CAP {
+            TOKEN_MEMO.clear();
+        }
+        TOKEN_MEMO.insert(token.to_string(), detected.clone());
     }
-    TOKEN_MEMO.insert(token.to_string(), detected.clone());
     detected
 }
 
@@ -124,7 +132,7 @@ pub(crate) fn detect_from_token(token: &str) -> Option<String> {
 /// Returns the syntax name in lowercase if found, None otherwise.
 pub(crate) fn detect_from_first_line(content: &str) -> Option<String> {
     let first_line = content.lines().next()?;
-    let memoized = first_line.len() <= FIRST_LINE_MEMO_MAX_LEN;
+    let memoized = first_line.len() <= MEMO_KEY_MAX_LEN;
     if memoized && let Some(known) = FIRST_LINE_MEMO.get(first_line) {
         return known.clone();
     }
@@ -234,9 +242,9 @@ mod tests {
     /// per region: an injection-heavy document repeats a handful of
     /// identifiers thousands of times, and the canonicalization sat at the
     /// top of the per-edit resolution cost. The memo answers repeats,
-    /// including a miss, and is bounded: crossing the cap resets it, after
-    /// which an evicted identifier is scanned again (never answered wrong)
-    /// and the identifier that crossed the cap is kept.
+    /// including a miss, and is bounded two ways: crossing the cap resets it,
+    /// after which an evicted identifier is scanned again (never answered
+    /// wrong), and an identifier past the key length limit is never kept.
     #[test]
     fn detect_from_token_scans_the_syntax_set_once_per_identifier() {
         let _serial = MEMO_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -270,12 +278,16 @@ mod tests {
             2,
             "an identifier the reset evicted is scanned again, and still answered right"
         );
-        let crossed = format!("memo-probe-synthetic-{TOKEN_MEMO_CAP}");
-        let _ = detect_from_token(&crossed);
+        // (Whether the identifier that crossed the cap survives the reset is
+        // not asserted: another test's lookup racing the reset can evict it.)
+
+        let long = format!("memo-probe-{}", "x".repeat(MEMO_KEY_MAX_LEN));
+        assert_eq!(detect_from_token(&long).as_deref(), None);
+        assert_eq!(detect_from_token(&long).as_deref(), None);
         assert_eq!(
-            syntax_scans(&crossed),
-            1,
-            "the identifier that crossed the cap is kept by the reset"
+            syntax_scans(&long),
+            2,
+            "an identifier past the key limit is looked up each time, not kept"
         );
     }
 
@@ -290,7 +302,7 @@ mod tests {
         let _serial = MEMO_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let hit = "#!/usr/bin/env python  # memo-probe";
         let miss = "memo-probe: a prose line no syntax claims";
-        let long = format!("memo-probe {}", "x".repeat(FIRST_LINE_MEMO_MAX_LEN));
+        let long = format!("memo-probe {}", "x".repeat(MEMO_KEY_MAX_LEN));
         clear_first_line_memo();
         let content = |line: &str| format!("{line}\nsecond line\n");
         assert_eq!(

--- a/src/language/heuristic.rs
+++ b/src/language/heuristic.rs
@@ -132,8 +132,11 @@ pub(crate) fn detect_from_first_line(content: &str) -> Option<String> {
     let detected = SYNTAX_SET
         .find_syntax_by_first_line(first_line)
         .map(|syntax| normalize_syntax_name(&syntax.name));
-    if FIRST_LINE_MEMO.len() >= TOKEN_MEMO_CAP {
-        FIRST_LINE_MEMO.clear();
+    if memoized {
+        if FIRST_LINE_MEMO.len() >= TOKEN_MEMO_CAP {
+            FIRST_LINE_MEMO.clear();
+        }
+        FIRST_LINE_MEMO.insert(first_line.to_string(), detected.clone());
     }
     detected
 }

--- a/src/language/heuristic.rs
+++ b/src/language/heuristic.rs
@@ -22,14 +22,72 @@ use syntect::parsing::SyntaxSet;
 /// Lazily initialized syntax set with extended syntaxes (via two-face).
 static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(two_face::syntax::extra_newlines);
 
+/// Scans per token, for the memo tests: other tests look tokens and lines up
+/// concurrently, so a process-wide total would count their scans too.
+#[cfg(test)]
+static SYNTAX_SCANS: LazyLock<dashmap::DashMap<String, usize>> =
+    LazyLock::new(dashmap::DashMap::new);
+
+#[cfg(test)]
+fn record_syntax_scan(key: &str) {
+    *SYNTAX_SCANS.entry(key.to_string()).or_insert(0) += 1;
+}
+
+#[cfg(not(test))]
+fn record_syntax_scan(_key: &str) {}
+
+#[cfg(test)]
+fn syntax_scans(key: &str) -> usize {
+    SYNTAX_SCANS.get(key).map_or(0, |scans| *scans)
+}
+
+/// Token → canonical name memo for [`detect_from_token`]. The lookup is a
+/// scan over every syntax's extension list and name; injection resolution
+/// asks it once per region, and a document repeats a handful of identifiers
+/// thousands of times. Misses are remembered too (an unknown fence
+/// identifier is the common case for prose fences). Bounded by
+/// [`TOKEN_MEMO_CAP`]: identifiers come from document content, so a hostile
+/// document could otherwise grow it without limit.
+static TOKEN_MEMO: LazyLock<dashmap::DashMap<String, Option<String>>> =
+    LazyLock::new(dashmap::DashMap::new);
+
+/// Distinct identifiers the memo holds before it resets. Far above any real
+/// vocabulary of fence identifiers (a few dozen), far below anything that
+/// costs memory: a reset re-scans, it never answers wrong.
+const TOKEN_MEMO_CAP: usize = 4096;
+
+#[cfg(test)]
+fn clear_token_memo() {
+    TOKEN_MEMO.clear();
+}
+
+#[cfg(test)]
+fn token_memo_len() -> usize {
+    TOKEN_MEMO.len()
+}
+
+/// Held by every test that clears or fills the process-wide memo, so two of
+/// them cannot race each other's reset.
+#[cfg(test)]
+static TOKEN_MEMO_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Detect language from a token (e.g., "py", "js", "bash").
 ///
 /// Used for code fence language identifiers in Markdown/HTML.
 /// Uses syntect's find_syntax_by_token which searches extension list then name.
 /// Returns the syntax name in lowercase if found, None otherwise.
 pub(crate) fn detect_from_token(token: &str) -> Option<String> {
-    let syntax = SYNTAX_SET.find_syntax_by_token(token)?;
-    Some(normalize_syntax_name(&syntax.name))
+    if let Some(known) = TOKEN_MEMO.get(token) {
+        return known.clone();
+    }
+    record_syntax_scan(token);
+    let detected = SYNTAX_SET
+        .find_syntax_by_token(token)
+        .map(|syntax| normalize_syntax_name(&syntax.name));
+    if TOKEN_MEMO.len() >= TOKEN_MEMO_CAP {
+        TOKEN_MEMO.clear();
+    }
+    detected
 }
 
 /// Detect language from file content's first line (shebang, mode line).
@@ -127,6 +185,58 @@ mod tests {
             "sentinel line unexpectedly matched syntax {:?}; \
              pick a new sentinel so all first-line regexes still get compiled",
             result.map(|s| s.name.clone())
+        );
+    }
+
+    /// A fence identifier is looked up in syntect's syntax set — a scan over
+    /// every syntax's extension list and name — once per identifier, not once
+    /// per region: an injection-heavy document repeats a handful of
+    /// identifiers thousands of times, and the canonicalization sat at the
+    /// top of the per-edit resolution cost. The memo answers repeats,
+    /// including a miss, and is bounded: crossing the cap resets it, after
+    /// which an evicted identifier is scanned again (never answered wrong)
+    /// and the identifier that crossed the cap is kept.
+    #[test]
+    fn detect_from_token_scans_the_syntax_set_once_per_identifier() {
+        let _serial = TOKEN_MEMO_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // Tokens no other test looks up, so their scan counts are this
+        // test's alone (the memo is process-wide). A token is matched as a
+        // whole extension or syntax name, so the hit must be a real one.
+        let hit = "clj";
+        let miss = "memo-probe-no-such-language";
+        clear_token_memo();
+        assert_eq!(detect_from_token(hit).as_deref(), Some("clojure"));
+        assert_eq!(detect_from_token(hit).as_deref(), Some("clojure"));
+        assert_eq!(detect_from_token(miss).as_deref(), None);
+        assert_eq!(detect_from_token(miss).as_deref(), None);
+        assert_eq!(
+            (syntax_scans(hit), syntax_scans(miss)),
+            (1, 1),
+            "one scan per distinct identifier, hits and misses alike"
+        );
+
+        clear_token_memo();
+        for i in 0..=TOKEN_MEMO_CAP {
+            let _ = detect_from_token(&format!("memo-probe-synthetic-{i}"));
+        }
+        assert!(
+            token_memo_len() < TOKEN_MEMO_CAP,
+            "the memo is bounded: crossing the cap resets it instead of growing"
+        );
+        assert_eq!(detect_from_token("memo-probe-synthetic-0").as_deref(), None);
+        assert_eq!(
+            syntax_scans("memo-probe-synthetic-0"),
+            2,
+            "an identifier the reset evicted is scanned again, and still answered right"
+        );
+        let crossed = format!("memo-probe-synthetic-{TOKEN_MEMO_CAP}");
+        let _ = detect_from_token(&crossed);
+        assert_eq!(
+            syntax_scans(&crossed),
+            1,
+            "the identifier that crossed the cap is kept by the reset"
         );
     }
 

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -62,20 +62,22 @@ pub(crate) struct CacheCoordinator {
 
 /// Everything one `populate_injections` pass derives from its single
 /// injection-query run (parse-snapshot ADR §3, never discover twice): the
-/// semantic-path discovery (gated) and the bridge-downstream region list
-/// (ungated). Both ride the `ParseSnapshot` the parse publishes.
+/// semantic-path discovery (below its own reuse gate) and, behind one gate
+/// (a runnable bridge server), two views of one resolution — the
+/// bridge-downstream region list and the whole-document resolved regions.
+/// All ride the `ParseSnapshot` the parse publishes.
 pub(crate) struct PopulatedInjections {
     pub(crate) discovery: Option<crate::document::DiscoveredInjections>,
-    /// `None` when the build was skipped (no bridge server configured) —
+    /// `None` when the resolution was skipped (no runnable bridge server) —
     /// bridge readers then fall back to inline resolution — vs `Some(empty)`
     /// for "ran, nothing matched" (readers skip their work).
     pub(crate) bridge_regions: Option<Vec<crate::document::DiscoveredBridgeRegion>>,
-    /// `None` when fully resolved regions were intentionally skipped on the
-    /// parse critical path; readers then fall back to inline resolution.
+    /// The same gate as `bridge_regions`: `None` exactly when it is, and the
+    /// whole-document readers then resolve inline.
     pub(crate) resolved_regions: Option<Vec<crate::language::injection::ResolvedInjection>>,
     /// The settings generation this populate pass ran under — stamped onto
-    /// the snapshot's `resolved_regions` so reload-stale resolution is never
-    /// served (see `ParseSnapshot::resolved_regions`).
+    /// the snapshot's `bridge_regions` and `resolved_regions` so reload-stale
+    /// resolution is never served (see `ParseSnapshot::resolved_regions`).
     pub(crate) generation: u64,
 }
 
@@ -388,10 +390,9 @@ impl CacheCoordinator {
                 ));
             }
 
-            // Resolve once for every consumer that needs resolved language /
-            // virtual content. In production the bridge and whole-document
-            // gates rise together, so resolving independently would duplicate
-            // the language-detection chain on the parse critical path.
+            // One resolution for every consumer that needs resolved languages /
+            // virtual content: the bridge regions and the whole-document
+            // resolved regions below are two views of this single pass.
             let resolved = if build_bridge_regions {
                 let resolved = crate::language::injection::InjectionResolver::resolve_from_prebuilt_cancellable(
                     language,
@@ -415,10 +416,8 @@ impl CacheCoordinator {
             // waste for the (common) bridge-less deployment — `None` makes
             // any late-configured bridge fall back to inline resolution.
             let bridge_regions: Option<Vec<crate::document::DiscoveredBridgeRegion>> =
-                build_bridge_regions.then(|| {
+                resolved.as_ref().map(|resolved| {
                     resolved
-                        .as_ref()
-                        .expect("bridge regions requested resolution")
                         .iter()
                         .map(|region| crate::document::DiscoveredBridgeRegion {
                             language: region.injection_language.clone(),
@@ -432,8 +431,7 @@ impl CacheCoordinator {
             // same single query run — and from the SAME per-region ids and
             // content hashes already in `cacheable_regions` (no duplicate
             // mint/hash on this critical path).
-            let resolved_regions = build_bridge_regions
-                .then(|| resolved.expect("whole-document regions requested resolution"));
+            let resolved_regions = resolved;
 
             if crate::cancel::is_cancelled(cancel) {
                 return None;

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -226,7 +226,6 @@ impl CacheCoordinator {
         entry_mint_epoch: (u64, u64),
         incarnation: u64,
         build_bridge_regions: bool,
-        build_resolved_regions: bool,
     ) -> Option<PopulatedInjections> {
         self.populate_injections_cancellable(
             uri,
@@ -238,7 +237,6 @@ impl CacheCoordinator {
             entry_mint_epoch,
             incarnation,
             build_bridge_regions,
-            build_resolved_regions,
             None,
         )
     }
@@ -255,7 +253,6 @@ impl CacheCoordinator {
         entry_mint_epoch: (u64, u64),
         incarnation: u64,
         build_bridge_regions: bool,
-        build_resolved_regions: bool,
         cancel: Option<&crate::cancel::CancelToken>,
     ) -> Option<PopulatedInjections> {
         if crate::cancel::is_cancelled(cancel) {
@@ -395,7 +392,7 @@ impl CacheCoordinator {
             // virtual content. In production the bridge and whole-document
             // gates rise together, so resolving independently would duplicate
             // the language-detection chain on the parse critical path.
-            let resolved = if build_bridge_regions || build_resolved_regions {
+            let resolved = if build_bridge_regions {
                 let resolved = crate::language::injection::InjectionResolver::resolve_from_prebuilt_cancellable(
                     language,
                     &regions,
@@ -435,7 +432,7 @@ impl CacheCoordinator {
             // same single query run — and from the SAME per-region ids and
             // content hashes already in `cacheable_regions` (no duplicate
             // mint/hash on this critical path).
-            let resolved_regions = build_resolved_regions
+            let resolved_regions = build_bridge_regions
                 .then(|| resolved.expect("whole-document regions requested resolution"));
 
             if crate::cancel::is_cancelled(cancel) {
@@ -982,7 +979,6 @@ mod tests {
                 tracker.mint_epoch(&uri),
                 1,
                 true,
-                true,
             )
             .expect("the pass ran");
 
@@ -1009,7 +1005,6 @@ mod tests {
                 &tracker,
                 tracker.mint_epoch(&uri),
                 1,
-                true,
                 true,
             )
             .expect("the pass ran");
@@ -1057,7 +1052,6 @@ mod tests {
             &tracker,
             tracker.mint_epoch(&uri),
             1,
-            true,
             true,
             Some(&cancel),
         );
@@ -1107,7 +1101,6 @@ mod tests {
             &tracker,
             tracker.mint_epoch(&uri),
             1,
-            true,
             true,
             Some(&cancel),
         );
@@ -1171,7 +1164,6 @@ print("hello")
             tracker.mint_epoch(&uri),
             0,
             true,
-            true,
         );
 
         // Verify we have one injection region
@@ -1233,7 +1225,6 @@ print("hello")
             &tracker,
             tracker.mint_epoch(&uri),
             0,
-            true,
             true,
         );
 
@@ -1314,7 +1305,6 @@ print("hello")
             tracker.mint_epoch(&uri),
             0,
             true,
-            true,
         );
 
         let regions = cache.get_injections(&uri).expect("should have injections");
@@ -1360,7 +1350,6 @@ print("goodbye")
             &tracker,
             tracker.mint_epoch(&uri),
             0,
-            true,
             true,
         );
 

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -1243,7 +1243,6 @@ mod tests {
             server.bridge.node_tracker_arc().mint_epoch(&uri),
             incarnation,
             true,
-            true,
         );
         let populated = populated.expect("current pass populates");
         let bridge_regions = populated.bridge_regions.expect("gate was true");
@@ -1432,7 +1431,6 @@ mod tests {
                 &server.bridge.node_tracker_arc(),
                 server.bridge.node_tracker_arc().mint_epoch(&uri),
                 server.documents.get(&uri).unwrap().incarnation(),
-                true,
                 true,
             )
             .expect("current pass populates");

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -394,7 +394,6 @@ impl ParseCoordinator {
                 entry_mint_epoch,
                 incarnation,
                 build_bridge_regions,
-                build_bridge_regions,
                 Some(&cancel_for_work),
             ) else {
                 return PopulatedSnapshotRegions::default();


### PR DESCRIPTION
## Summary

Every semantic-token request waits behind the parse publish, and before that publish the populate pass resolves every injection region. Measured with per-phase timers on the benchmark fixtures, 80–88 % of that resolution was **language canonicalization** — `canonical_injection_language` running syntect's `find_syntax_by_token` (a scan over every syntax's extensions and names) for known identifiers, and `find_syntax_by_first_line` (every syntax's shebang / mode-line regex, ~8 µs a call) for identifiers syntect does not know: `markdown_inline` for every paragraph of a markdown document, `comment` for every comment of a rust one. Both lookups are pure functions of their input, and a keystroke changes one region at most, so the same handful of identifiers and first lines are looked up thousands of times per parse.

This PR memoizes both lookups (following merged #1064 and rebased onto the latest `main`; the first commit is a flag fold in populate the later tidy relies on).

- **`heuristic::detect_from_token`** and **`detect_from_first_line`** each get a process-wide, bounded memo (`DashMap`, 4096 entries, misses included since an unknown fence identifier / a prose first line is the common case). Keys longer than 512 bytes are never retained (an injection capture can be arbitrary document text), so each memo's memory is bounded by cap × key length; crossing the cap resets the memo, which re-scans and never answers wrong.
- **populate**: the two identical booleans (`build_bridge_regions` / `build_resolved_regions`) become one; both region views derive from the single resolution, which removes two production `expect`s that were unreachable and fixes the field docs.
- **Tests** pin one scan per distinct key (hits and misses), the length exemption, and the reset at the cap, through per-key test-only scan counters (a process-wide counter is bumped by parallel tests).

### What this replaced

The first version of this branch gated resolution per document (skip it when no runnable bridge server handles any region language). Local review found it keyed on the raw fence identifier while the bridge routes on the canonical one (`py` vs `python`, shebang-only fences), and that a definitive-empty bridge set makes `process_injections` return before injected-grammar auto-install and `close_replaced_docs`; the sub-phase timers then showed canonicalization *is* the cost, so a drift-free gate would have to pay it anyway. The memos capture the win without changing what any consumer sees, and they help the wildcard-server configuration where a routing gate never skips.

## Measurements

Per-phase timers (edit → `semanticTokens/full/delta`, medians, real local config with a wildcard bridge server):

| fixture | resolve before | resolve after | of which canonicalization after |
|---|---|---|---|
| markdown 33 KB / 452 regions | 3.04 ms | 0.59 ms | 0.07 ms |
| rust 100 KB / 450 regions | 0.98 ms | 0.22 ms | 0.05 ms |
| rust 1 MB / 4500 regions | 11.45 ms | 2.10 ms | 0.45 ms |

`benches/semantic_tokens.rs`, 8 alternating A/B pairs (40 iters / 12 warmup each), this branch vs its base, same config:

| scenario | base | this PR | Δ | sign |
|---|---|---|---|---|
| markdown_injections/edit_delta | 5.26 ms | 3.67 ms | −31.1 % | 0/8 (all faster) |
| markdown_injections/open_first_token | 27.41 ms | 23.43 ms | −14.3 % | 0/8 (all faster) |
| rust_large/edit_delta | 21.68 ms | 20.94 ms | −3.7 % | 1/7 |
| rust_large/full | 2.83 ms | 2.82 ms | −1.3 % | 2/6 |
| markdown_injections_large/full | 1.00 ms | 1.00 ms | +0.9 % | 5/3 |

The two `full` scenarios never touch the parse path; they are the noise floor.

## Verification

- `cargo fmt --check`, `cargo clippy -- -D warnings` clean
- `cargo test --lib` (3712 passed, 2 ignored); `scripts/test_e2e.sh` (445 + 79 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhEfVnacTxTiURX5ftDwmn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved repeated syntax and language detection by reusing recent results, including unsuccessful lookups.
  - Added safeguards to keep detection-related memory usage bounded.

- **Improvements**
  - Streamlined language-server injection processing so related region calculations share a consistent resolution pass.
  - Maintained cancellation support and existing behavior while simplifying internal processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
