### PR TITLE
perf(parse): publish the tree before the regions are resolved

### DIFF
--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -281,11 +281,16 @@ obligation), and parse ordering (below) affects only hit-rate.
 **Currency — hit-rate, not correctness.** Correctness rests on the tree-identity
 binding above; ordering only governs how often a reusable discovery is *available*
 when the request runs. In the reparse loop the order is
-`populate_injections` → `install_parse` → `mark_parse_finished` / `advance_watermark`
+`populate_injections` (discovery built, handed out, then the resolution) with the
+first `install_parse` — the tree and the discovery — landing from inside the
+populate work-unit at the hand-off, the second `install_parse` — the same
+version upgraded with the bridge / resolved regions — after the pass returns,
+then `mark_parse_finished` / `advance_watermark`
 (`src/lsp/lsp_impl/coordinator/parse.rs`), and the semantic handler's settle waits on the parse
 watermark + parse-completion before snapshotting the tree
 (`src/lsp/lsp_impl/text_document/semantic_tokens.rs`), so in the common debounced case the
-snapshot already carries (or its epoch already matches) the populated discovery.
+snapshot already carries (or its epoch already matches) the populated discovery —
+and never waits for the resolution the token path does not consume.
 On the branches where `populate_injections` does not run (the no-tree / error
 paths — `advance_watermark` still runs there), when the
 200 ms settle budget expires, or on the on-demand-parse fallback, there is simply

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -286,11 +286,11 @@ first `install_parse` — the tree and the discovery — landing from inside the
 populate work-unit at the hand-off, the second `install_parse` — the same
 version upgraded with the bridge / resolved regions — after the pass returns,
 then `mark_parse_finished` / `advance_watermark`
-(`src/lsp/lsp_impl/coordinator/parse.rs`), and the semantic handler's settle waits on the parse
-watermark + parse-completion before snapshotting the tree
-(`src/lsp/lsp_impl/text_document/semantic_tokens.rs`), so in the common debounced case the
-snapshot already carries (or its epoch already matches) the populated discovery —
-and never waits for the resolution the token path does not consume.
+(`src/lsp/lsp_impl/coordinator/parse.rs`), and the semantic handler parks on the
+document's snapshot cell until the current version is published
+(`src/lsp/lsp_impl/text_document/semantic_tokens.rs`), so it always sees the discovery the
+first install published with the tree — and never waits for the resolution the token path
+does not consume.
 On the branches where `populate_injections` does not run (the no-tree / error
 paths — `advance_watermark` still runs there), when the
 200 ms settle budget expires, or on the on-demand-parse fallback, there is simply

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -144,12 +144,26 @@ check-then-act rather than a cross-map TOCTOU against `Document.incarnation`):
 > incarnation check (clause 1). The equal-version arm is what lets a reparse
 > attach its tree over a same-version tree-less publish — the reload placeholder
 > and the give-up snapshot both depend on it — without which strict `>` alone
-> would strand those documents tree-less until the next edit. The same arm also
-> admits an equal-version **regions upgrade** over a tree-bearing snapshot: both
-> sides carry a tree (readers derive theirs from the published one and must
-> never lose it), no region view goes from present to absent, and at least one
-> of the bridge / resolved views goes from absent to present. The same shape
-> again is not an upgrade, so a version never re-publishes for nothing.
+> would strand those documents tree-less until the next edit. Region completion
+> does not use this general admission rule: an equal-version replacement stays
+> rejected even if it carries a clone of the tree already published.
+
+`DocumentStore::complete_parse` instead receives the exact `Arc<ParseSnapshot>`
+accepted by the first install and optional resolved regions. Under the same
+entry guard it checks the language/lifetime and the held snapshot's pointer
+identity. If regions are available, the channel's restricted enrichment operation
+constructs a new snapshot from the held inputs, preserving text, tree, discovery,
+and the lazy layer-tree cell. A sibling parse cannot replace those inputs, nor
+can an already completed snapshot be enriched again. No extra parse-ID counter
+or tree-sitter child-identity comparison is needed.
+
+Completion rechecks currency even when resolution was skipped or cancelled.
+An edit can leave the first snapshot eligible for stale-but-consistent enrichment,
+but completion returns false for current-version downstream work. A newer publish,
+reload placeholder, or close/reopen rejects completion of the displaced snapshot.
+The coordinator keeps the initial publication outcome separate from this later
+currency verdict, recording the former once in a `OnceLock` outside the compute
+work unit so a contained panic after the hand-off cannot lose it.
 
 The bridge and whole-document region views are one `ResolvedRegions` value
 with one settings generation. They become available together; independent
@@ -233,18 +247,17 @@ A parse pass therefore has a **single version/incarnation-guarded commit sequenc
 compute the tree, region map, and tokens on the tree value (the populate pass
 commits its injection caches under its own tracker-epoch/lifetime guard, so a
 pass whose text moved on commits nothing there); install through the one
-primitive (`install_parse`: the snapshot publish under the entry guard, reported
-*current* iff the snapshot parsed the document's content version) — **twice per
-version**: the tree with its discovery the moment populate hands the discovery
-out, from inside the populate work-unit, so the token readers wake without
-waiting for the resolution only the bridge and the whole-document readers
-consume; then the same version again, upgraded with the bridge / resolved
-regions once the pass has resolved (the equal-version regions upgrade above; a
-pass refused before the hand-off installs once, with no regions); and emit the
-downstream — `semanticTokens/refresh`, injected-language forwarding, diagnostic
-republish — gated on the first install's result, after the upgrade, in the order
-the per-document-parse-scheduler loop already uses
-(`populate → install → install (upgrade) → mark finished → downstream`). A rejected publish (a racing
+store (`install_parse`: the initial snapshot publish under the entry guard,
+reported *current* iff the snapshot parsed the document's content version).
+The first publish carries tree/discovery from inside the populate work unit,
+releasing token readers before resolution. After the awaited work,
+`complete_parse` may enrich that exact snapshot with regions and separately
+reports currency at completion. A pass without a hand-off installs once.
+Downstream decisions use the appropriate outcome: current-tree follow-ups use
+completion-time currency; settle refresh uses the initial publication/placeholder
+upgrade and its existing live-version check. The scheduler order remains
+`populate → initial publish → optional enrichment → mark finished → downstream`.
+ A rejected publish (a racing
 edit or reopen advanced the slot) emits nothing and attaches nothing. (Two
 parses of the *same* version — an install reparse racing the edit reparse — may
 both commit their populate bookkeeping before one of them loses the equal-version

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -151,6 +151,13 @@ check-then-act rather than a cross-map TOCTOU against `Document.incarnation`):
 > of the bridge / resolved views goes from absent to present. The same shape
 > again is not an upgrade, so a version never re-publishes for nothing.
 
+The bridge and whole-document region views are one `ResolvedRegions` value
+with one settings generation. They become available together; independent
+optional fields would permit partial publication and conflicting stamps that
+no populate pass produces. `None` means unavailable (also after skipped or
+cancelled resolution), not a promise that a later publish will complete it.
+A present pair of empty vectors means the query established no regions.
+
 - **Incarnation-scoped, strict monotonicity.** The `>` is strict — equal-version
   double-publishes (e.g. a racing open-parse and reparse both at version 0) must
   not swap the `Tree` under an already-issued `result_id` and fire a spurious

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -144,7 +144,12 @@ check-then-act rather than a cross-map TOCTOU against `Document.incarnation`):
 > incarnation check (clause 1). The equal-version arm is what lets a reparse
 > attach its tree over a same-version tree-less publish — the reload placeholder
 > and the give-up snapshot both depend on it — without which strict `>` alone
-> would strand those documents tree-less until the next edit.
+> would strand those documents tree-less until the next edit. The same arm also
+> admits an equal-version **regions upgrade** over a tree-bearing snapshot: both
+> sides carry a tree (readers derive theirs from the published one and must
+> never lose it), no region view goes from present to absent, and at least one
+> of the bridge / resolved views goes from absent to present. The same shape
+> again is not an upgrade, so a version never re-publishes for nothing.
 
 - **Incarnation-scoped, strict monotonicity.** The `>` is strict — equal-version
   double-publishes (e.g. a racing open-parse and reparse both at version 0) must
@@ -220,12 +225,19 @@ Two obligations:
 A parse pass therefore has a **single version/incarnation-guarded commit sequence**, so no reader-visible publication or downstream emission ever escapes for a snapshot that lost the admission:
 compute the tree, region map, and tokens on the tree value (the populate pass
 commits its injection caches under its own tracker-epoch/lifetime guard, so a
-pass whose text moved on commits nothing there); run the one install
-(`install_parse`: the snapshot publish under the entry guard, reported *current*
-iff the snapshot parsed the document's content version); and emit the downstream — `semanticTokens/refresh`,
-injected-language forwarding, diagnostic republish — gated on the install's
-result, in the order the per-document-parse-scheduler loop already uses
-(`populate → install → mark finished → downstream`). A rejected publish (a racing
+pass whose text moved on commits nothing there); install through the one
+primitive (`install_parse`: the snapshot publish under the entry guard, reported
+*current* iff the snapshot parsed the document's content version) — **twice per
+version**: the tree with its discovery the moment populate hands the discovery
+out, from inside the populate work-unit, so the token readers wake without
+waiting for the resolution only the bridge and the whole-document readers
+consume; then the same version again, upgraded with the bridge / resolved
+regions once the pass has resolved (the equal-version regions upgrade above; a
+pass refused before the hand-off installs once, with no regions); and emit the
+downstream — `semanticTokens/refresh`, injected-language forwarding, diagnostic
+republish — gated on the first install's result, after the upgrade, in the order
+the per-document-parse-scheduler loop already uses
+(`populate → install → install (upgrade) → mark finished → downstream`). A rejected publish (a racing
 edit or reopen advanced the slot) emits nothing and attaches nothing. (Two
 parses of the *same* version — an install reparse racing the edit reparse — may
 both commit their populate bookkeeping before one of them loses the equal-version
@@ -540,7 +552,9 @@ inside the existing safety contracts at each step:
   cell — reads as absent until the reparse lands, so no reader sees a tree that
   predates the text. The populate pass runs *before* the install, on
   the tree value; it guards its own cache commits by the tracker's epoch and the
-  lifetime, so a pass whose text moved on commits nothing. `populate`'s split into geometry derivation and
+  lifetime, so a pass whose text moved on commits nothing — and it hands its
+  discovery out before resolving, which is where the first of the two installs
+  per version lands (§2). `populate`'s split into geometry derivation and
   the latch-gated tracker reconciliation (§3) is **already in**. Take the
   grammar auto-install off the read handlers (`compute_captures` no longer triggers
   `ensure_injection_languages_loaded_for_document` inline): the parse loop

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -172,6 +172,12 @@ no populate pass produces. `None` means unavailable (also after skipped or
 cancelled resolution), not a promise that a later publish will complete it.
 A present pair of empty vectors means the query established no regions.
 
+Store readers share the same lifetime/version/generation gate for both region
+views. Readers already bound to a snapshot validate its regions' generation on
+that snapshot instead of looking up the store again: a new publish must never
+pair the old text/tree with new regions. Generation mismatch preserves inline
+fallback rather than turning an unavailable result into a definitive empty one.
+
 - **Incarnation-scoped, strict monotonicity.** The `>` is strict — equal-version
   double-publishes (e.g. a racing open-parse and reparse both at version 0) must
   not swap the `Tree` under an already-issued `result_id` and fire a spurious

--- a/docs/architecture-decisions/per-document-parse-scheduler.md
+++ b/docs/architecture-decisions/per-document-parse-scheduler.md
@@ -463,7 +463,9 @@ write is the one non-inserting `install_parse`: the cell admits a snapshot only
 for the captured incarnation and a newer version — or the same version when the
 incoming snapshot brings a tree the held one lacks, which is how a reparse fills
 in a reload placeholder or a give-up snapshot instead of leaving the document
-tree-less until the next edit — the reparse's language check
+tree-less until the next edit, or when it brings bridge / resolved regions the
+held tree-bearing one lacks, which is how a parse's second install lands the
+resolution after its first already released the readers — the reparse's language check
 rejects a relabelled document, and the watermark advance is incarnation-guarded, so a
 close-then-reopen during an in-flight parse fails its epoch check at the write
 rather than resurrecting the closed document. Injection orchestration runs

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1880,11 +1880,11 @@ mod tests {
         let present = temp.path().join("present");
         std::fs::write(&present, "parser").unwrap();
 
-        assert_eq!(remove_parser_entry(&present).unwrap(), true);
+        assert!(remove_parser_entry(&present).unwrap());
         assert!(!present.exists());
         // The same call again: the entry is gone, which is success, but not a
         // removal this run performed.
-        assert_eq!(remove_parser_entry(&present).unwrap(), false);
+        assert!(!remove_parser_entry(&present).unwrap());
     }
 
     /// "Nothing here" and "could not tell" must stay distinguishable: the gate

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -865,7 +865,6 @@ mod tests {
                             "keyword".to_string(),
                             "base.keyword".to_string(),
                         )])),
-                        ..Default::default()
                     },
                 ),
             ])),
@@ -955,7 +954,6 @@ mod tests {
                             "type.builtin".to_string(),
                             "rust.type".to_string(),
                         )])),
-                        ..Default::default()
                     },
                 ),
             ])),

--- a/src/document.rs
+++ b/src/document.rs
@@ -14,4 +14,4 @@ pub(crate) use injections::{
 pub(crate) use model::Document;
 pub use store::DocumentStore;
 
-pub(crate) use store::LanguageCheck;
+pub(crate) use store::{LanguageCheck, ParseInstall};

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -231,7 +231,7 @@ impl Document {
             injection_regions: None,
             bridge_regions: None,
             resolved_regions: None,
-            layer_trees: std::sync::OnceLock::new(),
+            layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
         })
     }
 
@@ -518,7 +518,7 @@ mod tests {
             injection_regions: None,
             bridge_regions: None,
             resolved_regions: None,
-            layer_trees: std::sync::OnceLock::new(),
+            layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
         })
     }
 
@@ -721,7 +721,7 @@ mod tests {
             injection_regions: None,
             bridge_regions: None,
             resolved_regions: None,
-            layer_trees: std::sync::OnceLock::new(),
+            layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
         })));
         // `Tree` clones share their subtrees but not the root handle, so a
         // child node's id is the identity that survives the clone.

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -229,8 +229,7 @@ impl Document {
             parsed_version: self.content_version,
             incarnation: self.incarnation,
             injection_regions: None,
-            bridge_regions: None,
-            resolved_regions: None,
+            regions: None,
             layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
         })
     }
@@ -516,8 +515,7 @@ mod tests {
             parsed_version,
             incarnation: doc.incarnation(),
             injection_regions: None,
-            bridge_regions: None,
-            resolved_regions: None,
+            regions: None,
             layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
         })
     }
@@ -719,8 +717,7 @@ mod tests {
             parsed_version: doc.content_version(),
             incarnation: 7,
             injection_regions: None,
-            bridge_regions: None,
-            resolved_regions: None,
+            regions: None,
             layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
         })));
         // `Tree` clones share their subtrees but not the root handle, so a

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -285,6 +285,17 @@ impl Document {
         installed
     }
 
+    /// Complete a published parse without accepting replacement parse inputs.
+    /// The store retains `expected` and `regions` until after its guard drops.
+    pub(super) fn enrich_regions(
+        &self,
+        expected: &Arc<ParseSnapshot>,
+        regions: &super::snapshot::ResolvedRegions,
+    ) -> bool {
+        self.snapshot_tx
+            .send_if_modified(|slot| slot.enrich_regions(expected, regions))
+    }
+
     /// Install the terminal closed slot (see
     /// [`CLOSED_INCARNATION`](super::snapshot::CLOSED_INCARNATION)): wakes any
     /// reader parked on the first-parse `watch::changed()` and rejects every

--- a/src/document/snapshot.rs
+++ b/src/document/snapshot.rs
@@ -148,7 +148,12 @@ impl SnapshotSlot {
     ///    (tree-less, releases parked first-parse waiters) must not block
     ///    the real parse of the same version that a later successful install
     ///    produces. Same version means same input text, so the upgrade only
-    ///    adds information; the equal-version tree *swap* stays rejected.
+    ///    adds information; the equal-version tree *swap* stays rejected —
+    ///    **or** an equal-version **regions upgrade** over a tree-bearing
+    ///    snapshot (see [`Self::regions_upgrade`]): a parse publishes its
+    ///    tree as soon as the injection discovery is derived, and the
+    ///    bridge/resolved regions (a resolution the token readers never
+    ///    consume) land on the same version afterwards.
     pub(crate) fn admits(&self, snapshot: &ParseSnapshot) -> bool {
         // The sentinel is reserved: no snapshot legitimately carries it (the
         // store's counter never draws it), so a closed slot admits nothing —
@@ -159,8 +164,37 @@ impl SnapshotSlot {
                 let tree_downgrade = current.tree.is_some() && snapshot.tree.is_none();
                 let tree_upgrade = current.tree.is_none() && snapshot.tree.is_some();
                 (snapshot.parsed_version > current.parsed_version && !tree_downgrade)
-                    || (snapshot.parsed_version == current.parsed_version && tree_upgrade)
+                    || (snapshot.parsed_version == current.parsed_version
+                        && (tree_upgrade || Self::regions_upgrade(current, snapshot)))
             })
+    }
+
+    /// The equal-version regions upgrade: both sides carry a tree (readers
+    /// derive theirs from the published one and must never lose it), no
+    /// region view goes from present to absent, and at least one of the
+    /// bridge / resolved views goes from absent to present. The same shape
+    /// again is not an upgrade, so a version never re-publishes for nothing.
+    fn regions_upgrade(current: &ParseSnapshot, snapshot: &ParseSnapshot) -> bool {
+        let upgraded = |before: bool, after: bool| !before && after;
+        let downgraded = |before: bool, after: bool| before && !after;
+        let bridge = (
+            current.bridge_regions.is_some(),
+            snapshot.bridge_regions.is_some(),
+        );
+        let resolved = (
+            current.resolved_regions.is_some(),
+            snapshot.resolved_regions.is_some(),
+        );
+        let discovery = (
+            current.injection_regions.is_some(),
+            snapshot.injection_regions.is_some(),
+        );
+        current.tree.is_some()
+            && snapshot.tree.is_some()
+            && !downgraded(bridge.0, bridge.1)
+            && !downgraded(resolved.0, resolved.1)
+            && !downgraded(discovery.0, discovery.1)
+            && (upgraded(bridge.0, bridge.1) || upgraded(resolved.0, resolved.1))
     }
 }
 

--- a/src/document/snapshot.rs
+++ b/src/document/snapshot.rs
@@ -169,9 +169,10 @@ impl SnapshotSlot {
             })
     }
 
-    /// The equal-version regions upgrade: both sides carry a tree (readers
-    /// derive theirs from the published one and must never lose it), no
-    /// region view goes from present to absent, and at least one of the
+    /// The equal-version regions upgrade: both sides carry the SAME tree
+    /// (readers derive theirs from the published one and must never lose it
+    /// or see it swapped — not even for a sibling parse of the same text),
+    /// no region view goes from present to absent, and at least one of the
     /// bridge / resolved views goes from absent to present. The same shape
     /// again is not an upgrade, so a version never re-publishes for nothing.
     fn regions_upgrade(current: &ParseSnapshot, snapshot: &ParseSnapshot) -> bool {
@@ -189,12 +190,30 @@ impl SnapshotSlot {
             current.injection_regions.is_some(),
             snapshot.injection_regions.is_some(),
         );
-        current.tree.is_some()
-            && snapshot.tree.is_some()
+        Self::same_tree(current, snapshot)
             && !downgraded(bridge.0, bridge.1)
             && !downgraded(resolved.0, resolved.1)
             && !downgraded(discovery.0, discovery.1)
             && (upgraded(bridge.0, bridge.1) || upgraded(resolved.0, resolved.1))
+    }
+
+    /// Whether both snapshots carry the same tree. A `Tree` clone gives its
+    /// root node a fresh identity but shares the children, so the first
+    /// child's identity tells a clone of one parse from another parse of the
+    /// same text; a tree with no children (an empty document) is told by
+    /// its text instead, which the two installs of one parse share by
+    /// allocation.
+    fn same_tree(current: &ParseSnapshot, snapshot: &ParseSnapshot) -> bool {
+        match (&current.tree, &snapshot.tree) {
+            (Some(held), Some(incoming)) => {
+                match (held.root_node().child(0), incoming.root_node().child(0)) {
+                    (Some(held), Some(incoming)) => held.id() == incoming.id(),
+                    (None, None) => Arc::ptr_eq(&current.text, &snapshot.text),
+                    _ => false,
+                }
+            }
+            _ => false,
+        }
     }
 }
 

--- a/src/document/snapshot.rs
+++ b/src/document/snapshot.rs
@@ -89,6 +89,17 @@ pub(crate) struct ParseSnapshot {
     pub(crate) layer_trees: Arc<std::sync::OnceLock<(u64, Arc<Vec<SnapshotLayerTree>>)>>,
 }
 
+impl ParseSnapshot {
+    /// Read regions belonging to this snapshot only when their settings are
+    /// still current. A reader already bound to a snapshot must not re-read
+    /// the store and pair its tree with a newer snapshot's regions.
+    pub(crate) fn regions_for_generation(&self, generation: u64) -> Option<&ResolvedRegions> {
+        self.regions
+            .as_ref()
+            .filter(|regions| regions.generation == generation)
+    }
+}
+
 /// The bridge and whole-document views of one resolution. They are published
 /// together, so neither presence nor the settings generation can disagree.
 #[derive(Clone)]

--- a/src/document/snapshot.rs
+++ b/src/document/snapshot.rs
@@ -288,28 +288,53 @@ mod tests {
         snapshot
     }
 
+    /// Clone of a held tree: a parse's two installs carry the same tree, and
+    /// clones share their child nodes even though each clone's root node
+    /// has its own identity.
+    fn upgrade_of(held: &ParseSnapshot, bridge: bool, resolved: bool) -> ParseSnapshot {
+        let mut snapshot = snap_with_tree(held.incarnation, held.parsed_version);
+        snapshot.tree = held.tree.clone();
+        with_regions(snapshot, bridge, resolved)
+    }
+
     /// A parse publishes its tree as soon as the injection discovery is
     /// derived, and the bridge/resolved regions — the resolution the token
     /// readers never consume — land on the same version afterwards. The
-    /// cell admits that as an upgrade: same lifetime, same version, a tree
-    /// on both sides, and at least one region view going from absent to
+    /// cell admits that as an upgrade: same lifetime, same version, the
+    /// SAME tree on both sides (a tree under an already-issued result id is
+    /// never swapped, not even by a sibling parse of the same text carrying
+    /// regions), and at least one region view going from absent to
     /// present. Nothing else re-publishes an equal version: the same shape
-    /// again, a tree-less upgrade (no reader may lose the tree), or a
-    /// region view going from present to absent.
+    /// again, a tree-less upgrade, a different tree, or any region view
+    /// going from present to absent.
     #[test]
     fn equal_version_regions_upgrade_is_admitted_over_a_tree_bearing_snapshot() {
         let mut slot = SnapshotSlot::bootstrap(7);
-        slot.snapshot = Some(Arc::new(snap_with_tree(7, 3)));
+        let held = snap_with_tree(7, 3);
+        let held_tree = held.tree.clone();
+        slot.snapshot = Some(Arc::new(held));
+        let held = || ParseSnapshot {
+            tree: held_tree.clone(),
+            ..snap_with_tree(7, 3)
+        };
         assert!(
-            slot.admits(&with_regions(snap_with_tree(7, 3), true, false)),
+            slot.admits(&upgrade_of(&held(), true, false)),
             "bridge regions arriving on the published version upgrade it"
         );
         assert!(
-            slot.admits(&with_regions(snap_with_tree(7, 3), true, true)),
+            slot.admits(&upgrade_of(&held(), true, true)),
             "both region views arriving upgrade it"
         );
         assert!(
-            !slot.admits(&with_regions(snap_with_tree(6, 3), true, true)),
+            !slot.admits(&with_regions(snap_with_tree(7, 3), true, true)),
+            "a sibling parse's tree of the same text is a swap, never admitted"
+        );
+        assert!(
+            !slot.admits(&{
+                let mut other = upgrade_of(&held(), true, true);
+                other.incarnation = 6;
+                other
+            }),
             "the incarnation clause is never bypassed by the upgrade"
         );
         assert!(
@@ -317,18 +342,34 @@ mod tests {
             "an upgrade must carry the tree the readers already derive from"
         );
 
-        slot.snapshot = Some(Arc::new(with_regions(snap_with_tree(7, 3), true, false)));
+        // With one region view present, only the other's arrival upgrades.
+        slot.snapshot = Some(Arc::new(upgrade_of(&held(), true, false)));
         assert!(
-            slot.admits(&with_regions(snap_with_tree(7, 3), true, true)),
+            slot.admits(&upgrade_of(&held(), true, true)),
             "the remaining region view arriving still upgrades"
         );
         assert!(
-            !slot.admits(&with_regions(snap_with_tree(7, 3), true, false)),
+            !slot.admits(&upgrade_of(&held(), true, false)),
             "the same shape again is not an upgrade"
         );
         assert!(
-            !slot.admits(&snap_with_tree(7, 3)),
+            !slot.admits(&upgrade_of(&held(), false, true)),
+            "a view going absent is a downgrade even when another arrives"
+        );
+        assert!(
+            !slot.admits(&held()),
             "a region view going absent is a downgrade, never admitted"
+        );
+        let mut with_discovery = upgrade_of(&held(), true, false);
+        with_discovery.injection_regions = Some(Arc::new(DiscoveredInjections {
+            generation: 1,
+            complete: true,
+            regions: Vec::new(),
+        }));
+        slot.snapshot = Some(Arc::new(with_discovery));
+        assert!(
+            !slot.admits(&upgrade_of(&held(), true, true)),
+            "the discovery going absent is a downgrade even as the resolution arrives"
         );
     }
 

--- a/src/document/snapshot.rs
+++ b/src/document/snapshot.rs
@@ -152,12 +152,10 @@ impl SnapshotSlot {
     ///    (tree-less, releases parked first-parse waiters) must not block
     ///    the real parse of the same version that a later successful install
     ///    produces. Same version means same input text, so the upgrade only
-    ///    adds information; the equal-version tree *swap* stays rejected —
-    ///    **or** an equal-version **regions upgrade** over a tree-bearing
-    ///    snapshot (see [`Self::regions_upgrade`]): a parse publishes its
-    ///    tree as soon as the injection discovery is derived, and the
-    ///    bridge/resolved regions (a resolution the token readers never
-    ///    consume) land on the same version afterwards.
+    ///    adds information; an equal-version tree swap stays rejected.
+    ///
+    /// Regions use the separate, exact-snapshot [`Self::enrich_regions`]
+    /// operation rather than this general parse-result admission rule.
     pub(crate) fn admits(&self, snapshot: &ParseSnapshot) -> bool {
         // The sentinel is reserved: no snapshot legitimately carries it (the
         // store's counter never draws it), so a closed slot admits nothing —
@@ -168,41 +166,41 @@ impl SnapshotSlot {
                 let tree_downgrade = current.tree.is_some() && snapshot.tree.is_none();
                 let tree_upgrade = current.tree.is_none() && snapshot.tree.is_some();
                 (snapshot.parsed_version > current.parsed_version && !tree_downgrade)
-                    || (snapshot.parsed_version == current.parsed_version
-                        && (tree_upgrade || Self::regions_upgrade(current, snapshot)))
+                    || (snapshot.parsed_version == current.parsed_version && tree_upgrade)
             })
     }
 
-    /// The equal-version regions upgrade: both sides carry the SAME tree
-    /// (readers derive theirs from the published one and must never lose it
-    /// or see it swapped — not even for a sibling parse of the same text),
-    /// no region view goes from present to absent, and at least one of the
-    /// bridge / resolved views goes from absent to present. The same shape
-    /// again is not an upgrade, so a version never re-publishes for nothing.
-    fn regions_upgrade(current: &ParseSnapshot, snapshot: &ParseSnapshot) -> bool {
-        Self::same_tree(current, snapshot)
-            && current.regions.is_none()
-            && snapshot.regions.is_some()
-            && !(current.injection_regions.is_some() && snapshot.injection_regions.is_none())
-    }
-
-    /// Whether both snapshots carry the same tree. A `Tree` clone gives its
-    /// root node a fresh identity but shares the children, so the first
-    /// child's identity tells a clone of one parse from another parse of the
-    /// same text; a tree with no children (an empty document) is told by
-    /// its text instead, which the two installs of one parse share by
-    /// allocation.
-    fn same_tree(current: &ParseSnapshot, snapshot: &ParseSnapshot) -> bool {
-        match (&current.tree, &snapshot.tree) {
-            (Some(held), Some(incoming)) => {
-                match (held.root_node().child(0), incoming.root_node().child(0)) {
-                    (Some(held), Some(incoming)) => held.id() == incoming.id(),
-                    (None, None) => Arc::ptr_eq(&current.text, &snapshot.text),
-                    _ => false,
-                }
-            }
-            _ => false,
+    /// Add regions only to the exact snapshot the first publish installed.
+    /// The caller cannot replace any parse input or the lazy layer-tree cell.
+    /// Pointer identity is the capability: a sibling parse of the same version
+    /// (even one sharing tree-sitter subtrees) cannot complete this snapshot.
+    pub(super) fn enrich_regions(
+        &mut self,
+        expected: &Arc<ParseSnapshot>,
+        regions: &ResolvedRegions,
+    ) -> bool {
+        if self.current_incarnation == CLOSED_INCARNATION
+            || self.current_incarnation != expected.incarnation
+            || expected.tree.is_none()
+            || expected.regions.is_some()
+            || !self
+                .snapshot
+                .as_ref()
+                .is_some_and(|held| Arc::ptr_eq(held, expected))
+        {
+            return false;
         }
+        self.snapshot = Some(Arc::new(ParseSnapshot {
+            text: Arc::clone(&expected.text),
+            tree: expected.tree.clone(),
+            language: expected.language.clone(),
+            parsed_version: expected.parsed_version,
+            incarnation: expected.incarnation,
+            injection_regions: expected.injection_regions.clone(),
+            regions: Some(regions.clone()),
+            layer_trees: Arc::clone(&expected.layer_trees),
+        }));
+        true
     }
 }
 
@@ -285,24 +283,91 @@ mod tests {
     }
 
     #[test]
-    fn equal_version_regions_upgrade_is_admitted_over_a_tree_bearing_snapshot() {
-        let mut held = snap_with_tree(7, 3);
-        let mut upgrade = snap_with_tree(7, 3);
-        upgrade.tree = held.tree.clone();
-        upgrade.regions = Some(ResolvedRegions::empty(1));
-        let mut slot = SnapshotSlot::bootstrap(7);
-        slot.snapshot = Some(Arc::new(held));
-        assert!(slot.admits(&upgrade));
-        let mut sibling = snap_with_tree(7, 3);
-        sibling.regions = Some(ResolvedRegions::empty(1));
+    fn ordinary_publish_cannot_enrich_even_a_clone_of_the_published_tree() {
+        let held = snap_with_tree(7, 3);
+        let mut incoming = snap_with_tree(7, 3);
+        incoming.tree = held.tree.clone();
+        incoming.text = Arc::clone(&held.text);
+        incoming.regions = Some(ResolvedRegions::empty(1));
+        let slot = SnapshotSlot {
+            current_incarnation: 7,
+            snapshot: Some(Arc::new(held)),
+        };
         assert!(
-            !slot.admits(&sibling),
-            "a sibling tree must not replace the published tree"
+            !slot.admits(&incoming),
+            "region completion must name the exact published snapshot, not submit a replacement tree"
         );
-        slot.snapshot = Some(Arc::new(upgrade));
-        assert!(!slot.admits(&sibling), "regions may only arrive once");
-        held = snap_with_tree(7, 3);
-        assert!(!slot.admits(&held), "regions cannot disappear");
+    }
+
+    #[test]
+    fn enrichment_requires_the_exact_snapshot_and_preserves_its_inputs() {
+        let mut held = snap_with_tree(7, 3);
+        held.injection_regions = Some(Arc::new(DiscoveredInjections {
+            generation: 1,
+            complete: true,
+            regions: Vec::new(),
+        }));
+        let mut sibling = snap_with_tree(7, 3);
+        sibling.tree = held.tree.clone();
+        sibling.text = Arc::clone(&held.text);
+        let held = Arc::new(held);
+        let mut slot = SnapshotSlot {
+            current_incarnation: 7,
+            snapshot: Some(Arc::clone(&held)),
+        };
+        let regions = ResolvedRegions::empty(1);
+        assert!(!slot.enrich_regions(&Arc::new(sibling), &regions));
+        assert!(slot.enrich_regions(&held, &regions));
+        let enriched = slot.snapshot.as_ref().unwrap();
+        assert!(Arc::ptr_eq(&enriched.text, &held.text));
+        assert!(Arc::ptr_eq(&enriched.layer_trees, &held.layer_trees));
+        assert!(Arc::ptr_eq(
+            enriched.injection_regions.as_ref().unwrap(),
+            held.injection_regions.as_ref().unwrap()
+        ));
+        assert_eq!(
+            enriched
+                .tree
+                .as_ref()
+                .unwrap()
+                .root_node()
+                .child(0)
+                .unwrap()
+                .id(),
+            held.tree
+                .as_ref()
+                .unwrap()
+                .root_node()
+                .child(0)
+                .unwrap()
+                .id()
+        );
+        assert!(enriched.regions.is_some());
+        assert!(
+            held.regions.is_none(),
+            "the already-issued snapshot stays immutable"
+        );
+        assert!(
+            !slot.enrich_regions(&held, &regions),
+            "a completion cannot publish twice"
+        );
+        let enriched = Arc::clone(slot.snapshot.as_ref().unwrap());
+        assert!(
+            !slot.enrich_regions(&enriched, &regions),
+            "regions cannot be replaced either"
+        );
+    }
+
+    #[test]
+    fn enrichment_rejects_a_placeholder_or_closed_lifetime() {
+        let held = Arc::new(snap(7, 3));
+        let regions = ResolvedRegions::empty(1);
+        let mut slot = SnapshotSlot {
+            current_incarnation: 7,
+            snapshot: Some(Arc::clone(&held)),
+        };
+        assert!(!slot.enrich_regions(&held, &regions));
+        assert!(!SnapshotSlot::closed().enrich_regions(&held, &regions));
     }
 
     #[test]

--- a/src/document/snapshot.rs
+++ b/src/document/snapshot.rs
@@ -244,6 +244,60 @@ mod tests {
         );
     }
 
+    fn with_regions(mut snapshot: ParseSnapshot, bridge: bool, resolved: bool) -> ParseSnapshot {
+        if bridge {
+            snapshot.bridge_regions = Some((1, Arc::new(Vec::new())));
+        }
+        if resolved {
+            snapshot.resolved_regions = Some((1, Arc::new(Vec::new())));
+        }
+        snapshot
+    }
+
+    /// A parse publishes its tree as soon as the injection discovery is
+    /// derived, and the bridge/resolved regions — the resolution the token
+    /// readers never consume — land on the same version afterwards. The
+    /// cell admits that as an upgrade: same lifetime, same version, a tree
+    /// on both sides, and at least one region view going from absent to
+    /// present. Nothing else re-publishes an equal version: the same shape
+    /// again, a tree-less upgrade (no reader may lose the tree), or a
+    /// region view going from present to absent.
+    #[test]
+    fn equal_version_regions_upgrade_is_admitted_over_a_tree_bearing_snapshot() {
+        let mut slot = SnapshotSlot::bootstrap(7);
+        slot.snapshot = Some(Arc::new(snap_with_tree(7, 3)));
+        assert!(
+            slot.admits(&with_regions(snap_with_tree(7, 3), true, false)),
+            "bridge regions arriving on the published version upgrade it"
+        );
+        assert!(
+            slot.admits(&with_regions(snap_with_tree(7, 3), true, true)),
+            "both region views arriving upgrade it"
+        );
+        assert!(
+            !slot.admits(&with_regions(snap_with_tree(6, 3), true, true)),
+            "the incarnation clause is never bypassed by the upgrade"
+        );
+        assert!(
+            !slot.admits(&with_regions(snap(7, 3), true, true)),
+            "an upgrade must carry the tree the readers already derive from"
+        );
+
+        slot.snapshot = Some(Arc::new(with_regions(snap_with_tree(7, 3), true, false)));
+        assert!(
+            slot.admits(&with_regions(snap_with_tree(7, 3), true, true)),
+            "the remaining region view arriving still upgrades"
+        );
+        assert!(
+            !slot.admits(&with_regions(snap_with_tree(7, 3), true, false)),
+            "the same shape again is not an upgrade"
+        );
+        assert!(
+            !slot.admits(&snap_with_tree(7, 3)),
+            "a region view going absent is a downgrade, never admitted"
+        );
+    }
+
     #[test]
     fn equal_version_tree_upgrade_is_admitted_but_swap_and_downgrade_are_not() {
         let mut slot = SnapshotSlot::bootstrap(7);

--- a/src/document/snapshot.rs
+++ b/src/document/snapshot.rs
@@ -65,26 +65,11 @@ pub(crate) struct ParseSnapshot {
     /// binding: text, tree, and regions are one value, so the regions can
     /// never be consumed against a different tree.
     pub(crate) injection_regions: Option<Arc<DiscoveredInjections>>,
-    /// The bridge downstream's region list, derived by the same populate pass
-    /// (`None` when populate didn't run for this snapshot or no bridge server
-    /// was configured — the downstream then resolves inline; `Some(empty)`
-    /// means genuinely no regions). Stamped with the settings generation the
-    /// discovery ran under, like `resolved_regions`: a reload can change the
-    /// injection query without publishing a new snapshot, and the consumer
-    /// must fall back inline rather than open virtual documents for regions
-    /// the new query would not discover.
-    pub(crate) bridge_regions: Option<(u64, Arc<Vec<DiscoveredBridgeRegion>>)>,
-    /// Fully resolved injection regions (`InjectionResolver::resolve_all`'s
-    /// shape) from the same populate pass, for the whole-document readers —
-    /// pull/push diagnostics, documentSymbol/Color, formatting's virt layer —
-    /// which previously each re-ran the injection query per request. Same
-    /// `None`/`Some(empty)` semantics as `bridge_regions`.
-    /// Stamped with the settings generation the populate pass ran under: a
-    /// reload (which can change injection resolution) bumps the generation
-    /// WITHOUT publishing a new snapshot, so consumers gate on the stamp and
-    /// fall back to inline resolution on mismatch (same pattern as
-    /// `DiscoveredInjections.generation` and `layer_trees`).
-    pub(crate) resolved_regions: Option<(u64, Arc<Vec<ResolvedInjection>>)>,
+    /// Both views of one resolution, under one settings generation.
+    /// `None` means unavailable (including skipped/cancelled resolution), not
+    /// necessarily pending. Readers fall back inline. Present empty vectors
+    /// mean the pass established that there are no injection regions.
+    pub(crate) regions: Option<ResolvedRegions>,
     /// Lazily-built, per-snapshot injection layer trees (document-order DFS,
     /// depth ≥ 1) for the captures/node layer walk: the FIRST walking request
     /// on this snapshot builds them (on the compute pool — the same cost the
@@ -102,6 +87,25 @@ pub(crate) struct ParseSnapshot {
     /// seeing a generation mismatch bypasses the cell and walks fresh (the
     /// pre-cache per-request cost) until the next snapshot rebuilds it.
     pub(crate) layer_trees: Arc<std::sync::OnceLock<(u64, Arc<Vec<SnapshotLayerTree>>)>>,
+}
+
+/// The bridge and whole-document views of one resolution. They are published
+/// together, so neither presence nor the settings generation can disagree.
+#[derive(Clone)]
+pub(crate) struct ResolvedRegions {
+    pub(crate) generation: u64,
+    pub(crate) bridge: Arc<Vec<DiscoveredBridgeRegion>>,
+    pub(crate) whole_document: Arc<Vec<ResolvedInjection>>,
+}
+
+impl ResolvedRegions {
+    pub(crate) fn empty(generation: u64) -> Self {
+        Self {
+            generation,
+            bridge: Arc::new(Vec::new()),
+            whole_document: Arc::new(Vec::new()),
+        }
+    }
 }
 
 /// The per-URI `watch` value: the current lifetime plus the latest snapshot.
@@ -176,25 +180,10 @@ impl SnapshotSlot {
     /// bridge / resolved views goes from absent to present. The same shape
     /// again is not an upgrade, so a version never re-publishes for nothing.
     fn regions_upgrade(current: &ParseSnapshot, snapshot: &ParseSnapshot) -> bool {
-        let upgraded = |before: bool, after: bool| !before && after;
-        let downgraded = |before: bool, after: bool| before && !after;
-        let bridge = (
-            current.bridge_regions.is_some(),
-            snapshot.bridge_regions.is_some(),
-        );
-        let resolved = (
-            current.resolved_regions.is_some(),
-            snapshot.resolved_regions.is_some(),
-        );
-        let discovery = (
-            current.injection_regions.is_some(),
-            snapshot.injection_regions.is_some(),
-        );
         Self::same_tree(current, snapshot)
-            && !downgraded(bridge.0, bridge.1)
-            && !downgraded(resolved.0, resolved.1)
-            && !downgraded(discovery.0, discovery.1)
-            && (upgraded(bridge.0, bridge.1) || upgraded(resolved.0, resolved.1))
+            && current.regions.is_none()
+            && snapshot.regions.is_some()
+            && !(current.injection_regions.is_some() && snapshot.injection_regions.is_none())
     }
 
     /// Whether both snapshots carry the same tree. A `Tree` clone gives its
@@ -229,8 +218,7 @@ mod tests {
             parsed_version,
             incarnation,
             injection_regions: None,
-            bridge_regions: None,
-            resolved_regions: None,
+            regions: None,
             layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }
@@ -276,8 +264,7 @@ mod tests {
             parsed_version,
             incarnation,
             injection_regions: None,
-            bridge_regions: None,
-            resolved_regions: None,
+            regions: None,
             layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }
@@ -297,99 +284,25 @@ mod tests {
         );
     }
 
-    fn with_regions(mut snapshot: ParseSnapshot, bridge: bool, resolved: bool) -> ParseSnapshot {
-        if bridge {
-            snapshot.bridge_regions = Some((1, Arc::new(Vec::new())));
-        }
-        if resolved {
-            snapshot.resolved_regions = Some((1, Arc::new(Vec::new())));
-        }
-        snapshot
-    }
-
-    /// Clone of a held tree: a parse's two installs carry the same tree, and
-    /// clones share their child nodes even though each clone's root node
-    /// has its own identity.
-    fn upgrade_of(held: &ParseSnapshot, bridge: bool, resolved: bool) -> ParseSnapshot {
-        let mut snapshot = snap_with_tree(held.incarnation, held.parsed_version);
-        snapshot.tree = held.tree.clone();
-        with_regions(snapshot, bridge, resolved)
-    }
-
-    /// A parse publishes its tree as soon as the injection discovery is
-    /// derived, and the bridge/resolved regions — the resolution the token
-    /// readers never consume — land on the same version afterwards. The
-    /// cell admits that as an upgrade: same lifetime, same version, the
-    /// SAME tree on both sides (a tree under an already-issued result id is
-    /// never swapped, not even by a sibling parse of the same text carrying
-    /// regions), and at least one region view going from absent to
-    /// present. Nothing else re-publishes an equal version: the same shape
-    /// again, a tree-less upgrade, a different tree, or any region view
-    /// going from present to absent.
     #[test]
     fn equal_version_regions_upgrade_is_admitted_over_a_tree_bearing_snapshot() {
+        let mut held = snap_with_tree(7, 3);
+        let mut upgrade = snap_with_tree(7, 3);
+        upgrade.tree = held.tree.clone();
+        upgrade.regions = Some(ResolvedRegions::empty(1));
         let mut slot = SnapshotSlot::bootstrap(7);
-        let held = snap_with_tree(7, 3);
-        let held_tree = held.tree.clone();
         slot.snapshot = Some(Arc::new(held));
-        let held = || ParseSnapshot {
-            tree: held_tree.clone(),
-            ..snap_with_tree(7, 3)
-        };
+        assert!(slot.admits(&upgrade));
+        let mut sibling = snap_with_tree(7, 3);
+        sibling.regions = Some(ResolvedRegions::empty(1));
         assert!(
-            slot.admits(&upgrade_of(&held(), true, false)),
-            "bridge regions arriving on the published version upgrade it"
+            !slot.admits(&sibling),
+            "a sibling tree must not replace the published tree"
         );
-        assert!(
-            slot.admits(&upgrade_of(&held(), true, true)),
-            "both region views arriving upgrade it"
-        );
-        assert!(
-            !slot.admits(&with_regions(snap_with_tree(7, 3), true, true)),
-            "a sibling parse's tree of the same text is a swap, never admitted"
-        );
-        assert!(
-            !slot.admits(&{
-                let mut other = upgrade_of(&held(), true, true);
-                other.incarnation = 6;
-                other
-            }),
-            "the incarnation clause is never bypassed by the upgrade"
-        );
-        assert!(
-            !slot.admits(&with_regions(snap(7, 3), true, true)),
-            "an upgrade must carry the tree the readers already derive from"
-        );
-
-        // With one region view present, only the other's arrival upgrades.
-        slot.snapshot = Some(Arc::new(upgrade_of(&held(), true, false)));
-        assert!(
-            slot.admits(&upgrade_of(&held(), true, true)),
-            "the remaining region view arriving still upgrades"
-        );
-        assert!(
-            !slot.admits(&upgrade_of(&held(), true, false)),
-            "the same shape again is not an upgrade"
-        );
-        assert!(
-            !slot.admits(&upgrade_of(&held(), false, true)),
-            "a view going absent is a downgrade even when another arrives"
-        );
-        assert!(
-            !slot.admits(&held()),
-            "a region view going absent is a downgrade, never admitted"
-        );
-        let mut with_discovery = upgrade_of(&held(), true, false);
-        with_discovery.injection_regions = Some(Arc::new(DiscoveredInjections {
-            generation: 1,
-            complete: true,
-            regions: Vec::new(),
-        }));
-        slot.snapshot = Some(Arc::new(with_discovery));
-        assert!(
-            !slot.admits(&upgrade_of(&held(), true, true)),
-            "the discovery going absent is a downgrade even as the resolution arrives"
-        );
+        slot.snapshot = Some(Arc::new(upgrade));
+        assert!(!slot.admits(&sibling), "regions may only arrive once");
+        held = snap_with_tree(7, 3);
+        assert!(!slot.admits(&held), "regions cannot disappear");
     }
 
     #[test]

--- a/src/document/snapshot.rs
+++ b/src/document/snapshot.rs
@@ -101,7 +101,7 @@ pub(crate) struct ParseSnapshot {
     /// empty embedded layer for the rest of this snapshot's life. A walker
     /// seeing a generation mismatch bypasses the cell and walks fresh (the
     /// pre-cache per-request cost) until the next snapshot rebuilds it.
-    pub(crate) layer_trees: std::sync::OnceLock<(u64, Arc<Vec<SnapshotLayerTree>>)>,
+    pub(crate) layer_trees: Arc<std::sync::OnceLock<(u64, Arc<Vec<SnapshotLayerTree>>)>>,
 }
 
 /// The per-URI `watch` value: the current lifetime plus the latest snapshot.
@@ -231,7 +231,7 @@ mod tests {
             injection_regions: None,
             bridge_regions: None,
             resolved_regions: None,
-            layer_trees: std::sync::OnceLock::new(),
+            layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -278,7 +278,7 @@ mod tests {
             injection_regions: None,
             bridge_regions: None,
             resolved_regions: None,
-            layer_trees: std::sync::OnceLock::new(),
+            layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -756,6 +756,19 @@ impl DocumentStore {
                             && held.incarnation == incarnation
                             && held.tree.is_none()
                     });
+                // An equal-version upgrade replaces the held snapshot with one
+                // carrying the same tree: the layer trees a reader already
+                // derived on the held one are carried over rather than
+                // derived again by the next reader. (A snapshot the cell then
+                // refuses is simply dropped with them.)
+                if has_tree
+                    && let Some(held) = evicted.as_ref()
+                    && held.parsed_version == version
+                    && held.incarnation == incarnation
+                    && let Some(layer_trees) = held.layer_trees.get()
+                {
+                    let _ = snapshot.layer_trees.set(layer_trees.clone());
+                }
                 let published = doc.publish_snapshot(&snapshot);
                 let current = published && parsed_current_version;
                 // The reparses do not relabel (the snapshot carries the

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -1393,6 +1393,72 @@ mod tests {
         );
     }
 
+    /// Layer trees are derived lazily on the published snapshot by the
+    /// whole-document readers. The regions upgrade replaces that snapshot
+    /// with one carrying the same tree, so it inherits what a reader
+    /// already derived instead of making the next reader derive it again.
+    #[test]
+    fn install_parse_upgrade_inherits_the_layer_trees_already_derived() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///layer-trees.md").unwrap();
+        let text = "# doc\n";
+        let incarnation = store.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let (expected_text, content_version) = {
+            let doc = store.get(&uri).unwrap();
+            (doc.text_arc(), doc.content_version())
+        };
+        let tree = markdown_tree(text);
+        store.install_parse(
+            &uri,
+            LanguageCheck::Expect(Some("markdown")),
+            parse_snapshot(
+                &expected_text,
+                Some(tree.clone()),
+                content_version,
+                incarnation,
+            ),
+        );
+        let derived = store
+            .latest_snapshot(&uri)
+            .and_then(|view| view.slot.snapshot)
+            .expect("the tree is published");
+        assert!(derived.layer_trees.set((1, Arc::new(Vec::new()))).is_ok());
+
+        let mut snapshot = super::super::snapshot::ParseSnapshot {
+            text: Arc::clone(&expected_text),
+            tree: Some(tree.clone()),
+            language: Some("markdown".to_string()),
+            parsed_version: content_version,
+            incarnation,
+            injection_regions: None,
+            bridge_regions: None,
+            resolved_regions: None,
+            layer_trees: std::sync::OnceLock::new(),
+        };
+        snapshot.bridge_regions = Some((1, Arc::new(Vec::new())));
+        assert!(
+            store
+                .install_parse(
+                    &uri,
+                    LanguageCheck::Expect(Some("markdown")),
+                    Arc::new(snapshot),
+                )
+                .published
+        );
+        assert!(
+            store
+                .latest_snapshot(&uri)
+                .and_then(|view| view.slot.snapshot)
+                .is_some_and(|snapshot| snapshot.layer_trees.get().is_some()),
+            "the upgrade carries the layer trees the readers already derived"
+        );
+    }
+
     /// One publish per version and lifetime, and currency reported from the
     /// snapshot's stamps: the first install at a version lands and is current;
     /// an equal-version duplicate lands nothing and is not current; a parse of

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -1212,6 +1212,95 @@ mod tests {
         );
     }
 
+    /// A parse installs twice per version: the tree with its discovery as
+    /// soon as they exist, then the same version again once the bridge /
+    /// resolved regions are derived. The second install is an upgrade the
+    /// cell admits over the tree it already holds; it is current and
+    /// published like the first, and the same shape a third time lands
+    /// nothing — a version never re-publishes for nothing.
+    #[test]
+    fn install_parse_upgrades_the_current_version_with_regions_once() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///upgrade.md").unwrap();
+        let text = "# doc\n";
+        let incarnation = store.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let (expected_text, content_version) = {
+            let doc = store.get(&uri).unwrap();
+            (doc.text_arc(), doc.content_version())
+        };
+        let tree = markdown_tree(text);
+        let with_regions = || {
+            let mut snapshot = super::super::snapshot::ParseSnapshot {
+                text: Arc::clone(&expected_text),
+                tree: Some(tree.clone()),
+                language: Some("markdown".to_string()),
+                parsed_version: content_version,
+                incarnation,
+                injection_regions: None,
+                bridge_regions: None,
+                resolved_regions: None,
+                layer_trees: std::sync::OnceLock::new(),
+            };
+            snapshot.bridge_regions = Some((1, Arc::new(Vec::new())));
+            Arc::new(snapshot)
+        };
+
+        let first = store.install_parse(
+            &uri,
+            LanguageCheck::Expect(Some("markdown")),
+            parse_snapshot(
+                &expected_text,
+                Some(tree.clone()),
+                content_version,
+                incarnation,
+            ),
+        );
+        assert_eq!(
+            first,
+            ParseInstall {
+                current: true,
+                published: true
+            }
+        );
+        let upgrade = store.install_parse(
+            &uri,
+            LanguageCheck::Expect(Some("markdown")),
+            with_regions(),
+        );
+        assert_eq!(
+            upgrade,
+            ParseInstall {
+                current: true,
+                published: true
+            },
+            "the regions arriving on the published version upgrade it"
+        );
+        assert!(
+            store.latest_snapshot(&uri).is_some_and(|view| view
+                .slot
+                .snapshot
+                .as_ref()
+                .is_some_and(|s| s.parsed_version == content_version
+                    && s.tree.is_some()
+                    && s.bridge_regions.is_some())),
+            "readers now see the regions on the same version"
+        );
+        let again = store.install_parse(
+            &uri,
+            LanguageCheck::Expect(Some("markdown")),
+            with_regions(),
+        );
+        assert_eq!(
+            again,
+            ParseInstall::default(),
+            "the same shape again is not an upgrade"
+        );
+    }
     /// One publish per version and lifetime, and currency reported from the
     /// snapshot's stamps: the first install at a version lands and is current;
     /// an equal-version duplicate lands nothing and is not current; a parse of

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -748,6 +748,14 @@ impl DocumentStore {
                 }
                 let parsed_current_version = snapshot.parsed_version == doc.content_version();
                 let detected = snapshot.language.clone();
+                // Read before the publish, under the same guard: the held
+                // snapshot is what this publish upgrades, if anything.
+                let fills_placeholder = has_tree
+                    && evicted.as_ref().is_some_and(|held| {
+                        held.parsed_version == version
+                            && held.incarnation == incarnation
+                            && held.tree.is_none()
+                    });
                 let published = doc.publish_snapshot(&snapshot);
                 let current = published && parsed_current_version;
                 // The reparses do not relabel (the snapshot carries the
@@ -759,7 +767,7 @@ impl DocumentStore {
                 ParseInstall {
                     current,
                     published,
-                    tree_upgrade: false,
+                    tree_upgrade: published && fills_placeholder,
                 }
             });
         // Likewise a rejected `snapshot` (still owned here: the publish

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -628,8 +628,7 @@ impl DocumentStore {
             parsed_version: doc.content_version(),
             incarnation: doc.incarnation(),
             injection_regions: None,
-            bridge_regions: None,
-            resolved_regions: None,
+            regions: None,
             layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         doc.publish_snapshot(&Arc::new(snapshot));
@@ -651,8 +650,9 @@ impl DocumentStore {
         if snapshot.parsed_version != view.content_version {
             return None;
         }
-        let (stamped_generation, regions) = snapshot.resolved_regions.as_ref()?;
-        (*stamped_generation == current_generation).then(|| std::sync::Arc::clone(regions))
+        let regions = snapshot.regions.as_ref()?;
+        (regions.generation == current_generation)
+            .then(|| std::sync::Arc::clone(&regions.whole_document))
     }
 
     /// Subscribe to `uri`'s snapshot-slot changes for a **bounded** wait (the
@@ -814,8 +814,7 @@ mod tests {
             parsed_version,
             incarnation,
             injection_regions: None,
-            bridge_regions: None,
-            resolved_regions: None,
+            regions: None,
             layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
         })
     }
@@ -939,8 +938,7 @@ mod tests {
                 parsed_version: content_version,
                 incarnation,
                 injection_regions: None,
-                bridge_regions: None,
-                resolved_regions: None,
+                regions: None,
                 layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
             }),
         );
@@ -1263,11 +1261,10 @@ mod tests {
                 parsed_version: content_version,
                 incarnation,
                 injection_regions: None,
-                bridge_regions: None,
-                resolved_regions: None,
+                regions: None,
                 layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
             };
-            snapshot.bridge_regions = Some((1, Arc::new(Vec::new())));
+            snapshot.regions = Some(super::super::snapshot::ResolvedRegions::empty(1));
             Arc::new(snapshot)
         };
 
@@ -1310,7 +1307,7 @@ mod tests {
                 .as_ref()
                 .is_some_and(|s| s.parsed_version == content_version
                     && s.tree.is_some()
-                    && s.bridge_regions.is_some())),
+                    && s.regions.is_some())),
             "readers now see the regions on the same version"
         );
         let again = store.install_parse(
@@ -1376,11 +1373,10 @@ mod tests {
                 parsed_version: content_version,
                 incarnation,
                 injection_regions: None,
-                bridge_regions: None,
-                resolved_regions: None,
+                regions: None,
                 layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
             };
-            snapshot.bridge_regions = Some((1, Arc::new(Vec::new())));
+            snapshot.regions = Some(super::super::snapshot::ResolvedRegions::empty(1));
             store.install_parse(
                 &uri,
                 LanguageCheck::Expect(Some("markdown")),
@@ -1559,8 +1555,7 @@ mod tests {
                 parsed_version: 0,
                 incarnation,
                 injection_regions: None,
-                bridge_regions: None,
-                resolved_regions: None,
+                regions: None,
                 layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
             }),
         );
@@ -1591,8 +1586,7 @@ mod tests {
                 parsed_version,
                 incarnation: doc.incarnation(),
                 injection_regions: None,
-                bridge_regions: None,
-                resolved_regions: None,
+                regions: None,
                 layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
             }
         }

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -711,6 +711,47 @@ pub(crate) struct ParseInstall {
 }
 
 impl DocumentStore {
+    /// Finish the work for the exact first-published snapshot. If regions
+    /// arrived, enrich it through the restricted channel operation; otherwise
+    /// keep it unchanged. Return whether it is still current AT COMPLETION,
+    /// not whether it was current when initially published. An edit may leave
+    /// the snapshot eligible for stale-but-consistent enrichment, but the
+    /// caller must not run current-version downstream work for it.
+    pub(crate) fn complete_parse(
+        &self,
+        uri: &Url,
+        language: LanguageCheck<'_>,
+        expected: &Arc<super::snapshot::ParseSnapshot>,
+        regions: Option<super::snapshot::ResolvedRegions>,
+    ) -> bool {
+        let current_at_completion = self.documents.get_mut(uri).is_some_and(|doc| {
+            if let LanguageCheck::Expect(language) = language
+                && doc.language_id() != language
+            {
+                return false;
+            }
+            let slot = doc.latest_snapshot_slot();
+            if slot.current_incarnation != expected.incarnation
+                || !slot
+                    .snapshot
+                    .as_ref()
+                    .is_some_and(|held| Arc::ptr_eq(held, expected))
+            {
+                return false;
+            }
+            if let Some(regions) = &regions
+                && !doc.enrich_regions(expected, regions)
+            {
+                return false;
+            }
+            expected.parsed_version == doc.content_version()
+        });
+        // Rejected region vectors can be large; destroy them outside the
+        // entry guard, as with install_parse's rejected/evicted snapshots.
+        drop(regions);
+        current_at_completion
+    }
+
     /// Install a parse result: publish `snapshot` iff the stored language
     /// passes `language` and the cell admits it, under the document's entry
     /// lock — the one way a parse reaches readers (`Document::tree` is the
@@ -1231,95 +1272,109 @@ mod tests {
         );
     }
 
-    /// A parse installs twice per version: the tree with its discovery as
-    /// soon as they exist, then the same version again once the bridge /
-    /// resolved regions are derived. The second install is an upgrade the
-    /// cell admits over the tree it already holds; it is current and
-    /// published like the first, and the same shape a third time lands
-    /// nothing — a version never re-publishes for nothing.
     #[test]
-    fn install_parse_upgrades_the_current_version_with_regions_once() {
+    fn complete_parse_enriches_once_and_notifies_waiters() {
         let store = DocumentStore::new();
         let uri = Url::parse("file:///upgrade.md").unwrap();
-        let text = "# doc\n";
-        let incarnation = store.insert(
-            uri.clone(),
-            text.to_string(),
-            Some("markdown".to_string()),
-            None,
-        );
-        let (expected_text, content_version) = {
-            let doc = store.get(&uri).unwrap();
-            (doc.text_arc(), doc.content_version())
-        };
-        let tree = markdown_tree(text);
-        let with_regions = || {
-            let mut snapshot = super::super::snapshot::ParseSnapshot {
-                text: Arc::clone(&expected_text),
-                tree: Some(tree.clone()),
-                language: Some("markdown".to_string()),
-                parsed_version: content_version,
-                incarnation,
-                injection_regions: None,
-                regions: None,
-                layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
-            };
-            snapshot.regions = Some(super::super::snapshot::ResolvedRegions::empty(1));
-            Arc::new(snapshot)
-        };
-
-        let first = store.install_parse(
-            &uri,
-            LanguageCheck::Expect(Some("markdown")),
-            parse_snapshot(
-                &expected_text,
-                Some(tree.clone()),
-                content_version,
-                incarnation,
-            ),
-        );
-        assert_eq!(
-            first,
-            ParseInstall {
-                current: true,
-                published: true,
-                tree_upgrade: false
-            }
-        );
-        let upgrade = store.install_parse(
-            &uri,
-            LanguageCheck::Expect(Some("markdown")),
-            with_regions(),
-        );
-        assert_eq!(
-            upgrade,
-            ParseInstall {
-                current: true,
-                published: true,
-                tree_upgrade: false
-            },
-            "the regions arriving on the published version upgrade it"
-        );
+        let text: Arc<str> = Arc::from("# doc\n");
+        let incarnation =
+            store.insert(uri.clone(), text.to_string(), Some("markdown".into()), None);
+        let version = store.get(&uri).unwrap().content_version();
+        let first = parse_snapshot(&text, Some(markdown_tree(&text)), version, incarnation);
         assert!(
-            store.latest_snapshot(&uri).is_some_and(|view| view
-                .slot
-                .snapshot
-                .as_ref()
-                .is_some_and(|s| s.parsed_version == content_version
-                    && s.tree.is_some()
-                    && s.regions.is_some())),
-            "readers now see the regions on the same version"
+            store
+                .install_parse(
+                    &uri,
+                    LanguageCheck::Expect(Some("markdown")),
+                    Arc::clone(&first)
+                )
+                .current
         );
-        let again = store.install_parse(
+        let mut watcher = store.subscribe_snapshots(&uri).unwrap();
+        watcher.borrow_and_update();
+        let complete = || {
+            store.complete_parse(
+                &uri,
+                LanguageCheck::Expect(Some("markdown")),
+                &first,
+                Some(super::super::snapshot::ResolvedRegions::empty(1)),
+            )
+        };
+        assert!(complete());
+        assert!(watcher.has_changed().unwrap());
+        let enriched = store.latest_snapshot(&uri).unwrap().slot.snapshot.unwrap();
+        assert!(enriched.regions.is_some());
+        watcher.borrow_and_update();
+        assert!(!complete());
+        assert!(!watcher.has_changed().unwrap());
+        assert!(Arc::ptr_eq(
+            &enriched,
+            &store.latest_snapshot(&uri).unwrap().slot.snapshot.unwrap()
+        ));
+    }
+
+    #[rstest::rstest]
+    #[case(true)]
+    #[case(false)]
+    fn complete_parse_rechecks_currency_after_an_edit(#[case] with_regions: bool) {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///edited-completion.md").unwrap();
+        let text: Arc<str> = Arc::from("# doc\n");
+        let incarnation =
+            store.insert(uri.clone(), text.to_string(), Some("markdown".into()), None);
+        let version = store.get(&uri).unwrap().content_version();
+        let first = parse_snapshot(&text, Some(markdown_tree(&text)), version, incarnation);
+        assert!(
+            store
+                .install_parse(&uri, LanguageCheck::Record, Arc::clone(&first))
+                .current
+        );
+        store.update_document(uri.clone(), "# edited\n".into(), None);
+        assert!(!store.complete_parse(
             &uri,
-            LanguageCheck::Expect(Some("markdown")),
-            with_regions(),
-        );
+            LanguageCheck::Record,
+            &first,
+            with_regions.then(|| super::super::snapshot::ResolvedRegions::empty(1))
+        ));
+        let stale = store.latest_snapshot(&uri).unwrap().slot.snapshot.unwrap();
+        assert_eq!(stale.parsed_version, version);
         assert_eq!(
-            again,
-            ParseInstall::default(),
-            "the same shape again is not an upgrade"
+            stale.regions.is_some(),
+            with_regions,
+            "stale enrichment stays internally consistent"
         );
+    }
+
+    #[rstest::rstest]
+    #[case(true)]
+    #[case(false)]
+    fn complete_parse_rejects_a_reopened_or_reloaded_document(#[case] reopen: bool) {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///reopened-completion.md").unwrap();
+        let text: Arc<str> = Arc::from("# doc\n");
+        let incarnation =
+            store.insert(uri.clone(), text.to_string(), Some("markdown".into()), None);
+        let version = store.get(&uri).unwrap().content_version();
+        let first = parse_snapshot(&text, Some(markdown_tree(&text)), version, incarnation);
+        assert!(
+            store
+                .install_parse(&uri, LanguageCheck::Record, Arc::clone(&first))
+                .current
+        );
+        if reopen {
+            store.remove(&uri);
+            assert!(!store.complete_parse(&uri, LanguageCheck::Record, &first, None));
+            store.insert(uri.clone(), text.to_string(), Some("markdown".into()), None);
+        } else {
+            store.invalidate_all_parses();
+        }
+        assert!(!store.complete_parse(
+            &uri,
+            LanguageCheck::Record,
+            &first,
+            Some(super::super::snapshot::ResolvedRegions::empty(1))
+        ));
+        assert!(store.current_resolved_regions(&uri, 1).is_none());
     }
 
     /// A reparse's refresh gate needs to know whether its publish upgraded
@@ -1365,28 +1420,13 @@ mod tests {
             filled.published && filled.tree_upgrade,
             "the tree landing over the placeholder is the upgrade the refresh gate asks about"
         );
-        let upgrade = {
-            let mut snapshot = super::super::snapshot::ParseSnapshot {
-                text: Arc::clone(&expected_text),
-                tree: Some(tree.clone()),
-                language: Some("markdown".to_string()),
-                parsed_version: content_version,
-                incarnation,
-                injection_regions: None,
-                regions: None,
-                layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
-            };
-            snapshot.regions = Some(super::super::snapshot::ResolvedRegions::empty(1));
-            store.install_parse(
-                &uri,
-                LanguageCheck::Expect(Some("markdown")),
-                Arc::new(snapshot),
-            )
-        };
-        assert!(
-            upgrade.published && !upgrade.tree_upgrade,
-            "the regions upgrade lands on a version that already had its tree"
-        );
+        let first = store.latest_snapshot(&uri).unwrap().slot.snapshot.unwrap();
+        assert!(store.complete_parse(
+            &uri,
+            LanguageCheck::Expect(Some("markdown")),
+            &first,
+            Some(super::super::snapshot::ResolvedRegions::empty(1))
+        ));
     }
 
     /// One publish per version and lifetime, and currency reported from the

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -756,19 +756,6 @@ impl DocumentStore {
                             && held.incarnation == incarnation
                             && held.tree.is_none()
                     });
-                // An equal-version upgrade replaces the held snapshot with one
-                // carrying the same tree: the layer trees a reader already
-                // derived on the held one are carried over rather than
-                // derived again by the next reader. (A snapshot the cell then
-                // refuses is simply dropped with them.)
-                if has_tree
-                    && let Some(held) = evicted.as_ref()
-                    && held.parsed_version == version
-                    && held.incarnation == incarnation
-                    && let Some(layer_trees) = held.layer_trees.get()
-                {
-                    let _ = snapshot.layer_trees.set(layer_trees.clone());
-                }
                 let published = doc.publish_snapshot(&snapshot);
                 let current = published && parsed_current_version;
                 // The reparses do not relabel (the snapshot carries the
@@ -1403,72 +1390,6 @@ mod tests {
         assert!(
             upgrade.published && !upgrade.tree_upgrade,
             "the regions upgrade lands on a version that already had its tree"
-        );
-    }
-
-    /// Layer trees are derived lazily on the published snapshot by the
-    /// whole-document readers. The regions upgrade replaces that snapshot
-    /// with one carrying the same tree, so it inherits what a reader
-    /// already derived instead of making the next reader derive it again.
-    #[test]
-    fn install_parse_upgrade_inherits_the_layer_trees_already_derived() {
-        let store = DocumentStore::new();
-        let uri = Url::parse("file:///layer-trees.md").unwrap();
-        let text = "# doc\n";
-        let incarnation = store.insert(
-            uri.clone(),
-            text.to_string(),
-            Some("markdown".to_string()),
-            None,
-        );
-        let (expected_text, content_version) = {
-            let doc = store.get(&uri).unwrap();
-            (doc.text_arc(), doc.content_version())
-        };
-        let tree = markdown_tree(text);
-        store.install_parse(
-            &uri,
-            LanguageCheck::Expect(Some("markdown")),
-            parse_snapshot(
-                &expected_text,
-                Some(tree.clone()),
-                content_version,
-                incarnation,
-            ),
-        );
-        let derived = store
-            .latest_snapshot(&uri)
-            .and_then(|view| view.slot.snapshot)
-            .expect("the tree is published");
-        assert!(derived.layer_trees.set((1, Arc::new(Vec::new()))).is_ok());
-
-        let mut snapshot = super::super::snapshot::ParseSnapshot {
-            text: Arc::clone(&expected_text),
-            tree: Some(tree.clone()),
-            language: Some("markdown".to_string()),
-            parsed_version: content_version,
-            incarnation,
-            injection_regions: None,
-            bridge_regions: None,
-            resolved_regions: None,
-            layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
-        };
-        snapshot.bridge_regions = Some((1, Arc::new(Vec::new())));
-        assert!(
-            store
-                .install_parse(
-                    &uri,
-                    LanguageCheck::Expect(Some("markdown")),
-                    Arc::new(snapshot),
-                )
-                .published
-        );
-        assert!(
-            store
-                .latest_snapshot(&uri)
-                .and_then(|view| view.slot.snapshot)
-                .is_some_and(|snapshot| snapshot.layer_trees.get().is_some()),
-            "the upgrade carries the layer trees the readers already derived"
         );
     }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -645,14 +645,33 @@ impl DocumentStore {
         uri: &Url,
         current_generation: u64,
     ) -> Option<std::sync::Arc<Vec<crate::language::injection::ResolvedInjection>>> {
+        self.current_region_views(uri, current_generation)
+            .map(|regions| regions.whole_document)
+    }
+
+    /// The same currency/generation gate for bridge lifecycle readers.
+    pub(crate) fn current_bridge_regions(
+        &self,
+        uri: &Url,
+        current_generation: u64,
+    ) -> Option<Arc<Vec<super::DiscoveredBridgeRegion>>> {
+        self.current_region_views(uri, current_generation)
+            .map(|regions| regions.bridge)
+    }
+
+    fn current_region_views(
+        &self,
+        uri: &Url,
+        current_generation: u64,
+    ) -> Option<super::snapshot::ResolvedRegions> {
         let view = self.latest_snapshot(uri)?;
         let snapshot = view.slot.snapshot?;
-        if snapshot.parsed_version != view.content_version {
+        if snapshot.incarnation != view.slot.current_incarnation
+            || snapshot.parsed_version != view.content_version
+        {
             return None;
         }
-        let regions = snapshot.regions.as_ref()?;
-        (regions.generation == current_generation)
-            .then(|| std::sync::Arc::clone(&regions.whole_document))
+        snapshot.regions_for_generation(current_generation).cloned()
     }
 
     /// Subscribe to `uri`'s snapshot-slot changes for a **bounded** wait (the
@@ -1270,6 +1289,81 @@ mod tests {
             store.get(&uri).is_none() && !store.parse_states.contains_key(&uri),
             "an install into a closed document must not resurrect it or its parse state"
         );
+    }
+
+    #[test]
+    fn both_region_readers_distinguish_unavailable_empty_and_stale() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///region-readers.md").unwrap();
+        let text: Arc<str> = Arc::from("# doc\n");
+        let incarnation =
+            store.insert(uri.clone(), text.to_string(), Some("markdown".into()), None);
+        let version = store.get(&uri).unwrap().content_version();
+        let first = parse_snapshot(&text, Some(markdown_tree(&text)), version, incarnation);
+        assert!(
+            store
+                .install_parse(&uri, LanguageCheck::Record, Arc::clone(&first))
+                .current
+        );
+        assert!(store.current_bridge_regions(&uri, 1).is_none());
+        assert!(store.current_resolved_regions(&uri, 1).is_none());
+        assert!(store.complete_parse(
+            &uri,
+            LanguageCheck::Record,
+            &first,
+            Some(super::super::snapshot::ResolvedRegions::empty(1))
+        ));
+        assert!(store.current_bridge_regions(&uri, 1).unwrap().is_empty());
+        assert!(store.current_resolved_regions(&uri, 1).unwrap().is_empty());
+        assert!(store.current_bridge_regions(&uri, 2).is_none());
+        assert!(store.current_resolved_regions(&uri, 2).is_none());
+        let bound = store.latest_snapshot(&uri).unwrap().slot.snapshot.unwrap();
+        store.update_document(uri.clone(), "# edited\n".into(), None);
+        assert!(store.current_bridge_regions(&uri, 1).is_none());
+        assert!(store.current_resolved_regions(&uri, 1).is_none());
+        assert!(
+            bound.regions_for_generation(1).is_some(),
+            "snapshot-bound reads keep their own regions"
+        );
+        assert!(
+            bound.regions_for_generation(2).is_none(),
+            "even a bound read rejects reload-stale regions"
+        );
+    }
+
+    #[test]
+    fn completion_cannot_overwrite_a_newer_published_tree() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///newer-tree.md").unwrap();
+        let text: Arc<str> = Arc::from("# doc\n");
+        let incarnation =
+            store.insert(uri.clone(), text.to_string(), Some("markdown".into()), None);
+        let version = store.get(&uri).unwrap().content_version();
+        let first = parse_snapshot(&text, Some(markdown_tree(&text)), version, incarnation);
+        assert!(
+            store
+                .install_parse(&uri, LanguageCheck::Record, Arc::clone(&first))
+                .current
+        );
+        let edited: Arc<str> = Arc::from("# edited\n");
+        store.update_document(uri.clone(), edited.to_string(), None);
+        let version = store.get(&uri).unwrap().content_version();
+        let newer = parse_snapshot(&edited, Some(markdown_tree(&edited)), version, incarnation);
+        assert!(
+            store
+                .install_parse(&uri, LanguageCheck::Record, Arc::clone(&newer))
+                .current
+        );
+        for regions in [
+            None,
+            Some(super::super::snapshot::ResolvedRegions::empty(1)),
+        ] {
+            assert!(!store.complete_parse(&uri, LanguageCheck::Record, &first, regions));
+            assert!(Arc::ptr_eq(
+                &newer,
+                &store.latest_snapshot(&uri).unwrap().slot.snapshot.unwrap()
+            ));
+        }
     }
 
     #[test]

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -703,6 +703,11 @@ pub(crate) struct ParseInstall {
     /// The snapshot landed in the document's cell: the language matched and
     /// the slot admitted it.
     pub(crate) published: bool,
+    /// The publish was the equal-version tree upgrade: a tree landing over a
+    /// tree-less placeholder or give-up of the same version. Read under the
+    /// same entry guard as the publish, so a reparse's refresh gate needs no
+    /// probe of its own that a racing give-up could invalidate.
+    pub(crate) tree_upgrade: bool,
 }
 
 impl DocumentStore {
@@ -751,7 +756,11 @@ impl DocumentStore {
                 if current && matches!(language, LanguageCheck::Record) {
                     doc.record_language(detected);
                 }
-                ParseInstall { current, published }
+                ParseInstall {
+                    current,
+                    published,
+                    tree_upgrade: false,
+                }
             });
         // Likewise a rejected `snapshot` (still owned here: the publish
         // borrows) — destroyed only after the guard is released.
@@ -838,7 +847,8 @@ mod tests {
             outcome,
             ParseInstall {
                 current: false,
-                published: true
+                published: true,
+                tree_upgrade: false
             }
         );
         assert!(store.get(&uri).unwrap().tree().is_none());
@@ -885,7 +895,8 @@ mod tests {
             outcome,
             ParseInstall {
                 current: false,
-                published: true
+                published: true,
+                tree_upgrade: false
             }
         );
         assert_eq!(
@@ -1158,7 +1169,8 @@ mod tests {
             outcome,
             ParseInstall {
                 current: true,
-                published: true
+                published: true,
+                tree_upgrade: false
             },
             "same version, same lifetime: the current parse, whichever allocation it read"
         );
@@ -1187,7 +1199,8 @@ mod tests {
             installed,
             ParseInstall {
                 current: true,
-                published: true
+                published: true,
+                tree_upgrade: false
             }
         );
         let doc = store.get(&uri).unwrap();
@@ -1264,7 +1277,8 @@ mod tests {
             first,
             ParseInstall {
                 current: true,
-                published: true
+                published: true,
+                tree_upgrade: false
             }
         );
         let upgrade = store.install_parse(
@@ -1276,7 +1290,8 @@ mod tests {
             upgrade,
             ParseInstall {
                 current: true,
-                published: true
+                published: true,
+                tree_upgrade: false
             },
             "the regions arriving on the published version upgrade it"
         );
@@ -1301,6 +1316,75 @@ mod tests {
             "the same shape again is not an upgrade"
         );
     }
+
+    /// A reparse's refresh gate needs to know whether its publish upgraded
+    /// a tree-less placeholder of the same version (the client may have
+    /// been served empty against it). The install reports that from under
+    /// the entry guard: true for the tree landing over the placeholder,
+    /// false for a fresh version and for the regions upgrade of a version
+    /// that already had its tree.
+    #[test]
+    fn install_parse_reports_the_tree_upgrade_it_made() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///tree-upgrade.md").unwrap();
+        let text = "# doc\n";
+        let incarnation = store.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let (expected_text, content_version) = {
+            let doc = store.get(&uri).unwrap();
+            (doc.text_arc(), doc.content_version())
+        };
+        let tree = markdown_tree(text);
+
+        let placeholder = store.install_parse(
+            &uri,
+            LanguageCheck::Expect(Some("markdown")),
+            parse_snapshot(&expected_text, None, content_version, incarnation),
+        );
+        assert!(placeholder.published && !placeholder.tree_upgrade);
+        let filled = store.install_parse(
+            &uri,
+            LanguageCheck::Expect(Some("markdown")),
+            parse_snapshot(
+                &expected_text,
+                Some(tree.clone()),
+                content_version,
+                incarnation,
+            ),
+        );
+        assert!(
+            filled.published && filled.tree_upgrade,
+            "the tree landing over the placeholder is the upgrade the refresh gate asks about"
+        );
+        let upgrade = {
+            let mut snapshot = super::super::snapshot::ParseSnapshot {
+                text: Arc::clone(&expected_text),
+                tree: Some(tree.clone()),
+                language: Some("markdown".to_string()),
+                parsed_version: content_version,
+                incarnation,
+                injection_regions: None,
+                bridge_regions: None,
+                resolved_regions: None,
+                layer_trees: std::sync::OnceLock::new(),
+            };
+            snapshot.bridge_regions = Some((1, Arc::new(Vec::new())));
+            store.install_parse(
+                &uri,
+                LanguageCheck::Expect(Some("markdown")),
+                Arc::new(snapshot),
+            )
+        };
+        assert!(
+            upgrade.published && !upgrade.tree_upgrade,
+            "the regions upgrade lands on a version that already had its tree"
+        );
+    }
+
     /// One publish per version and lifetime, and currency reported from the
     /// snapshot's stamps: the first install at a version lands and is current;
     /// an equal-version duplicate lands nothing and is not current; a parse of
@@ -1336,7 +1420,8 @@ mod tests {
             outcome,
             ParseInstall {
                 current: true,
-                published: true
+                published: true,
+                tree_upgrade: false
             }
         );
         assert!(store.get(&uri).unwrap().tree().is_some(), "tree visible");

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -630,7 +630,7 @@ impl DocumentStore {
             injection_regions: None,
             bridge_regions: None,
             resolved_regions: None,
-            layer_trees: std::sync::OnceLock::new(),
+            layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         doc.publish_snapshot(&Arc::new(snapshot));
     }
@@ -829,7 +829,7 @@ mod tests {
             injection_regions: None,
             bridge_regions: None,
             resolved_regions: None,
-            layer_trees: std::sync::OnceLock::new(),
+            layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
         })
     }
 
@@ -954,7 +954,7 @@ mod tests {
                 injection_regions: None,
                 bridge_regions: None,
                 resolved_regions: None,
-                layer_trees: std::sync::OnceLock::new(),
+                layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
             }),
         );
         assert!(reparse.current && reparse.published);
@@ -1278,7 +1278,7 @@ mod tests {
                 injection_regions: None,
                 bridge_regions: None,
                 resolved_regions: None,
-                layer_trees: std::sync::OnceLock::new(),
+                layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
             };
             snapshot.bridge_regions = Some((1, Arc::new(Vec::new())));
             Arc::new(snapshot)
@@ -1391,7 +1391,7 @@ mod tests {
                 injection_regions: None,
                 bridge_regions: None,
                 resolved_regions: None,
-                layer_trees: std::sync::OnceLock::new(),
+                layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
             };
             snapshot.bridge_regions = Some((1, Arc::new(Vec::new())));
             store.install_parse(
@@ -1451,7 +1451,7 @@ mod tests {
             injection_regions: None,
             bridge_regions: None,
             resolved_regions: None,
-            layer_trees: std::sync::OnceLock::new(),
+            layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
         };
         snapshot.bridge_regions = Some((1, Arc::new(Vec::new())));
         assert!(
@@ -1640,7 +1640,7 @@ mod tests {
                 injection_regions: None,
                 bridge_regions: None,
                 resolved_regions: None,
-                layer_trees: std::sync::OnceLock::new(),
+                layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
             }),
         );
         assert!(
@@ -1672,7 +1672,7 @@ mod tests {
                 injection_regions: None,
                 bridge_regions: None,
                 resolved_regions: None,
-                layer_trees: std::sync::OnceLock::new(),
+                layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
             }
         }
 

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -783,6 +783,16 @@ impl LanguageCoordinator {
     /// intentionally not registered when the derived language owns a distinct
     /// parser; see [`Self::build_base_map`].
     /// Example: "rmd" → Some("markdown") when its base mapping is eligible.
+    /// Test probe: a base mapping installed mid-flight, so a test can tell
+    /// which side of a hand-off a language resolution ran on.
+    #[cfg(test)]
+    pub(crate) fn set_base_mapping(&self, language_id: &str, base: &str) {
+        self.base_map
+            .write()
+            .recover_poison("LanguageCoordinator::set_base_mapping")
+            .insert(language_id.to_string(), base.to_string());
+    }
+
     fn resolve_base(&self, language_id: &str) -> Option<String> {
         let base_map = self
             .base_map

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -777,12 +777,6 @@ impl LanguageCoordinator {
         }
     }
 
-    /// Resolve a derived languageId to its base language name.
-    ///
-    /// Returns the registered base mapping, otherwise `None`. A declaration is
-    /// intentionally not registered when the derived language owns a distinct
-    /// parser; see [`Self::build_base_map`].
-    /// Example: "rmd" → Some("markdown") when its base mapping is eligible.
     /// Test probe: a base mapping installed mid-flight, so a test can tell
     /// which side of a hand-off a language resolution ran on.
     #[cfg(test)]
@@ -793,6 +787,12 @@ impl LanguageCoordinator {
             .insert(language_id.to_string(), base.to_string());
     }
 
+    /// Resolve a derived languageId to its base language name.
+    ///
+    /// Returns the registered base mapping, otherwise `None`. A declaration is
+    /// intentionally not registered when the derived language owns a distinct
+    /// parser; see [`Self::build_base_map`].
+    /// Example: "rmd" → Some("markdown") when its base mapping is eligible.
     fn resolve_base(&self, language_id: &str) -> Option<String> {
         let base_map = self
             .base_map

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -94,17 +94,8 @@ pub(crate) struct InjectionDiscovery {
 /// All ride the `ParseSnapshot` the parse publishes.
 pub(crate) struct PopulatedInjections {
     pub(crate) discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
-    /// `None` when the resolution was skipped (no runnable bridge server) —
-    /// bridge readers then fall back to inline resolution — vs `Some(empty)`
-    /// for "ran, nothing matched" (readers skip their work).
-    pub(crate) bridge_regions: Option<Vec<crate::document::DiscoveredBridgeRegion>>,
-    /// The same gate as `bridge_regions`: `None` exactly when it is, and the
-    /// whole-document readers then resolve inline.
-    pub(crate) resolved_regions: Option<Vec<crate::language::injection::ResolvedInjection>>,
-    /// The settings generation this populate pass ran under — stamped onto
-    /// the snapshot's `bridge_regions` and `resolved_regions` so reload-stale
-    /// resolution is never served (see `ParseSnapshot::resolved_regions`).
-    pub(crate) generation: u64,
+    /// Both resolution views, or unavailable when resolution was skipped.
+    pub(crate) regions: Option<crate::document::snapshot::ResolvedRegions>,
 }
 
 impl PopulatedInjections {
@@ -113,9 +104,9 @@ impl PopulatedInjections {
     pub(crate) fn empty(generation: u64) -> Self {
         Self {
             discovery: None,
-            bridge_regions: Some(Vec::new()),
-            resolved_regions: Some(Vec::new()),
-            generation,
+            regions: Some(crate::document::snapshot::ResolvedRegions::empty(
+                generation,
+            )),
         }
     }
 
@@ -126,12 +117,10 @@ impl PopulatedInjections {
     /// documents that do have injections once the query is loaded. Riding
     /// without regions makes readers fall back to inline resolution, which
     /// finds the query as soon as it is there.
-    pub(crate) fn undetermined(generation: u64) -> Self {
+    pub(crate) fn undetermined() -> Self {
         Self {
             discovery: None,
-            bridge_regions: None,
-            resolved_regions: None,
-            generation,
+            regions: None,
         }
     }
 }
@@ -343,7 +332,7 @@ impl CacheCoordinator {
                 return Some(if parser_published {
                     PopulatedInjections::empty(generation)
                 } else {
-                    PopulatedInjections::undetermined(generation)
+                    PopulatedInjections::undetermined()
                 });
             }
         };
@@ -479,23 +468,21 @@ impl CacheCoordinator {
             // critical path, and the per-region content copies are pure
             // waste for the (common) bridge-less deployment — `None` makes
             // any late-configured bridge fall back to inline resolution.
-            let bridge_regions: Option<Vec<crate::document::DiscoveredBridgeRegion>> =
-                resolved.as_ref().map(|resolved| {
-                    resolved
-                        .iter()
-                        .map(|region| crate::document::DiscoveredBridgeRegion {
-                            language: region.injection_language.clone(),
-                            region_id: region.region.region_id.clone(),
-                            content: region.virtual_content.clone(),
-                        })
-                        .collect()
-                });
-
-            // The whole-document readers' fully resolved regions, from the
-            // same single query run — and from the SAME per-region ids and
-            // content hashes already in `cacheable_regions` (no duplicate
-            // mint/hash on this critical path).
-            let resolved_regions = resolved;
+            let regions = resolved.map(|resolved| {
+                let bridge = resolved
+                    .iter()
+                    .map(|region| crate::document::DiscoveredBridgeRegion {
+                        language: region.injection_language.clone(),
+                        region_id: region.region.region_id.clone(),
+                        content: region.virtual_content.clone(),
+                    })
+                    .collect();
+                crate::document::snapshot::ResolvedRegions {
+                    generation,
+                    bridge: std::sync::Arc::new(bridge),
+                    whole_document: std::sync::Arc::new(resolved),
+                }
+            });
 
             if crate::cancel::is_cancelled(cancel) {
                 return None;
@@ -555,12 +542,7 @@ impl CacheCoordinator {
                     .retain_document(uri, &live_hashes);
             });
             committed?;
-            Some(PopulatedInjections {
-                discovery,
-                bridge_regions,
-                resolved_regions,
-                generation,
-            })
+            Some(PopulatedInjections { discovery, regions })
         }
     }
 
@@ -1051,10 +1033,9 @@ mod tests {
             .expect("the pass ran");
 
         assert!(
-            populated.bridge_regions.is_none(),
+            populated.regions.is_none(),
             "no query available must not publish a definitive empty region set"
         );
-        assert!(populated.resolved_regions.is_none());
         assert!(populated.discovery.is_none());
 
         // Once the parser is visible its queries are too (they are published
@@ -1077,10 +1058,9 @@ mod tests {
             )
             .expect("the pass ran");
         assert!(
-            populated
-                .bridge_regions
-                .as_ref()
-                .is_some_and(|regions| regions.is_empty()),
+            populated.regions.as_ref().is_some_and(
+                |regions| regions.bridge.is_empty() && regions.whole_document.is_empty()
+            ),
             "a settled language without an injection query publishes a definitive empty set"
         );
     }
@@ -1146,11 +1126,12 @@ mod tests {
             .expect("the pass ran");
         assert_eq!(
             handed_out.get(),
-            Some(populated.generation),
+            populated.regions.as_ref().map(|regions| regions.generation),
             "the hand-off carries the pass's generation"
         );
         assert_eq!(
-            populated.bridge_regions.as_ref().map(|regions| regions
+            populated.regions.as_ref().map(|regions| regions
+                .bridge
                 .iter()
                 .map(|region| region.language.as_str())
                 .collect::<Vec<_>>()),

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -67,7 +67,7 @@ pub(crate) struct CacheCoordinator {
 /// bridge-downstream region list and the whole-document resolved regions.
 /// All ride the `ParseSnapshot` the parse publishes.
 pub(crate) struct PopulatedInjections {
-    pub(crate) discovery: Option<crate::document::DiscoveredInjections>,
+    pub(crate) discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
     /// `None` when the resolution was skipped (no runnable bridge server) —
     /// bridge readers then fall back to inline resolution — vs `Some(empty)`
     /// for "ran, nothing matched" (readers skip their work).
@@ -511,7 +511,7 @@ impl CacheCoordinator {
             });
             committed?;
             Some(PopulatedInjections {
-                discovery,
+                discovery: discovery.map(std::sync::Arc::new),
                 bridge_regions,
                 resolved_regions,
                 generation,

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -66,6 +66,17 @@ pub(crate) struct CacheCoordinator {
 /// (a runnable bridge server), two views of one resolution — the
 /// bridge-downstream region list and the whole-document resolved regions.
 /// All ride the `ParseSnapshot` the parse publishes.
+/// The first half of a populate pass, handed out before resolution starts
+/// (see [`CacheCoordinator::populate_injections_cancellable`]): everything
+/// the token readers consume. The parse publishes its tree with this, so a
+/// token request parks only behind the discovery, never behind the
+/// resolution that only the bridge and the whole-document readers use.
+pub(crate) struct InjectionDiscovery {
+    /// The settings generation the pass ran under (the same value the full
+    /// [`PopulatedInjections`] carries).
+    pub(crate) generation: u64,
+}
+
 pub(crate) struct PopulatedInjections {
     pub(crate) discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
     /// `None` when the resolution was skipped (no runnable bridge server) —
@@ -239,6 +250,7 @@ impl CacheCoordinator {
             entry_mint_epoch,
             incarnation,
             build_bridge_regions,
+            &mut |_| {},
             None,
         )
     }
@@ -255,6 +267,7 @@ impl CacheCoordinator {
         entry_mint_epoch: (u64, u64),
         incarnation: u64,
         build_bridge_regions: bool,
+        on_discovered: &mut dyn FnMut(InjectionDiscovery),
         cancel: Option<&crate::cancel::CancelToken>,
     ) -> Option<PopulatedInjections> {
         if crate::cancel::is_cancelled(cancel) {
@@ -455,6 +468,8 @@ impl CacheCoordinator {
                 incarnation,
                 cancel,
             )?;
+
+            on_discovered(InjectionDiscovery { generation });
 
             // Live-hash set for the content-addressed injection-token cache's
             // eviction sweep, taken from the DISCOVERY's own per-region cache
@@ -1015,6 +1030,74 @@ mod tests {
         );
     }
 
+    /// The token readers consume the discovery and the tree, never the
+    /// resolution (virtual content and canonical languages for the bridge),
+    /// so populate hands the discovery out — for the parse to publish —
+    /// before it starts resolving. Resolution canonicalizes each region's
+    /// language through the base map, so a mapping installed by the
+    /// hand-off is the probe: a resolution run after it sees the mapping.
+    #[test]
+    fn populate_hands_the_discovery_out_before_resolving() {
+        use tree_sitter::Parser;
+
+        let cache = CacheCoordinator::new();
+        let tracker = NodeTracker::new();
+        let coordinator = LanguageCoordinator::new();
+        let uri = create_test_uri("handoff.md");
+        let language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let query = tree_sitter::Query::new(
+            &language,
+            "(fenced_code_block (info_string (language) @injection.language) \
+             (code_fence_content) @injection.content)",
+        )
+        .expect("valid markdown injection query");
+        coordinator
+            .query_store()
+            .insert_injection_query("markdown".to_string(), std::sync::Arc::new(query));
+        coordinator
+            .language_registry_for_parallel()
+            .register("markdown".to_string(), language.clone());
+        let text = "```lua\nprint(1)\n```\n";
+        let mut parser = Parser::new();
+        parser.set_language(&language).unwrap();
+        let tree = parser.parse(text, None).unwrap();
+
+        let handed_out = std::cell::Cell::new(None);
+        let mut on_discovered = |discovered: InjectionDiscovery| {
+            handed_out.set(Some(discovered.generation));
+            coordinator.set_base_mapping("lua", "python");
+        };
+        let populated = cache
+            .populate_injections_cancellable(
+                &uri,
+                text,
+                &tree,
+                "markdown",
+                &coordinator,
+                &tracker,
+                tracker.mint_epoch(&uri),
+                1,
+                true,
+                &mut on_discovered,
+                None,
+            )
+            .expect("the pass ran");
+        assert_eq!(
+            handed_out.get(),
+            Some(populated.generation),
+            "the hand-off carries the pass's generation"
+        );
+        assert_eq!(
+            populated
+                .bridge_regions
+                .as_ref()
+                .and_then(|regions| regions.first())
+                .map(|region| region.language.as_str()),
+            Some("python"),
+            "resolution ran after the hand-off: it saw the mapping the hand-off installed"
+        );
+    }
+
     #[test]
     fn cancelled_populate_commits_no_injection_state() {
         use tree_sitter::{Parser, Query};
@@ -1051,6 +1134,7 @@ mod tests {
             tracker.mint_epoch(&uri),
             1,
             true,
+            &mut |_| {},
             Some(&cancel),
         );
 
@@ -1100,6 +1184,7 @@ mod tests {
             tracker.mint_epoch(&uri),
             1,
             true,
+            &mut |_| {},
             Some(&cancel),
         );
 

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -33,7 +33,21 @@ pub(crate) type RequestId = u64;
 /// This struct wraps five underlying caches (full tokens, range tokens, the
 /// injection map, injection-region tokens, and request tracking) and provides a
 /// unified API for document lifecycle management, edit handling, and token operations.
+/// Drop to release the populate passes [`CacheCoordinator::hold_resolution`] holds.
+#[cfg(test)]
+pub(crate) struct ResolutionHold(std::sync::Arc<(std::sync::Mutex<bool>, std::sync::Condvar)>);
+
+#[cfg(test)]
+impl Drop for ResolutionHold {
+    fn drop(&mut self) {
+        *self.0.0.lock().unwrap_or_else(|e| e.into_inner()) = false;
+        self.0.1.notify_all();
+    }
+}
+
 pub(crate) struct CacheCoordinator {
+    #[cfg(test)]
+    resolution_hold: std::sync::Arc<(std::sync::Mutex<bool>, std::sync::Condvar)>,
     semantic_cache: SemanticTokenCache,
     /// Most-recent `semanticTokens/range` result per URI (#535), keyed by viewport
     /// range + the same `cache_key` as `semantic_cache`. Cleared on a generation
@@ -72,6 +86,7 @@ pub(crate) struct CacheCoordinator {
 /// token request parks only behind the discovery, never behind the
 /// resolution that only the bridge and the whole-document readers use.
 pub(crate) struct InjectionDiscovery {
+    pub(crate) discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
     /// The settings generation the pass ran under (the same value the full
     /// [`PopulatedInjections`] carries).
     pub(crate) generation: u64,
@@ -125,6 +140,11 @@ impl CacheCoordinator {
     /// Create a new cache coordinator with empty caches.
     pub(crate) fn new() -> Self {
         Self {
+            #[cfg(test)]
+            resolution_hold: std::sync::Arc::new((
+                std::sync::Mutex::new(false),
+                std::sync::Condvar::new(),
+            )),
             semantic_cache: SemanticTokenCache::new(),
             semantic_range_cache: SemanticTokenRangeCache::new(),
             injection_map: InjectionMap::new(),
@@ -403,6 +423,37 @@ impl CacheCoordinator {
                 ));
             }
 
+            // Producer half of the discovery lever: build the owned discovery
+            // from the SAME `regions` just collected — the injection query (`Q`)
+            // is not re-run — so a semanticTokens request bound to the snapshot
+            // this parse publishes can rebuild its contexts without
+            // re-discovering. `None` when not worth reusing
+            // (gate/combined/incomplete).
+            let discovery = crate::analysis::semantic::build_document_discovery_cancellable(
+                &regions,
+                &cacheable_regions,
+                injection_query.as_ref(),
+                text,
+                language,
+                uri,
+                tracker,
+                generation,
+                incarnation,
+                cancel,
+            )?;
+
+            // Hand the discovery out before resolving: the parse publishes
+            // its tree with it, releasing the token readers, while the
+            // resolution below — which only the bridge and the whole-document
+            // readers consume — runs afterwards and lands on the same version
+            // as an upgrade (parse-snapshot ADR §2).
+            let discovery = discovery.map(std::sync::Arc::new);
+            on_discovered(InjectionDiscovery {
+                discovery: discovery.clone(),
+                generation,
+            });
+            self.await_resolution_hold();
+
             // One resolution for every consumer that needs resolved languages /
             // virtual content: the bridge regions and the whole-document
             // resolved regions below are two views of this single pass.
@@ -449,27 +500,6 @@ impl CacheCoordinator {
             if crate::cancel::is_cancelled(cancel) {
                 return None;
             }
-
-            // Producer half of the discovery lever: build the owned discovery
-            // from the SAME `regions` just collected — the injection query (`Q`)
-            // is not re-run — so a semanticTokens request bound to the snapshot
-            // this parse publishes can rebuild its contexts without
-            // re-discovering. `None` when not worth reusing
-            // (gate/combined/incomplete).
-            let discovery = crate::analysis::semantic::build_document_discovery_cancellable(
-                &regions,
-                &cacheable_regions,
-                injection_query.as_ref(),
-                text,
-                language,
-                uri,
-                tracker,
-                generation,
-                incarnation,
-                cancel,
-            )?;
-
-            on_discovered(InjectionDiscovery { generation });
 
             // Live-hash set for the content-addressed injection-token cache's
             // eviction sweep, taken from the DISCOVERY's own per-region cache
@@ -526,7 +556,7 @@ impl CacheCoordinator {
             });
             committed?;
             Some(PopulatedInjections {
-                discovery: discovery.map(std::sync::Arc::new),
+                discovery,
                 bridge_regions,
                 resolved_regions,
                 generation,
@@ -542,6 +572,31 @@ impl CacheCoordinator {
 
     /// Share the per-region injection token cache for use on the blocking
     /// semantic-token pool (#529), where the hot path reuses/stores region tokens.
+    /// Test probe: hold every populate pass between its discovery hand-off
+    /// and its resolution until the returned guard is dropped, so a test can
+    /// observe the first install (tree + discovery) as a state of its own.
+    #[cfg(test)]
+    pub(crate) fn hold_resolution(&self) -> ResolutionHold {
+        *self
+            .resolution_hold
+            .0
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = true;
+        ResolutionHold(std::sync::Arc::clone(&self.resolution_hold))
+    }
+
+    #[cfg(test)]
+    fn await_resolution_hold(&self) {
+        let (held, released) = &*self.resolution_hold;
+        let mut held = held.lock().unwrap_or_else(|e| e.into_inner());
+        while *held {
+            held = released.wait(held).unwrap_or_else(|e| e.into_inner());
+        }
+    }
+
+    #[cfg(not(test))]
+    fn await_resolution_hold(&self) {}
+
     pub(crate) fn injection_token_cache_arc(&self) -> std::sync::Arc<InjectionTokenCache> {
         std::sync::Arc::clone(&self.injection_token_cache)
     }

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -92,6 +92,7 @@ pub(crate) struct InjectionDiscovery {
 /// (a runnable bridge server), two views of one resolution — the
 /// bridge-downstream region list and the whole-document resolved regions.
 /// All ride the `ParseSnapshot` the parse publishes.
+#[derive(Default)]
 pub(crate) struct PopulatedInjections {
     pub(crate) discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
     /// Both resolution views, or unavailable when resolution was skipped.

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -30,9 +30,6 @@ pub(crate) type RequestId = u64;
 
 /// Coordinates all cache structures for semantic token operations.
 ///
-/// This struct wraps five underlying caches (full tokens, range tokens, the
-/// injection map, injection-region tokens, and request tracking) and provides a
-/// unified API for document lifecycle management, edit handling, and token operations.
 /// Drop to release the populate passes [`CacheCoordinator::hold_resolution`] holds.
 #[cfg(test)]
 pub(crate) struct ResolutionHold(std::sync::Arc<(std::sync::Mutex<bool>, std::sync::Condvar)>);
@@ -45,6 +42,9 @@ impl Drop for ResolutionHold {
     }
 }
 
+/// This struct wraps five underlying caches (full tokens, range tokens, the
+/// injection map, injection-region tokens, and request tracking) and provides a
+/// unified API for document lifecycle management, edit handling, and token operations.
 pub(crate) struct CacheCoordinator {
     #[cfg(test)]
     resolution_hold: std::sync::Arc<(std::sync::Mutex<bool>, std::sync::Condvar)>,
@@ -74,12 +74,6 @@ pub(crate) struct CacheCoordinator {
     served_semantic_versions: dashmap::DashMap<Url, u64>,
 }
 
-/// Everything one `populate_injections` pass derives from its single
-/// injection-query run (parse-snapshot ADR §3, never discover twice): the
-/// semantic-path discovery (below its own reuse gate) and, behind one gate
-/// (a runnable bridge server), two views of one resolution — the
-/// bridge-downstream region list and the whole-document resolved regions.
-/// All ride the `ParseSnapshot` the parse publishes.
 /// The first half of a populate pass, handed out before resolution starts
 /// (see [`CacheCoordinator::populate_injections_cancellable`]): everything
 /// the token readers consume. The parse publishes its tree with this, so a
@@ -92,6 +86,12 @@ pub(crate) struct InjectionDiscovery {
     pub(crate) generation: u64,
 }
 
+/// Everything one `populate_injections` pass derives from its single
+/// injection-query run (parse-snapshot ADR §3, never discover twice): the
+/// semantic-path discovery (below its own reuse gate) and, behind one gate
+/// (a runnable bridge server), two views of one resolution — the
+/// bridge-downstream region list and the whole-document resolved regions.
+/// All ride the `ParseSnapshot` the parse publishes.
 pub(crate) struct PopulatedInjections {
     pub(crate) discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
     /// `None` when the resolution was skipped (no runnable bridge server) —
@@ -570,8 +570,6 @@ impl CacheCoordinator {
         self.injection_map.get(uri)
     }
 
-    /// Share the per-region injection token cache for use on the blocking
-    /// semantic-token pool (#529), where the hot path reuses/stores region tokens.
     /// Test probe: hold every populate pass between its discovery hand-off
     /// and its resolution until the returned guard is dropped, so a test can
     /// observe the first install (tree + discovery) as a state of its own.
@@ -597,6 +595,8 @@ impl CacheCoordinator {
     #[cfg(not(test))]
     fn await_resolution_hold(&self) {}
 
+    /// Share the per-region injection token cache for use on the blocking
+    /// semantic-token pool (#529), where the hot path reuses/stores region tokens.
     pub(crate) fn injection_token_cache_arc(&self) -> std::sync::Arc<InjectionTokenCache> {
         std::sync::Arc::clone(&self.injection_token_cache)
     }

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -1112,13 +1112,20 @@ mod tests {
         coordinator
             .language_registry_for_parallel()
             .register("markdown".to_string(), language.clone());
-        let text = "```lua\nprint(1)\n```\n";
+        // Enough regions for the discovery to be worth storing (the token
+        // path's reuse gate), so the hand-off is seen to carry it.
+        let text = "```lua\nprint(1)\n```\n".repeat(9);
+        let text = text.as_str();
         let mut parser = Parser::new();
         parser.set_language(&language).unwrap();
         let tree = parser.parse(text, None).unwrap();
 
         let handed_out = std::cell::Cell::new(None);
         let mut on_discovered = |discovered: InjectionDiscovery| {
+            assert!(
+                discovered.discovery.is_some(),
+                "the hand-off carries the discovery the token readers consume"
+            );
             handed_out.set(Some(discovered.generation));
             coordinator.set_base_mapping("lua", "python");
         };
@@ -1143,12 +1150,11 @@ mod tests {
             "the hand-off carries the pass's generation"
         );
         assert_eq!(
-            populated
-                .bridge_regions
-                .as_ref()
-                .and_then(|regions| regions.first())
-                .map(|region| region.language.as_str()),
-            Some("python"),
+            populated.bridge_regions.as_ref().map(|regions| regions
+                .iter()
+                .map(|region| region.language.as_str())
+                .collect::<Vec<_>>()),
+            Some(vec!["python"; 9]),
             "resolution ran after the hand-off: it saw the mapping the hand-off installed"
         );
     }

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -691,7 +691,7 @@ mod tests {
                 injection_regions: None,
                 bridge_regions: None,
                 resolved_regions: None,
-                layer_trees: std::sync::OnceLock::new(),
+                layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
             }),
         );
         assert!(installed.current && installed.published);
@@ -739,7 +739,7 @@ mod tests {
                         injection_regions: None,
                         bridge_regions: None,
                         resolved_regions: None,
-                        layer_trees: std::sync::OnceLock::new(),
+                        layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     }),
                 )
                 .current

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -689,8 +689,7 @@ mod tests {
                 parsed_version: content_version,
                 incarnation,
                 injection_regions: None,
-                bridge_regions: None,
-                resolved_regions: None,
+                regions: None,
                 layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
             }),
         );
@@ -737,8 +736,7 @@ mod tests {
                         parsed_version: content_version,
                         incarnation,
                         injection_regions: None,
-                        bridge_regions: None,
-                        resolved_regions: None,
+                        regions: None,
                         layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     }),
                 )

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -3551,8 +3551,7 @@ mod tests {
                         parsed_version: content_version,
                         incarnation,
                         injection_regions: None,
-                        bridge_regions: None,
-                        resolved_regions: None,
+                        regions: None,
                         layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -3553,7 +3553,7 @@ mod tests {
                         injection_regions: None,
                         bridge_regions: None,
                         resolved_regions: None,
-                        layer_trees: std::sync::OnceLock::new(),
+                        layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))
             })

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -158,14 +158,15 @@ impl InjectionCoordinator {
         if let Some(view) = self.documents.latest_snapshot(uri)
             && let Some(snapshot) = &view.slot.snapshot
             && snapshot.parsed_version == view.content_version
-            && let Some((stamped_generation, bridge_regions)) = &snapshot.bridge_regions
+            && let Some(regions) = &snapshot.regions
             // Generation gate (like resolved_regions): a reload can change
             // the injection query without a new snapshot — consuming the old
             // query's regions would open/update virtual documents the new
             // query would not discover. Mismatch falls back inline below.
-            && *stamped_generation == self.cache.semantic_token_generation()
+            && regions.generation == self.cache.semantic_token_generation()
         {
-            let regions = bridge_regions
+            let regions = regions
+                .bridge
                 .iter()
                 .map(|region| BridgeInjection {
                     language: region.language.clone(),
@@ -981,8 +982,7 @@ mod tests {
                     parsed_version: content_version,
                     incarnation,
                     injection_regions: None,
-                    bridge_regions: None,
-                    resolved_regions: None,
+                    regions: None,
                     layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                 }))
             })
@@ -1139,8 +1139,7 @@ mod tests {
                         parsed_version: content_version,
                         incarnation,
                         injection_regions: None,
-                        bridge_regions: None,
-                        resolved_regions: None,
+                        regions: None,
                         layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))
@@ -1202,7 +1201,7 @@ mod tests {
             .slot
             .current_incarnation;
         let content_version = server.documents.get(&uri).unwrap().content_version();
-        let publish = |bridge_regions, parsed_version| {
+        let publish = |regions, parsed_version| {
             let landed = server
                 .documents
                 .get(&uri)
@@ -1215,8 +1214,7 @@ mod tests {
                             parsed_version,
                             incarnation,
                             injection_regions: None,
-                            bridge_regions,
-                            resolved_regions: None,
+                            regions,
                             layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                         },
                     ))
@@ -1245,15 +1243,12 @@ mod tests {
             true,
         );
         let populated = populated.expect("current pass populates");
-        let bridge_regions = populated.bridge_regions.expect("gate was true");
+        let regions = populated.regions.expect("gate was true");
         server
             .documents
             .update_document(uri.clone(), text.to_string(), None);
         let content_version = server.documents.get(&uri).unwrap().content_version();
-        publish(
-            Some((populated.generation, std::sync::Arc::new(bridge_regions))),
-            content_version,
-        );
+        publish(Some(regions), content_version);
         let fast = injection
             .resolve_injection_data(&uri, "rust")
             .expect("query present");
@@ -1434,7 +1429,7 @@ mod tests {
                 true,
             )
             .expect("current pass populates");
-        let bridge_regions = populated.bridge_regions.expect("gate was true");
+        let regions = populated.regions.expect("gate was true");
         // A new revision, so the fast-path snapshot below is admitted (a
         // second publish at the same revision is refused).
         server
@@ -1456,11 +1451,7 @@ mod tests {
                         parsed_version: content_version,
                         incarnation,
                         injection_regions: None,
-                        bridge_regions: Some((
-                            populated.generation,
-                            std::sync::Arc::new(bridge_regions),
-                        )),
-                        resolved_regions: None,
+                        regions: Some(regions),
                         layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))
@@ -1623,8 +1614,7 @@ mod tests {
                         parsed_version: content_version,
                         incarnation,
                         injection_regions: None,
-                        bridge_regions: None,
-                        resolved_regions: None,
+                        regions: None,
                         layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -155,18 +155,11 @@ impl InjectionCoordinator {
         // downstream runs right after the publish, so it virtually always is;
         // a raced edit falls back to the inline resolution below (which reads
         // the live tree, exactly as before).
-        if let Some(view) = self.documents.latest_snapshot(uri)
-            && let Some(snapshot) = &view.slot.snapshot
-            && snapshot.parsed_version == view.content_version
-            && let Some(regions) = &snapshot.regions
-            // Generation gate (like resolved_regions): a reload can change
-            // the injection query without a new snapshot — consuming the old
-            // query's regions would open/update virtual documents the new
-            // query would not discover. Mismatch falls back inline below.
-            && regions.generation == self.cache.semantic_token_generation()
+        if let Some(regions) = self
+            .documents
+            .current_bridge_regions(uri, self.cache.semantic_token_generation())
         {
             let regions = regions
-                .bridge
                 .iter()
                 .map(|region| BridgeInjection {
                     language: region.language.clone(),

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -983,7 +983,7 @@ mod tests {
                     injection_regions: None,
                     bridge_regions: None,
                     resolved_regions: None,
-                    layer_trees: std::sync::OnceLock::new(),
+                    layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                 }))
             })
             .unwrap_or(false);
@@ -1141,7 +1141,7 @@ mod tests {
                         injection_regions: None,
                         bridge_regions: None,
                         resolved_regions: None,
-                        layer_trees: std::sync::OnceLock::new(),
+                        layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))
             })
@@ -1217,7 +1217,7 @@ mod tests {
                             injection_regions: None,
                             bridge_regions,
                             resolved_regions: None,
-                            layer_trees: std::sync::OnceLock::new(),
+                            layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                         },
                     ))
                 })
@@ -1461,7 +1461,7 @@ mod tests {
                             std::sync::Arc::new(bridge_regions),
                         )),
                         resolved_regions: None,
-                        layer_trees: std::sync::OnceLock::new(),
+                        layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))
             })
@@ -1625,7 +1625,7 @@ mod tests {
                         injection_regions: None,
                         bridge_regions: None,
                         resolved_regions: None,
-                        layer_trees: std::sync::OnceLock::new(),
+                        layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))
             })

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -2,7 +2,7 @@ use crate::document::DocumentStore;
 use crate::document::model::IncrementalSeed;
 use crate::language::{DocumentParserPool, LanguageCoordinator};
 use crate::lsp::bridge::BridgeCoordinator;
-use crate::lsp::cache::CacheCoordinator;
+use crate::lsp::cache::{CacheCoordinator, PopulatedInjections};
 use crate::lsp::client::ClientNotifier;
 use tower_lsp_server::Client;
 use url::Url;
@@ -23,7 +23,7 @@ struct SnapshotInputs {
 impl SnapshotInputs {
     fn snapshot(
         &self,
-        regions: PopulatedSnapshotRegions,
+        regions: PopulatedInjections,
     ) -> std::sync::Arc<crate::document::snapshot::ParseSnapshot> {
         std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
             text: std::sync::Arc::clone(&self.text),
@@ -52,16 +52,6 @@ impl InstallCheck {
             Self::Expect(language) => crate::document::LanguageCheck::Expect(language.as_deref()),
         }
     }
-}
-
-/// Everything one populate pass derives for the snapshot it rides on
-/// (parse-snapshot ADR §3): all `None` when the pool work-unit panicked or
-/// populate's own epoch/lifetime guard committed nothing — readers then fall
-/// back to inline resolution for that snapshot.
-#[derive(Default)]
-struct PopulatedSnapshotRegions {
-    discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
-    regions: Option<crate::document::snapshot::ResolvedRegions>,
 }
 
 /// Keep the historical publish outcome separate from the verdict after the
@@ -402,7 +392,7 @@ impl ParseCoordinator {
                 .install_parse(
                     uri,
                     check.as_check(),
-                    inputs.snapshot(PopulatedSnapshotRegions::default()),
+                    inputs.snapshot(PopulatedInjections::default()),
                 )
                 .into();
         };
@@ -440,9 +430,9 @@ impl ParseCoordinator {
                             inputs.parsed_version,
                             discovered.generation
                         );
-                        let snapshot = inputs.snapshot(PopulatedSnapshotRegions {
+                        let snapshot = inputs.snapshot(PopulatedInjections {
                             discovery: discovered.discovery,
-                            ..PopulatedSnapshotRegions::default()
+                            ..PopulatedInjections::default()
                         });
                         let installed = documents.install_parse(
                             &pool_uri,
@@ -460,12 +450,7 @@ impl ParseCoordinator {
                 // ran-and-empty shape instead would publish "no injections"
                 // for a pass that never derived anything, blanking the
                 // document's injections until the next parse.
-                populated.map_or_else(PopulatedSnapshotRegions::default, |populated| {
-                    PopulatedSnapshotRegions {
-                        discovery: populated.discovery,
-                        regions: populated.regions,
-                    }
-                })
+                populated.unwrap_or_default()
             }
         })
         .await

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -10,10 +10,6 @@ use url::Url;
 use crate::lsp::lsp_impl::{Kakehashi, build_notifier};
 use crate::lsp::settings_manager::SettingsManager;
 
-/// Everything one populate pass derives for the snapshot it rides on
-/// (parse-snapshot ADR §3): all `None` when the pool work-unit panicked or
-/// populate's own epoch/lifetime guard committed nothing — readers then fall
-/// back to inline resolution for that snapshot.
 /// What every snapshot a parse publishes shares: the text and tree it parsed,
 /// the language it detected, and the version/lifetime stamps. The two
 /// installs a parse makes per version (tree + discovery first, the regions
@@ -61,6 +57,10 @@ impl InstallCheck {
     }
 }
 
+/// Everything one populate pass derives for the snapshot it rides on
+/// (parse-snapshot ADR §3): all `None` when the pool work-unit panicked or
+/// populate's own epoch/lifetime guard committed nothing — readers then fall
+/// back to inline resolution for that snapshot.
 #[derive(Default)]
 struct PopulatedSnapshotRegions {
     discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
@@ -451,11 +451,12 @@ impl ParseCoordinator {
                     Some(&cancel_for_work),
                 );
                 // A refused pass (`None`) maps to all-`None` region fields —
-                // the snapshot then rides WITHOUT regions and readers fall
-                // back to inline resolution. Mapping it to the ran-and-empty
-                // shape instead would publish "no injections" for a pass
-                // that never derived anything, blanking the document's
-                // injections until the next parse.
+                // the version then keeps what the first install published
+                // (the tree with the discovery already handed out, or
+                // nothing yet) and readers resolve inline. Mapping it to the
+                // ran-and-empty shape instead would publish "no injections"
+                // for a pass that never derived anything, blanking the
+                // document's injections until the next parse.
                 populated.map_or_else(PopulatedSnapshotRegions::default, |populated| {
                     PopulatedSnapshotRegions {
                         discovery: populated.discovery,

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -392,13 +392,20 @@ impl ParseCoordinator {
                 if latest.is_none() {
                     self.documents.remove_edit_lock_if_unshared(uri, &edit_lock);
                 }
-                return self.documents.install_parse(
-                    uri,
-                    check.as_check(),
-                    inputs.snapshot(PopulatedSnapshotRegions::default()),
-                );
+                None
+            } else {
+                Some(latch)
             }
-            latch
+        };
+        // Refused at the latch (the inputs moved on): one install, without
+        // regions — after the edit lock is released, so a queued edit never
+        // waits behind a stale publish and the evicted tree's teardown.
+        let Some(entry_mint_epoch) = entry_mint_epoch else {
+            return self.documents.install_parse(
+                uri,
+                check.as_check(),
+                inputs.snapshot(PopulatedSnapshotRegions::default()),
+            );
         };
         let build_bridge_regions = self
             .settings_manager

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -39,8 +39,7 @@ impl SnapshotInputs {
             parsed_version: self.parsed_version,
             incarnation: self.incarnation,
             injection_regions: regions.discovery,
-            bridge_regions: regions.bridge_regions,
-            resolved_regions: regions.resolved_regions,
+            regions: regions.regions,
             layer_trees,
         })
     }
@@ -73,14 +72,7 @@ impl InstallCheck {
 #[derive(Default)]
 struct PopulatedSnapshotRegions {
     discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
-    bridge_regions: Option<(
-        u64,
-        std::sync::Arc<Vec<crate::document::DiscoveredBridgeRegion>>,
-    )>,
-    resolved_regions: Option<(
-        u64,
-        std::sync::Arc<Vec<crate::language::injection::ResolvedInjection>>,
-    )>,
+    regions: Option<crate::document::snapshot::ResolvedRegions>,
 }
 
 /// Timeout for compute-pool parse operations to prevent hangs on pathological inputs.
@@ -481,12 +473,7 @@ impl ParseCoordinator {
                 populated.map_or_else(PopulatedSnapshotRegions::default, |populated| {
                     PopulatedSnapshotRegions {
                         discovery: populated.discovery,
-                        bridge_regions: populated
-                            .bridge_regions
-                            .map(|regions| (populated.generation, std::sync::Arc::new(regions))),
-                        resolved_regions: populated
-                            .resolved_regions
-                            .map(|regions| (populated.generation, std::sync::Arc::new(regions))),
+                        regions: populated.regions,
                     }
                 })
             }
@@ -511,9 +498,7 @@ impl ParseCoordinator {
                 // must not run for a version that is no longer current.
                 // The upgrade re-judges under the entry guard; without one,
                 // the cell is asked whether the version is still current.
-                let upgraded = (first.published
-                    && (regions.bridge_regions.is_some() || regions.resolved_regions.is_some()))
-                .then(|| {
+                let upgraded = (first.published && regions.regions.is_some()).then(|| {
                     self.documents.install_parse(
                         uri,
                         check.as_check(),
@@ -718,8 +703,7 @@ impl ParseCoordinator {
                     parsed_version: content_version,
                     incarnation,
                     injection_regions: None,
-                    bridge_regions: None,
-                    resolved_regions: None,
+                    regions: None,
                     layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                 }),
             );
@@ -743,8 +727,7 @@ impl ParseCoordinator {
                 parsed_version: content_version,
                 incarnation,
                 injection_regions: None,
-                bridge_regions: None,
-                resolved_regions: None,
+                regions: None,
                 layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
             }),
         );

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -394,6 +394,13 @@ impl ParseCoordinator {
                 entry_mint_epoch,
                 incarnation,
                 build_bridge_regions,
+                &mut |discovered| {
+                    log::trace!(
+                        target: "kakehashi::populate",
+                        "discovery handed out at settings generation {}",
+                        discovered.generation
+                    );
+                },
                 Some(&cancel_for_work),
             ) else {
                 return PopulatedSnapshotRegions::default();

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -10,10 +10,8 @@ use url::Url;
 use crate::lsp::lsp_impl::{Kakehashi, build_notifier};
 use crate::lsp::settings_manager::SettingsManager;
 
-/// What every snapshot a parse publishes shares: the text and tree it parsed,
-/// the language it detected, and the version/lifetime stamps. The two
-/// installs a parse makes per version (tree + discovery first, the regions
-/// upgrade after) differ only in the regions they carry.
+/// Inputs of the initial snapshot. Region completion reuses that published
+/// snapshot directly and cannot submit these inputs again.
 struct SnapshotInputs {
     text: std::sync::Arc<str>,
     tree: tree_sitter::Tree,
@@ -23,14 +21,9 @@ struct SnapshotInputs {
 }
 
 impl SnapshotInputs {
-    /// `layer_trees` is the lazy cell the snapshot derives its layer trees
-    /// into: fresh for a first install, the first install's own for the
-    /// regions upgrade of the same version, so a reader deriving them
-    /// across the upgrade lands where every later reader looks.
     fn snapshot(
         &self,
         regions: PopulatedSnapshotRegions,
-        layer_trees: LayerTreeCell,
     ) -> std::sync::Arc<crate::document::snapshot::ParseSnapshot> {
         std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
             text: std::sync::Arc::clone(&self.text),
@@ -40,14 +33,10 @@ impl SnapshotInputs {
             incarnation: self.incarnation,
             injection_regions: regions.discovery,
             regions: regions.regions,
-            layer_trees,
+            layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
         })
     }
 }
-
-type LayerTreeCell = std::sync::Arc<
-    std::sync::OnceLock<(u64, std::sync::Arc<Vec<crate::document::SnapshotLayerTree>>)>,
->;
 
 /// An owned [`LanguageCheck`](crate::document::LanguageCheck): the first
 /// install runs on the compute pool, so the expectation must travel.
@@ -73,6 +62,22 @@ impl InstallCheck {
 struct PopulatedSnapshotRegions {
     discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
     regions: Option<crate::document::snapshot::ResolvedRegions>,
+}
+
+/// Keep the historical publish outcome separate from the verdict after the
+/// resolution work finishes. Only the latter authorizes current downstream work.
+struct ParseCompletion {
+    initial_install: crate::document::ParseInstall,
+    current_at_completion: bool,
+}
+
+impl From<crate::document::ParseInstall> for ParseCompletion {
+    fn from(initial_install: crate::document::ParseInstall) -> Self {
+        Self {
+            current_at_completion: initial_install.current,
+            initial_install,
+        }
+    }
 }
 
 /// Timeout for compute-pool parse operations to prevent hangs on pathological inputs.
@@ -340,29 +345,19 @@ impl ParseCoordinator {
         }
     }
 
-    /// Run `CacheCoordinator::populate_injections` as a compute-pool work-unit
-    /// and make the two installs a parse makes per version (parse-snapshot
-    /// ADR §2): the tree with its discovery as soon as the pass hands the
-    /// discovery out — from inside the work-unit, so the token readers
-    /// parked on the cell wake without waiting for resolution — and the same
-    /// version again, upgraded with the bridge / resolved regions, once the
-    /// pass has resolved. Returns the FIRST install's outcome: `current` is
-    /// "this parse published the current tree", which is what the callers'
-    /// downstream keys on; the upgrade rides the same version and needs no
-    /// separate verdict (the cell refuses it when nothing new arrived).
-    ///
-    /// The pass is **awaited**, not detached, preserving the `populate →
-    /// mark finished` ordering the injection-map invalidation depends on. A
-    /// pass refused before the hand-off (its inputs moved on, no query yet)
-    /// or that could not look installs once, with no regions, exactly as a
-    /// pass that never ran.
+    /// Publish tree/discovery from inside the compute work unit, then complete
+    /// that exact snapshot with the resolution. The store owns enrichment and
+    /// rechecks currency after the awaited work; downstream never acts on the
+    /// earlier install-time verdict. A skipped/cancelled/panicking resolution
+    /// leaves the first snapshot usable and readers fall back inline.
+    /// Awaiting the work unit preserves populate → mark-finished ordering.
     async fn populate_and_install(
         &self,
         uri: &Url,
         check: InstallCheck,
         inputs: SnapshotInputs,
         version_cancel: crate::cancel::CancelToken,
-    ) -> crate::document::ParseInstall {
+    ) -> ParseCompletion {
         let cache = std::sync::Arc::clone(&self.cache);
         let language = std::sync::Arc::clone(&self.language);
         let tracker = self.bridge.node_tracker_arc();
@@ -402,14 +397,14 @@ impl ParseCoordinator {
         // regions — after the edit lock is released, so a queued edit never
         // waits behind a stale publish and the evicted tree's teardown.
         let Some(entry_mint_epoch) = entry_mint_epoch else {
-            return self.documents.install_parse(
-                uri,
-                check.as_check(),
-                inputs.snapshot(
-                    PopulatedSnapshotRegions::default(),
-                    std::sync::Arc::new(std::sync::OnceLock::new()),
-                ),
-            );
+            return self
+                .documents
+                .install_parse(
+                    uri,
+                    check.as_check(),
+                    inputs.snapshot(PopulatedSnapshotRegions::default()),
+                )
+                .into();
         };
         let build_bridge_regions = self
             .settings_manager
@@ -418,12 +413,11 @@ impl ParseCoordinator {
         let pool_uri = uri.clone();
         // The first install's verdict lives outside the work-unit too, so a
         // panic after the hand-off cannot lose a publish that already landed.
-        type First = Option<(
+        type First = (
             crate::document::ParseInstall,
             std::sync::Arc<crate::document::snapshot::ParseSnapshot>,
-        )>;
-        let first: std::sync::Arc<std::sync::Mutex<First>> =
-            std::sync::Arc::new(std::sync::Mutex::new(None));
+        );
+        let first = std::sync::Arc::new(std::sync::OnceLock::<First>::new());
         let regions = run_awaited_populate(&self.compute_pool, version_cancel, {
             let inputs = std::sync::Arc::clone(&inputs);
             let check = std::sync::Arc::clone(&check);
@@ -446,20 +440,16 @@ impl ParseCoordinator {
                             inputs.parsed_version,
                             discovered.generation
                         );
-                        let snapshot = inputs.snapshot(
-                            PopulatedSnapshotRegions {
-                                discovery: discovered.discovery,
-                                ..PopulatedSnapshotRegions::default()
-                            },
-                            std::sync::Arc::new(std::sync::OnceLock::new()),
-                        );
+                        let snapshot = inputs.snapshot(PopulatedSnapshotRegions {
+                            discovery: discovered.discovery,
+                            ..PopulatedSnapshotRegions::default()
+                        });
                         let installed = documents.install_parse(
                             &pool_uri,
                             check.as_check(),
                             std::sync::Arc::clone(&snapshot),
                         );
-                        *first.lock().unwrap_or_else(|e| e.into_inner()) =
-                            Some((installed, snapshot));
+                        let _ = first.set((installed, snapshot));
                     },
                     Some(&cancel_for_work),
                 );
@@ -482,8 +472,7 @@ impl ParseCoordinator {
         // A work-unit the pool contained (it panicked) derived nothing: the
         // snapshot rides without regions, exactly as a refused pass.
         .unwrap_or_default();
-        let first = first.lock().unwrap_or_else(|e| e.into_inner()).take();
-        match first {
+        match first.get() {
             // The pass handed its discovery out and the tree is published:
             // land the regions it resolved on the same version. Nothing to
             // land (skipped resolution, refused commit) publishes nothing —
@@ -491,39 +480,24 @@ impl ParseCoordinator {
             // the cell refused (a sibling parse of this version landed its
             // tree first) has nothing to upgrade: the regions would ride the
             // sibling's tree with a tree the readers never derived from.
-            Some((first, first_snapshot)) => {
-                // The verdict the callers act on is taken now, after the
-                // resolution, not at the first install: an edit landing in
-                // between has moved the document on, and the downstream
-                // must not run for a version that is no longer current.
-                // The upgrade re-judges under the entry guard; without one,
-                // the cell is asked whether the version is still current.
-                let upgraded = (first.published && regions.regions.is_some()).then(|| {
-                    self.documents.install_parse(
+            Some((initial_install, first_snapshot)) => {
+                let current_at_completion = initial_install.published
+                    && self.documents.complete_parse(
                         uri,
                         check.as_check(),
-                        inputs
-                            .snapshot(regions, std::sync::Arc::clone(&first_snapshot.layer_trees)),
-                    )
-                });
-                let current = match upgraded {
-                    Some(upgrade) => upgrade.current,
-                    None => {
-                        first.current
-                            && self.documents.latest_snapshot(uri).is_some_and(|view| {
-                                view.slot.current_incarnation == inputs.incarnation
-                                    && view.content_version == inputs.parsed_version
-                            })
-                    }
-                };
-                crate::document::ParseInstall { current, ..first }
+                        first_snapshot,
+                        regions.regions,
+                    );
+                ParseCompletion {
+                    initial_install: *initial_install,
+                    current_at_completion,
+                }
             }
-            // The pass never reached the hand-off: one install, as before.
-            None => self.documents.install_parse(
-                uri,
-                check.as_check(),
-                inputs.snapshot(regions, std::sync::Arc::new(std::sync::OnceLock::new())),
-            ),
+            // No hand-off: one install, whose currency is judged right now.
+            None => self
+                .documents
+                .install_parse(uri, check.as_check(), inputs.snapshot(regions))
+                .into(),
         }
     }
 
@@ -672,7 +646,7 @@ impl ParseCoordinator {
                         version_cancel.clone(),
                     )
                     .await;
-                if installed.current {
+                if installed.current_at_completion {
                     // AFTER the install: a downstream task woken by this mark
                     // on another runtime thread must find the snapshot (and
                     // its fast-path regions) already in the cell.
@@ -685,7 +659,7 @@ impl ParseCoordinator {
                 // racing `didChange`/reopen moved the text or incarnation on and the
                 // edit reparse won, in which case the open downstream must NOT re-run
                 // over the edit's tree.
-                return installed.current;
+                return installed.current_at_completion;
             }
 
             // Parse produced no tree (timeout / parser unavailable / join error) but
@@ -913,12 +887,12 @@ impl ParseCoordinator {
             // still compiling has no lineage to re-drive it — without the
             // refresh, a slow install leaves the document unhighlighted
             // until an incidental edit.
-            if installed.published {
+            if installed.initial_install.published {
                 events.push(crate::language::LanguageEvent::semantic_tokens_refresh(
                     language_name.clone(),
                 ));
             }
-            if installed.current {
+            if installed.current_at_completion {
                 break;
             }
             // Not current: the text moved under us (a concurrent `didChange`
@@ -1108,7 +1082,7 @@ impl ParseCoordinator {
                     version_cancel.clone(),
                 )
                 .await;
-            let published = installed.published;
+            let published = installed.initial_install.published;
             // Serve-stale's heal signal (ADR §3), narrowed to the cases the
             // workspace-scoped request is actually FOR. `refresh` is expensive
             // for the client (Neovim's handler cancels its in-flight token
@@ -1134,7 +1108,7 @@ impl ParseCoordinator {
                     &self.cache,
                     uri,
                     content_version,
-                    installed.tree_upgrade,
+                    installed.initial_install.tree_upgrade,
                 )
             {
                 events.push(crate::language::LanguageEvent::semantic_tokens_refresh(
@@ -1273,11 +1247,11 @@ mod tests {
         drop(hold);
         let installed = install.await.expect("the install task completes");
         assert!(
-            installed.published,
+            installed.initial_install.published,
             "the first install did publish the tree of the version it parsed"
         );
         assert!(
-            !installed.current,
+            !installed.current_at_completion,
             "the verdict acted on after the resolution must reflect the edit"
         );
     }

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -1068,13 +1068,6 @@ impl ParseCoordinator {
             // against a pass whose text moved on mid-parse (the scheduler's
             // dirty loop is already reparsing the newer text), and the install
             // then publishes it.
-            // Read BEFORE the installs: the first one lands the tree from
-            // inside the populate work-unit.
-            let tree_less_upgrade = self.documents.latest_snapshot(uri).is_some_and(|view| {
-                view.slot.snapshot.is_some_and(|snapshot| {
-                    snapshot.parsed_version == content_version && snapshot.tree.is_none()
-                })
-            });
             let installed = self
                 .populate_and_install(
                     uri,
@@ -1115,7 +1108,7 @@ impl ParseCoordinator {
                     &self.cache,
                     uri,
                     content_version,
-                    tree_less_upgrade || installed.tree_upgrade,
+                    installed.tree_upgrade,
                 )
             {
                 events.push(crate::language::LanguageEvent::semantic_tokens_refresh(

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -14,6 +14,53 @@ use crate::lsp::settings_manager::SettingsManager;
 /// (parse-snapshot ADR §3): all `None` when the pool work-unit panicked or
 /// populate's own epoch/lifetime guard committed nothing — readers then fall
 /// back to inline resolution for that snapshot.
+/// What every snapshot a parse publishes shares: the text and tree it parsed,
+/// the language it detected, and the version/lifetime stamps. The two
+/// installs a parse makes per version (tree + discovery first, the regions
+/// upgrade after) differ only in the regions they carry.
+struct SnapshotInputs {
+    text: std::sync::Arc<str>,
+    tree: tree_sitter::Tree,
+    language_name: String,
+    parsed_version: u64,
+    incarnation: u64,
+}
+
+impl SnapshotInputs {
+    fn snapshot(
+        &self,
+        regions: PopulatedSnapshotRegions,
+    ) -> std::sync::Arc<crate::document::snapshot::ParseSnapshot> {
+        std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
+            text: std::sync::Arc::clone(&self.text),
+            tree: Some(self.tree.clone()),
+            language: Some(self.language_name.clone()),
+            parsed_version: self.parsed_version,
+            incarnation: self.incarnation,
+            injection_regions: regions.discovery,
+            bridge_regions: regions.bridge_regions,
+            resolved_regions: regions.resolved_regions,
+            layer_trees: std::sync::OnceLock::new(),
+        })
+    }
+}
+
+/// An owned [`LanguageCheck`](crate::document::LanguageCheck): the first
+/// install runs on the compute pool, so the expectation must travel.
+enum InstallCheck {
+    Record,
+    Expect(Option<String>),
+}
+
+impl InstallCheck {
+    fn as_check(&self) -> crate::document::LanguageCheck<'_> {
+        match self {
+            Self::Record => crate::document::LanguageCheck::Record,
+            Self::Expect(language) => crate::document::LanguageCheck::Expect(language.as_deref()),
+        }
+    }
+}
+
 #[derive(Default)]
 struct PopulatedSnapshotRegions {
     discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
@@ -293,63 +340,40 @@ impl ParseCoordinator {
     }
 
     /// Run `CacheCoordinator::populate_injections` as a compute-pool work-unit
-    /// and await it.
+    /// and make the two installs a parse makes per version (parse-snapshot
+    /// ADR §2): the tree with its discovery as soon as the pass hands the
+    /// discovery out — from inside the work-unit, so the token readers
+    /// parked on the cell wake without waiting for resolution — and the same
+    /// version again, upgraded with the bridge / resolved regions, once the
+    /// pass has resolved. Returns the FIRST install's outcome: `current` is
+    /// "this parse published the current tree", which is what the callers'
+    /// downstream keys on; the upgrade rides the same version and needs no
+    /// separate verdict (the cell refuses it when nothing new arrived).
     ///
-    /// The injection walk (injection-query execution + per-region ULID mint +
-    /// content hash) is O(regions) synchronous tree-CPU — hundreds of ms on an
-    /// injection-heavy document — and previously ran inline on a tokio worker
-    /// right after the parse, starving the runtime (parse-snapshot ADR, Context).
-    /// It is **awaited**, not detached, preserving the `populate → mark finished
-    /// → downstream` ordering the injection-map invalidation depends on (Stage-1
-    /// obligation). All parameters are cheap clones (refcount bumps).
-    /// Returns everything the populate pass derived from its single injection
-    /// query — the semantic discovery and the bridge-downstream regions — both
-    /// destined for the snapshot this pass publishes (ADR §3,
-    /// don't-discover-twice). `(None, None)` when the work-unit panicked.
-    #[allow(clippy::too_many_arguments)] // One immutable parse snapshot plus its version token.
-    async fn populate_injections_on_pool(
+    /// The pass is **awaited**, not detached, preserving the `populate →
+    /// mark finished` ordering the injection-map invalidation depends on. A
+    /// pass refused before the hand-off (its inputs moved on, no query yet)
+    /// or that could not look installs once, with no regions, exactly as a
+    /// pass that never ran.
+    async fn populate_and_install(
         &self,
-        uri: Url,
-        text: std::sync::Arc<str>,
-        tree: tree_sitter::Tree,
-        language_name: String,
-        incarnation: u64,
-        content_version: u64,
+        uri: &Url,
+        check: InstallCheck,
+        inputs: SnapshotInputs,
         version_cancel: crate::cancel::CancelToken,
-    ) -> PopulatedSnapshotRegions {
+    ) -> crate::document::ParseInstall {
         let cache = std::sync::Arc::clone(&self.cache);
         let language = std::sync::Arc::clone(&self.language);
         let tracker = self.bridge.node_tracker_arc();
-        // Latch + at-mint validity gate, taken UNDER this document's edit
-        // lock so the pair is atomic against `did_change` (which holds the
-        // same lock across its tracker edit-shift AND its
-        // `content_version` bump — the ADR's "only the fast tracker-mint
-        // runs under edit_lock" obligation). Lock-free latch-then-validate
-        // is NOT enough here: didChange shifts the tracker BEFORE it bumps
-        // the version, so a latch taken after the shift with a version read
-        // before the bump would look current on both counts and let this
-        // pass mint its old-tree coordinates into the shifted index as
-        // correct-at-birth. Under the lock, the gate checks:
-        // - liveness + lifetime (a didClose that ran to COMPLETION leaves
-        //   the tracker at `(0, epoch+1)` — indistinguishable from a
-        //   reopen's first mint, so the latch alone cannot refuse it; the
-        //   reopen case fails the incarnation check);
-        // - currency (`content_version` unchanged since the parse captured
-        //   its inputs — an edit that already landed makes this pass's tree
-        //   stale).
-        // Anything landing AFTER the lock drops is caught by the latch
-        // re-check inside the batch mint / commit (`cleanup` bumps the
-        // epoch before it removes; an edit-shift bumps the generation).
-        // Skipping populate matches the stale/closed outcome everywhere
-        // else: the snapshot (if it still publishes) rides without regions.
+        let documents = std::sync::Arc::clone(&self.documents);
         let entry_mint_epoch = {
-            let edit_lock = self.documents.edit_lock(&uri);
+            let edit_lock = self.documents.edit_lock(uri);
             let _edit_guard = edit_lock.lock().await;
-            let latch = tracker.mint_epoch(&uri);
-            let latest = self.documents.latest_snapshot(&uri);
+            let latch = tracker.mint_epoch(uri);
+            let latest = self.documents.latest_snapshot(uri);
             let valid = latest.as_ref().is_some_and(|view| {
-                view.slot.current_incarnation == incarnation
-                    && view.content_version == content_version
+                view.slot.current_incarnation == inputs.incarnation
+                    && view.content_version == inputs.parsed_version
             });
             if !valid {
                 // The edit_lock() accessor above materializes a lock entry
@@ -361,63 +385,91 @@ impl ParseCoordinator {
                 // removing it from under a queued edit would let the next
                 // edit mint a fresh mutex and run concurrently.
                 if latest.is_none() {
-                    self.documents
-                        .remove_edit_lock_if_unshared(&uri, &edit_lock);
+                    self.documents.remove_edit_lock_if_unshared(uri, &edit_lock);
                 }
-                return PopulatedSnapshotRegions::default();
+                return self.documents.install_parse(
+                    uri,
+                    check.as_check(),
+                    inputs.snapshot(PopulatedSnapshotRegions::default()),
+                );
             }
             latch
         };
-        // Coarse per-parse gate: with no runnable bridge server configured,
-        // the bridge-region build (per-region content copies) and fully
-        // resolved downstream regions are pure waste on the pre-publish
-        // critical path. `None` on the snapshot makes a bridge configured by
-        // a later reload fall back to inline resolution.
         let build_bridge_regions = self
             .settings_manager
             .load_settings()
             .any_bridge_server_runnable();
-        run_awaited_populate(&self.compute_pool, version_cancel, move |cancel_for_work| {
-            // A refused pass (`None`) maps to all-`None` region fields —
-            // the snapshot then rides WITHOUT regions and readers fall
-            // back to inline resolution. Mapping it to the ran-and-empty
-            // shape instead would publish "no injections" for a pass
-            // that never derived anything, blanking the document's
-            // injections until the next parse.
-            let Some(populated) = cache.populate_injections_cancellable(
-                &uri,
-                &text,
-                &tree,
-                &language_name,
-                &language,
-                &tracker,
-                entry_mint_epoch,
-                incarnation,
-                build_bridge_regions,
-                &mut |discovered| {
-                    log::trace!(
-                        target: "kakehashi::populate",
-                        "discovery handed out at settings generation {} (reusable: {})",
-                        discovered.generation,
-                        discovered.discovery.is_some()
-                    );
-                },
-                Some(&cancel_for_work),
-            ) else {
-                return PopulatedSnapshotRegions::default();
-            };
-            PopulatedSnapshotRegions {
-                discovery: populated.discovery,
-                bridge_regions: populated
-                    .bridge_regions
-                    .map(|regions| (populated.generation, std::sync::Arc::new(regions))),
-                resolved_regions: populated
-                    .resolved_regions
-                    .map(|regions| (populated.generation, std::sync::Arc::new(regions))),
+        let pool_uri = uri.clone();
+        let (first, regions, inputs, check) =
+            run_awaited_populate(&self.compute_pool, version_cancel, move |cancel_for_work| {
+                let mut first: Option<crate::document::ParseInstall> = None;
+                let populated = cache.populate_injections_cancellable(
+                    &pool_uri,
+                    &inputs.text,
+                    &inputs.tree,
+                    &inputs.language_name,
+                    &language,
+                    &tracker,
+                    entry_mint_epoch,
+                    inputs.incarnation,
+                    build_bridge_regions,
+                    &mut |discovered| {
+                        log::trace!(
+                            target: "kakehashi::parse",
+                            "first install of {pool_uri} v{} at settings generation {}",
+                            inputs.parsed_version,
+                            discovered.generation
+                        );
+                        first = Some(documents.install_parse(
+                            &pool_uri,
+                            check.as_check(),
+                            inputs.snapshot(PopulatedSnapshotRegions {
+                                discovery: discovered.discovery,
+                                ..PopulatedSnapshotRegions::default()
+                            }),
+                        ));
+                    },
+                    Some(&cancel_for_work),
+                );
+                // A refused pass (`None`) maps to all-`None` region fields —
+                // the snapshot then rides WITHOUT regions and readers fall
+                // back to inline resolution. Mapping it to the ran-and-empty
+                // shape instead would publish "no injections" for a pass
+                // that never derived anything, blanking the document's
+                // injections until the next parse.
+                let regions =
+                    populated.map_or_else(PopulatedSnapshotRegions::default, |populated| {
+                        PopulatedSnapshotRegions {
+                            discovery: populated.discovery,
+                            bridge_regions: populated.bridge_regions.map(|regions| {
+                                (populated.generation, std::sync::Arc::new(regions))
+                            }),
+                            resolved_regions: populated.resolved_regions.map(|regions| {
+                                (populated.generation, std::sync::Arc::new(regions))
+                            }),
+                        }
+                    });
+                (first, regions, inputs, check)
+            })
+            .await
+            .unwrap_or_else(|| unreachable!("the populate work-unit is awaited, never dropped"));
+        match first {
+            // The pass handed its discovery out and the tree is published:
+            // land the regions it resolved on the same version. Nothing to
+            // land (skipped resolution, refused commit) publishes nothing —
+            // the cell would refuse the same shape anyway.
+            Some(first) => {
+                if regions.bridge_regions.is_some() || regions.resolved_regions.is_some() {
+                    self.documents
+                        .install_parse(uri, check.as_check(), inputs.snapshot(regions));
+                }
+                first
             }
-        })
-        .await
-        .unwrap_or_default()
+            // The pass never reached the hand-off: one install, as before.
+            None => self
+                .documents
+                .install_parse(uri, check.as_check(), inputs.snapshot(regions)),
+        }
     }
 
     /// Parse the (already-registered) document at `uri` and publish the result.
@@ -551,32 +603,20 @@ impl ParseCoordinator {
                 // the snapshot iff the cell admits it and reports it current
                 // iff it parsed the document's content version (a language
                 // mismatch rejects it outright).
-                let regions = self
-                    .populate_injections_on_pool(
-                        uri.clone(),
-                        text.clone(),
-                        tree.clone(),
-                        language_name.clone(),
-                        incarnation,
-                        content_version,
+                let installed = self
+                    .populate_and_install(
+                        &uri,
+                        InstallCheck::Record,
+                        SnapshotInputs {
+                            text: text.clone(),
+                            tree,
+                            language_name: language_name.clone(),
+                            parsed_version: content_version,
+                            incarnation,
+                        },
                         version_cancel.clone(),
                     )
                     .await;
-                let installed = self.documents.install_parse(
-                    &uri,
-                    crate::document::LanguageCheck::Record,
-                    std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
-                        text: text.clone(),
-                        tree: Some(tree.clone()),
-                        language: Some(language_name.clone()),
-                        parsed_version: content_version,
-                        incarnation,
-                        injection_regions: regions.discovery,
-                        bridge_regions: regions.bridge_regions,
-                        resolved_regions: regions.resolved_regions,
-                        layer_trees: std::sync::OnceLock::new(),
-                    }),
-                );
                 if installed.current {
                     // AFTER the install: a downstream task woken by this mark
                     // on another runtime thread must find the snapshot (and
@@ -801,32 +841,20 @@ impl ParseCoordinator {
             // concurrent parse already gave a tree at this version (the cell
             // refuses the equal-version swap) all leave this tree out.
             // (`Tree` clone is a cheap refcount bump.)
-            let regions = self
-                .populate_injections_on_pool(
-                    uri.clone(),
-                    text.clone(),
-                    tree.clone(),
-                    language_name.clone(),
-                    expected_incarnation,
-                    content_version,
+            let installed = self
+                .populate_and_install(
+                    &uri,
+                    InstallCheck::Expect(expected_language_id.clone()),
+                    SnapshotInputs {
+                        text: text.clone(),
+                        tree,
+                        language_name: language_name.clone(),
+                        parsed_version: content_version,
+                        incarnation: expected_incarnation,
+                    },
                     version_cancel.clone(),
                 )
                 .await;
-            let installed = self.documents.install_parse(
-                &uri,
-                crate::document::LanguageCheck::Expect(expected_language_id.as_deref()),
-                std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
-                    text: text.clone(),
-                    tree: Some(tree.clone()),
-                    language: Some(language_name.clone()),
-                    parsed_version: content_version,
-                    incarnation: expected_incarnation,
-                    injection_regions: regions.discovery,
-                    bridge_regions: regions.bridge_regions,
-                    resolved_regions: regions.resolved_regions,
-                    layer_trees: std::sync::OnceLock::new(),
-                }),
-            );
             // Serve-stale's heal signal, mirroring reparse_latest: a token
             // request answered empty (or 15s-capped) while the install was
             // still compiling has no lineage to re-drive it — without the
@@ -1013,37 +1041,27 @@ impl ParseCoordinator {
             // against a pass whose text moved on mid-parse (the scheduler's
             // dirty loop is already reparsing the newer text), and the install
             // then publishes it.
-            let regions = self
-                .populate_injections_on_pool(
-                    uri.clone(),
-                    text.clone(),
-                    tree.clone(),
-                    language_name.clone(),
-                    incarnation,
-                    content_version,
-                    version_cancel.clone(),
-                )
-                .await;
+            // Read BEFORE the installs: the first one lands the tree from
+            // inside the populate work-unit.
             let tree_less_upgrade = self.documents.latest_snapshot(uri).is_some_and(|view| {
                 view.slot.snapshot.is_some_and(|snapshot| {
                     snapshot.parsed_version == content_version && snapshot.tree.is_none()
                 })
             });
-            let installed = self.documents.install_parse(
-                uri,
-                crate::document::LanguageCheck::Expect(language_id.as_deref()),
-                std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
-                    text: text.clone(),
-                    tree: Some(tree.clone()),
-                    language: Some(language_name.clone()),
-                    parsed_version: content_version,
-                    incarnation,
-                    injection_regions: regions.discovery,
-                    bridge_regions: regions.bridge_regions,
-                    resolved_regions: regions.resolved_regions,
-                    layer_trees: std::sync::OnceLock::new(),
-                }),
-            );
+            let installed = self
+                .populate_and_install(
+                    uri,
+                    InstallCheck::Expect(language_id.clone()),
+                    SnapshotInputs {
+                        text: text.clone(),
+                        tree,
+                        language_name: language_name.clone(),
+                        parsed_version: content_version,
+                        incarnation,
+                    },
+                    version_cancel.clone(),
+                )
+                .await;
             let published = installed.published;
             // Serve-stale's heal signal (ADR §3), narrowed to the cases the
             // workspace-scoped request is actually FOR. `refresh` is expensive

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -36,7 +36,7 @@ impl SnapshotInputs {
             injection_regions: regions.discovery,
             bridge_regions: regions.bridge_regions,
             resolved_regions: regions.resolved_regions,
-            layer_trees: std::sync::OnceLock::new(),
+            layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
         })
     }
 }
@@ -693,7 +693,7 @@ impl ParseCoordinator {
                     injection_regions: None,
                     bridge_regions: None,
                     resolved_regions: None,
-                    layer_trees: std::sync::OnceLock::new(),
+                    layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                 }),
             );
             if installed.current {
@@ -718,7 +718,7 @@ impl ParseCoordinator {
                 injection_regions: None,
                 bridge_regions: None,
                 resolved_regions: None,
-                layer_trees: std::sync::OnceLock::new(),
+                layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
             }),
         );
         if installed.current {

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -484,13 +484,29 @@ impl ParseCoordinator {
             // tree first) has nothing to upgrade: the regions would ride the
             // sibling's tree with a tree the readers never derived from.
             Some(first) => {
-                if first.published
-                    && (regions.bridge_regions.is_some() || regions.resolved_regions.is_some())
-                {
+                // The verdict the callers act on is taken now, after the
+                // resolution, not at the first install: an edit landing in
+                // between has moved the document on, and the downstream
+                // must not run for a version that is no longer current.
+                // The upgrade re-judges under the entry guard; without one,
+                // the cell is asked whether the version is still current.
+                let upgraded = (first.published
+                    && (regions.bridge_regions.is_some() || regions.resolved_regions.is_some()))
+                .then(|| {
                     self.documents
-                        .install_parse(uri, check.as_check(), inputs.snapshot(regions));
-                }
-                first
+                        .install_parse(uri, check.as_check(), inputs.snapshot(regions))
+                });
+                let current = match upgraded {
+                    Some(upgrade) => upgrade.current,
+                    None => {
+                        first.current
+                            && self.documents.latest_snapshot(uri).is_some_and(|view| {
+                                view.slot.current_incarnation == inputs.incarnation
+                                    && view.content_version == inputs.parsed_version
+                            })
+                    }
+                };
+                crate::document::ParseInstall { current, ..first }
             }
             // The pass never reached the hand-off: one install, as before.
             None => self

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -1115,7 +1115,7 @@ impl ParseCoordinator {
                     &self.cache,
                     uri,
                     content_version,
-                    tree_less_upgrade,
+                    tree_less_upgrade || installed.tree_upgrade,
                 )
             {
                 events.push(crate::language::LanguageEvent::semantic_tokens_refresh(

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -366,6 +366,11 @@ impl ParseCoordinator {
         let language = std::sync::Arc::clone(&self.language);
         let tracker = self.bridge.node_tracker_arc();
         let documents = std::sync::Arc::clone(&self.documents);
+        // Shared with the work-unit rather than moved into it: a panic
+        // inside the pass is contained by the pool and must still leave
+        // this parse installed (once, without regions) — as it always did.
+        let inputs = std::sync::Arc::new(inputs);
+        let check = std::sync::Arc::new(check);
         let entry_mint_epoch = {
             let edit_lock = self.documents.edit_lock(uri);
             let _edit_guard = edit_lock.lock().await;
@@ -400,9 +405,15 @@ impl ParseCoordinator {
             .load_settings()
             .any_bridge_server_runnable();
         let pool_uri = uri.clone();
-        let (first, regions, inputs, check) =
-            run_awaited_populate(&self.compute_pool, version_cancel, move |cancel_for_work| {
-                let mut first: Option<crate::document::ParseInstall> = None;
+        // The first install's verdict lives outside the work-unit too, so a
+        // panic after the hand-off cannot lose a publish that already landed.
+        let first: std::sync::Arc<std::sync::Mutex<Option<crate::document::ParseInstall>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(None));
+        let regions = run_awaited_populate(&self.compute_pool, version_cancel, {
+            let inputs = std::sync::Arc::clone(&inputs);
+            let check = std::sync::Arc::clone(&check);
+            let first = std::sync::Arc::clone(&first);
+            move |cancel_for_work| {
                 let populated = cache.populate_injections_cancellable(
                     &pool_uri,
                     &inputs.text,
@@ -420,14 +431,15 @@ impl ParseCoordinator {
                             inputs.parsed_version,
                             discovered.generation
                         );
-                        first = Some(documents.install_parse(
+                        let installed = documents.install_parse(
                             &pool_uri,
                             check.as_check(),
                             inputs.snapshot(PopulatedSnapshotRegions {
                                 discovery: discovered.discovery,
                                 ..PopulatedSnapshotRegions::default()
                             }),
-                        ));
+                        );
+                        *first.lock().unwrap_or_else(|e| e.into_inner()) = Some(installed);
                     },
                     Some(&cancel_for_work),
                 );
@@ -437,29 +449,36 @@ impl ParseCoordinator {
                 // shape instead would publish "no injections" for a pass
                 // that never derived anything, blanking the document's
                 // injections until the next parse.
-                let regions =
-                    populated.map_or_else(PopulatedSnapshotRegions::default, |populated| {
-                        PopulatedSnapshotRegions {
-                            discovery: populated.discovery,
-                            bridge_regions: populated.bridge_regions.map(|regions| {
-                                (populated.generation, std::sync::Arc::new(regions))
-                            }),
-                            resolved_regions: populated.resolved_regions.map(|regions| {
-                                (populated.generation, std::sync::Arc::new(regions))
-                            }),
-                        }
-                    });
-                (first, regions, inputs, check)
-            })
-            .await
-            .unwrap_or_else(|| unreachable!("the populate work-unit is awaited, never dropped"));
+                populated.map_or_else(PopulatedSnapshotRegions::default, |populated| {
+                    PopulatedSnapshotRegions {
+                        discovery: populated.discovery,
+                        bridge_regions: populated
+                            .bridge_regions
+                            .map(|regions| (populated.generation, std::sync::Arc::new(regions))),
+                        resolved_regions: populated
+                            .resolved_regions
+                            .map(|regions| (populated.generation, std::sync::Arc::new(regions))),
+                    }
+                })
+            }
+        })
+        .await
+        // A work-unit the pool contained (it panicked) derived nothing: the
+        // snapshot rides without regions, exactly as a refused pass.
+        .unwrap_or_default();
+        let first = first.lock().unwrap_or_else(|e| e.into_inner()).take();
         match first {
             // The pass handed its discovery out and the tree is published:
             // land the regions it resolved on the same version. Nothing to
             // land (skipped resolution, refused commit) publishes nothing —
-            // the cell would refuse the same shape anyway.
+            // the cell would refuse the same shape anyway. A first install
+            // the cell refused (a sibling parse of this version landed its
+            // tree first) has nothing to upgrade: the regions would ride the
+            // sibling's tree with a tree the readers never derived from.
             Some(first) => {
-                if regions.bridge_regions.is_some() || regions.resolved_regions.is_some() {
+                if first.published
+                    && (regions.bridge_regions.is_some() || regions.resolved_regions.is_some())
+                {
                     self.documents
                         .install_parse(uri, check.as_check(), inputs.snapshot(regions));
                 }

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -23,9 +23,14 @@ struct SnapshotInputs {
 }
 
 impl SnapshotInputs {
+    /// `layer_trees` is the lazy cell the snapshot derives its layer trees
+    /// into: fresh for a first install, the first install's own for the
+    /// regions upgrade of the same version, so a reader deriving them
+    /// across the upgrade lands where every later reader looks.
     fn snapshot(
         &self,
         regions: PopulatedSnapshotRegions,
+        layer_trees: LayerTreeCell,
     ) -> std::sync::Arc<crate::document::snapshot::ParseSnapshot> {
         std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
             text: std::sync::Arc::clone(&self.text),
@@ -36,10 +41,14 @@ impl SnapshotInputs {
             injection_regions: regions.discovery,
             bridge_regions: regions.bridge_regions,
             resolved_regions: regions.resolved_regions,
-            layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
+            layer_trees,
         })
     }
 }
+
+type LayerTreeCell = std::sync::Arc<
+    std::sync::OnceLock<(u64, std::sync::Arc<Vec<crate::document::SnapshotLayerTree>>)>,
+>;
 
 /// An owned [`LanguageCheck`](crate::document::LanguageCheck): the first
 /// install runs on the compute pool, so the expectation must travel.
@@ -404,7 +413,10 @@ impl ParseCoordinator {
             return self.documents.install_parse(
                 uri,
                 check.as_check(),
-                inputs.snapshot(PopulatedSnapshotRegions::default()),
+                inputs.snapshot(
+                    PopulatedSnapshotRegions::default(),
+                    std::sync::Arc::new(std::sync::OnceLock::new()),
+                ),
             );
         };
         let build_bridge_regions = self
@@ -414,7 +426,11 @@ impl ParseCoordinator {
         let pool_uri = uri.clone();
         // The first install's verdict lives outside the work-unit too, so a
         // panic after the hand-off cannot lose a publish that already landed.
-        let first: std::sync::Arc<std::sync::Mutex<Option<crate::document::ParseInstall>>> =
+        type First = Option<(
+            crate::document::ParseInstall,
+            std::sync::Arc<crate::document::snapshot::ParseSnapshot>,
+        )>;
+        let first: std::sync::Arc<std::sync::Mutex<First>> =
             std::sync::Arc::new(std::sync::Mutex::new(None));
         let regions = run_awaited_populate(&self.compute_pool, version_cancel, {
             let inputs = std::sync::Arc::clone(&inputs);
@@ -438,15 +454,20 @@ impl ParseCoordinator {
                             inputs.parsed_version,
                             discovered.generation
                         );
+                        let snapshot = inputs.snapshot(
+                            PopulatedSnapshotRegions {
+                                discovery: discovered.discovery,
+                                ..PopulatedSnapshotRegions::default()
+                            },
+                            std::sync::Arc::new(std::sync::OnceLock::new()),
+                        );
                         let installed = documents.install_parse(
                             &pool_uri,
                             check.as_check(),
-                            inputs.snapshot(PopulatedSnapshotRegions {
-                                discovery: discovered.discovery,
-                                ..PopulatedSnapshotRegions::default()
-                            }),
+                            std::sync::Arc::clone(&snapshot),
                         );
-                        *first.lock().unwrap_or_else(|e| e.into_inner()) = Some(installed);
+                        *first.lock().unwrap_or_else(|e| e.into_inner()) =
+                            Some((installed, snapshot));
                     },
                     Some(&cancel_for_work),
                 );
@@ -483,7 +504,7 @@ impl ParseCoordinator {
             // the cell refused (a sibling parse of this version landed its
             // tree first) has nothing to upgrade: the regions would ride the
             // sibling's tree with a tree the readers never derived from.
-            Some(first) => {
+            Some((first, first_snapshot)) => {
                 // The verdict the callers act on is taken now, after the
                 // resolution, not at the first install: an edit landing in
                 // between has moved the document on, and the downstream
@@ -493,8 +514,12 @@ impl ParseCoordinator {
                 let upgraded = (first.published
                     && (regions.bridge_regions.is_some() || regions.resolved_regions.is_some()))
                 .then(|| {
-                    self.documents
-                        .install_parse(uri, check.as_check(), inputs.snapshot(regions))
+                    self.documents.install_parse(
+                        uri,
+                        check.as_check(),
+                        inputs
+                            .snapshot(regions, std::sync::Arc::clone(&first_snapshot.layer_trees)),
+                    )
                 });
                 let current = match upgraded {
                     Some(upgrade) => upgrade.current,
@@ -509,9 +534,11 @@ impl ParseCoordinator {
                 crate::document::ParseInstall { current, ..first }
             }
             // The pass never reached the hand-off: one install, as before.
-            None => self
-                .documents
-                .install_parse(uri, check.as_check(), inputs.snapshot(regions)),
+            None => self.documents.install_parse(
+                uri,
+                check.as_check(),
+                inputs.snapshot(regions, std::sync::Arc::new(std::sync::OnceLock::new())),
+            ),
         }
     }
 

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -399,7 +399,7 @@ impl ParseCoordinator {
                 return PopulatedSnapshotRegions::default();
             };
             PopulatedSnapshotRegions {
-                discovery: populated.discovery.map(std::sync::Arc::new),
+                discovery: populated.discovery,
                 bridge_regions: populated
                     .bridge_regions
                     .map(|regions| (populated.generation, std::sync::Arc::new(regions))),

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -1159,6 +1159,103 @@ mod tests {
         assert_eq!(snapshot.incarnation, incarnation);
     }
 
+    /// The first install's verdict says the tree it published was current
+    /// at that instant, but the caller acts on it only after the resolution
+    /// — an edit landing in between has moved the document on, and the
+    /// downstream (did_open's eager open, the finished mark) must not run
+    /// for a version that is no longer current. With the resolution held,
+    /// an edit lands between the two installs; the verdict must be stale.
+    #[tokio::test]
+    async fn an_edit_during_the_resolution_stales_the_installs_verdict() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("markdown".to_string(), language.clone());
+        let query = tree_sitter::Query::new(
+            &language,
+            "(fenced_code_block (info_string (language) @injection.language) \
+             (code_fence_content) @injection.content)",
+        )
+        .expect("valid markdown injection query");
+        server
+            .language
+            .query_store()
+            .insert_injection_query("markdown".to_string(), std::sync::Arc::new(query));
+        let uri = Url::parse("file:///workspace/stale-verdict.md").unwrap();
+        let text = "```lua\nprint(1)\n```\n";
+        let incarnation = server.documents.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let (text_arc, content_version, version_cancel) = {
+            let doc = server.documents.get(&uri).unwrap();
+            (
+                doc.text_arc(),
+                doc.content_version(),
+                doc.version_cancel_token(),
+            )
+        };
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&language).unwrap();
+        let tree = parser.parse(text, None).unwrap();
+
+        let hold = server.cache.hold_resolution();
+        let coordinator = server.parse_coordinator();
+        let task_uri = uri.clone();
+        let install = tokio::spawn(async move {
+            coordinator
+                .populate_and_install(
+                    &task_uri,
+                    InstallCheck::Expect(Some("markdown".to_string())),
+                    SnapshotInputs {
+                        text: text_arc,
+                        tree,
+                        language_name: "markdown".to_string(),
+                        parsed_version: content_version,
+                        incarnation,
+                    },
+                    version_cancel,
+                )
+                .await
+        });
+        // The first install lands while the resolution is held.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        while tokio::time::Instant::now() < deadline
+            && !server
+                .documents
+                .get(&uri)
+                .is_some_and(|doc| doc.has_current_tree())
+        {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            server
+                .documents
+                .get(&uri)
+                .is_some_and(|doc| doc.has_current_tree()),
+            "the tree publishes before the resolution"
+        );
+        // An edit lands between the two installs.
+        server
+            .documents
+            .apply_edit(&uri, "```lua\nprint(2)\n```\n".to_string(), &[]);
+        drop(hold);
+        let installed = install.await.expect("the install task completes");
+        assert!(
+            installed.published,
+            "the first install did publish the tree of the version it parsed"
+        );
+        assert!(
+            !installed.current,
+            "the verdict acted on after the resolution must reflect the edit"
+        );
+    }
+
     #[tokio::test]
     async fn cancelled_populate_keeps_awaiter_joined_until_work_returns() {
         let pool = crate::compute_pool::test_pool();

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -397,8 +397,9 @@ impl ParseCoordinator {
                 &mut |discovered| {
                     log::trace!(
                         target: "kakehashi::populate",
-                        "discovery handed out at settings generation {}",
-                        discovered.generation
+                        "discovery handed out at settings generation {} (reusable: {})",
+                        discovered.generation,
+                        discovered.discovery.is_some()
                     );
                 },
                 Some(&cancel_for_work),

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -1900,8 +1900,7 @@ mod tests {
                             parsed_version,
                             incarnation,
                             injection_regions: None,
-                            bridge_regions: None,
-                            resolved_regions: None,
+                            regions: None,
                             layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                         },
                     ))
@@ -1992,8 +1991,7 @@ mod tests {
                         parsed_version: 0,
                         incarnation,
                         injection_regions: None,
-                        bridge_regions: None,
-                        resolved_regions: None,
+                        regions: None,
                         layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))
@@ -2070,8 +2068,7 @@ mod tests {
                         parsed_version: 0,
                         incarnation,
                         injection_regions: None,
-                        bridge_regions: None,
-                        resolved_regions: None,
+                        regions: None,
                         layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))
@@ -2255,8 +2252,7 @@ mod tests {
                         parsed_version: version,
                         incarnation,
                         injection_regions: None,
-                        bridge_regions: None,
-                        resolved_regions: None,
+                        regions: None,
                         layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))
@@ -2372,8 +2368,7 @@ mod tests {
                         parsed_version: 0,
                         incarnation,
                         injection_regions: None,
-                        bridge_regions: None,
-                        resolved_regions: None,
+                        regions: None,
                         layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -1902,7 +1902,7 @@ mod tests {
                             injection_regions: None,
                             bridge_regions: None,
                             resolved_regions: None,
-                            layer_trees: std::sync::OnceLock::new(),
+                            layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                         },
                     ))
                 })
@@ -1994,7 +1994,7 @@ mod tests {
                         injection_regions: None,
                         bridge_regions: None,
                         resolved_regions: None,
-                        layer_trees: std::sync::OnceLock::new(),
+                        layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))
             })
@@ -2072,7 +2072,7 @@ mod tests {
                         injection_regions: None,
                         bridge_regions: None,
                         resolved_regions: None,
-                        layer_trees: std::sync::OnceLock::new(),
+                        layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))
             })
@@ -2257,7 +2257,7 @@ mod tests {
                         injection_regions: None,
                         bridge_regions: None,
                         resolved_regions: None,
-                        layer_trees: std::sync::OnceLock::new(),
+                        layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))
         };
@@ -2374,7 +2374,7 @@ mod tests {
                         injection_regions: None,
                         bridge_regions: None,
                         resolved_regions: None,
-                        layer_trees: std::sync::OnceLock::new(),
+                        layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))
         );

--- a/src/lsp/lsp_impl/snapshot_read.rs
+++ b/src/lsp/lsp_impl/snapshot_read.rs
@@ -191,8 +191,7 @@ mod tests {
                     parsed_version: version,
                     incarnation: inc,
                     injection_regions: None,
-                    bridge_regions: None,
-                    resolved_regions: None,
+                    regions: None,
                     layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                 }))
             })

--- a/src/lsp/lsp_impl/snapshot_read.rs
+++ b/src/lsp/lsp_impl/snapshot_read.rs
@@ -193,7 +193,7 @@ mod tests {
                     injection_regions: None,
                     bridge_regions: None,
                     resolved_regions: None,
-                    layer_trees: std::sync::OnceLock::new(),
+                    layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                 }))
             })
             .unwrap_or(false);

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -613,12 +613,13 @@ mod tests {
         // yet — and a token wait already returns it while the resolution is
         // still held.
         wait_until(|| regions_of(&uri) == Some((None, None))).await;
+        let first = server
+            .documents
+            .latest_snapshot(&uri)
+            .and_then(|view| view.slot.snapshot)
+            .expect("the first publish is in the cell");
         assert!(
-            server
-                .documents
-                .latest_snapshot(&uri)
-                .and_then(|view| view.slot.snapshot)
-                .is_some_and(|snapshot| snapshot.injection_regions.is_some()),
+            first.injection_regions.is_some(),
             "the first publish carries the discovery the token readers consume"
         );
         let woke = tokio::time::timeout(
@@ -638,6 +639,18 @@ mod tests {
         // Second publish: the same version, upgraded with the regions.
         drop(hold);
         wait_until(|| regions_of(&uri) == Some((Some(9), Some(9)))).await;
+        // The layer trees a reader derives on the first publish — even one
+        // still deriving them as the upgrade lands — are the upgrade's too:
+        // the two installs share the lazy cell.
+        let upgraded = server
+            .documents
+            .latest_snapshot(&uri)
+            .and_then(|view| view.slot.snapshot)
+            .expect("the upgrade is in the cell");
+        assert!(
+            std::sync::Arc::ptr_eq(&first.layer_trees, &upgraded.layer_trees),
+            "the two installs of one parse share their layer-tree cell"
+        );
     }
 
     #[tokio::test]

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -517,6 +517,118 @@ mod tests {
         );
     }
 
+    /// A parse publishes twice per version: the tree with its discovery as
+    /// soon as populate hands them out — releasing every reader parked on
+    /// the cell, the token readers above all — and the same version again,
+    /// upgraded with the bridge / resolved regions, once the resolution the
+    /// bridge consumes has run. With the resolution held, the first publish
+    /// is observable on its own: current, tree-bearing, regions absent, and
+    /// a token wait already returns it.
+    #[tokio::test]
+    async fn did_open_publishes_the_tree_before_the_regions_are_resolved() {
+        let (service, mut socket) = LspService::new(Kakehashi::new);
+        tokio::spawn(async move {
+            use futures::StreamExt;
+            while socket.next().await.is_some() {}
+        });
+        let server = service.inner();
+
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("markdown".to_string(), tree_sitter_md::LANGUAGE.into());
+        let markdown_language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let injection_query = Query::new(
+            &markdown_language,
+            r#"
+            (fenced_code_block
+              (info_string
+                (language) @injection.language)
+              (code_fence_content) @injection.content)
+            "#,
+        )
+        .expect("valid markdown injection query");
+        server
+            .language
+            .query_store()
+            .insert_injection_query("markdown".to_string(), std::sync::Arc::new(injection_query));
+
+        let mut language_servers = HashMap::new();
+        language_servers.insert(
+            "lua-bridge".to_string(),
+            BridgeServerConfig {
+                cmd: Some(vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    "cat > /dev/null".to_string(),
+                ]),
+                languages: Some(vec!["lua".to_string()]),
+                initialization_options: None,
+                workspace_markers: None,
+                on_type_formatting_triggers: None,
+                prefer_shared_instance: None,
+                force_start: None,
+                enabled: None,
+                settings: None,
+            },
+        );
+        server.settings_manager.apply_settings(WorkspaceSettings {
+            auto_install: false,
+            language_servers,
+            ..Default::default()
+        });
+        server
+            .bridge
+            .insert_ready_test_connection("lua-bridge")
+            .await;
+
+        let uri = Url::parse("file:///test/two_stage_install.md").expect("valid test URI");
+        let lsp_uri = crate::lsp::lsp_impl::url_to_uri(&uri).expect("URI should convert");
+        let regions_of = |uri: &Url| {
+            server.documents.latest_snapshot(uri).and_then(|view| {
+                let snapshot = view.slot.snapshot?;
+                (snapshot.parsed_version == view.content_version && snapshot.tree.is_some())
+                    .then_some((
+                        snapshot.bridge_regions.as_ref().map(|(_, r)| r.len()),
+                        snapshot.resolved_regions.as_ref().map(|(_, r)| r.len()),
+                    ))
+            })
+        };
+
+        let hold = server.cache.hold_resolution();
+        server
+            .did_open_impl(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: lsp_uri,
+                    language_id: "markdown".to_string(),
+                    version: 1,
+                    text: "# Example\n\n```lua\nprint(1)\n```\n".to_string(),
+                },
+            })
+            .await;
+
+        // First publish: the current tree with no regions yet — and a token
+        // wait already returns it while the resolution is still held.
+        wait_until(|| regions_of(&uri) == Some((None, None))).await;
+        let woke = tokio::time::timeout(
+            Duration::from_secs(1),
+            server.wait_for_current_snapshot(&uri, Duration::from_secs(1)),
+        )
+        .await
+        .expect("a token wait must not park behind the resolution");
+        assert!(
+            matches!(
+                woke,
+                crate::lsp::lsp_impl::snapshot_read::SnapshotWait::Current(_)
+            ),
+            "the first publish releases the token readers"
+        );
+
+        // Second publish: the same version, upgraded with the regions.
+        drop(hold);
+        wait_until(|| regions_of(&uri) == Some((Some(1), Some(1)))).await;
+    }
+
     #[tokio::test]
     async fn did_open_parses_before_eager_opening_injected_virtual_documents() {
         // Test isolation is automatic via the `cfg(test)` branch in

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -602,14 +602,25 @@ mod tests {
                     uri: lsp_uri,
                     language_id: "markdown".to_string(),
                     version: 1,
-                    text: "# Example\n\n```lua\nprint(1)\n```\n".to_string(),
+                    // Enough regions for the discovery to be worth storing,
+                    // so the first publish is seen to carry it.
+                    text: format!("# Example\n\n{}", "```lua\nprint(1)\n```\n".repeat(9)),
                 },
             })
             .await;
 
-        // First publish: the current tree with no regions yet — and a token
-        // wait already returns it while the resolution is still held.
+        // First publish: the current tree with its discovery and no regions
+        // yet — and a token wait already returns it while the resolution is
+        // still held.
         wait_until(|| regions_of(&uri) == Some((None, None))).await;
+        assert!(
+            server
+                .documents
+                .latest_snapshot(&uri)
+                .and_then(|view| view.slot.snapshot)
+                .is_some_and(|snapshot| snapshot.injection_regions.is_some()),
+            "the first publish carries the discovery the token readers consume"
+        );
         let woke = tokio::time::timeout(
             Duration::from_secs(1),
             server.wait_for_current_snapshot(&uri, Duration::from_secs(1)),
@@ -626,7 +637,7 @@ mod tests {
 
         // Second publish: the same version, upgraded with the regions.
         drop(hold);
-        wait_until(|| regions_of(&uri) == Some((Some(1), Some(1)))).await;
+        wait_until(|| regions_of(&uri) == Some((Some(9), Some(9)))).await;
     }
 
     #[tokio::test]

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -1593,7 +1593,7 @@ print("hello")
             .unwrap()
             .tree()
             .expect("the reparse published a tree");
-        assert_eq!(&*server.documents.get(&uri).unwrap().text(), after);
+        assert_eq!(server.documents.get(&uri).unwrap().text(), after);
         assert_eq!(
             keep_name(&reparsed),
             Some(before_id),

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -589,8 +589,8 @@ mod tests {
                 let snapshot = view.slot.snapshot?;
                 (snapshot.parsed_version == view.content_version && snapshot.tree.is_some())
                     .then_some((
-                        snapshot.bridge_regions.as_ref().map(|(_, r)| r.len()),
-                        snapshot.resolved_regions.as_ref().map(|(_, r)| r.len()),
+                        snapshot.regions.as_ref().map(|r| r.bridge.len()),
+                        snapshot.regions.as_ref().map(|r| r.whole_document.len()),
                     ))
             })
         };

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -1333,7 +1333,7 @@ mod tests {
                         injection_regions: None,
                         bridge_regions: None,
                         resolved_regions: None,
-                        layer_trees: std::sync::OnceLock::new(),
+                        layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))
             })
@@ -1773,7 +1773,7 @@ mod tests {
                         injection_regions: None,
                         bridge_regions: None,
                         resolved_regions: None,
-                        layer_trees: std::sync::OnceLock::new(),
+                        layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))
             })

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -1331,8 +1331,7 @@ mod tests {
                         parsed_version,
                         incarnation,
                         injection_regions: None,
-                        bridge_regions: None,
-                        resolved_regions: None,
+                        regions: None,
                         layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))
@@ -1771,8 +1770,7 @@ mod tests {
                         parsed_version: 0,
                         incarnation,
                         injection_regions: None,
-                        bridge_regions: None,
-                        resolved_regions: None,
+                        regions: None,
                         layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },
                 ))

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -118,11 +118,11 @@ impl Kakehashi {
             // one value; absent/reload-stale falls back inline over the same
             // tree.
             let all_regions = match snapshot
-                .resolved_regions
+                .regions
                 .as_ref()
-                .filter(|(stamped, _)| *stamped == self.cache.semantic_token_generation())
+                .filter(|regions| regions.generation == self.cache.semantic_token_generation())
             {
-                Some((_, regions)) => std::sync::Arc::clone(regions),
+                Some(regions) => std::sync::Arc::clone(&regions.whole_document),
                 None => std::sync::Arc::new(InjectionResolver::resolve_all(
                     &self.language,
                     self.bridge.node_tracker(),

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -117,22 +117,19 @@ impl Kakehashi {
             // regions. Snapshot immutability makes tree, text, and regions
             // one value; absent/reload-stale falls back inline over the same
             // tree.
-            let all_regions = match snapshot
-                .regions
-                .as_ref()
-                .filter(|regions| regions.generation == self.cache.semantic_token_generation())
-            {
-                Some(regions) => std::sync::Arc::clone(&regions.whole_document),
-                None => std::sync::Arc::new(InjectionResolver::resolve_all(
-                    &self.language,
-                    self.bridge.node_tracker(),
-                    &uri,
-                    snapshot_tree,
-                    &snapshot.text,
-                    injection_query.as_ref(),
-                    snapshot.incarnation,
-                )),
-            };
+            let all_regions =
+                match snapshot.regions_for_generation(self.cache.semantic_token_generation()) {
+                    Some(regions) => std::sync::Arc::clone(&regions.whole_document),
+                    None => std::sync::Arc::new(InjectionResolver::resolve_all(
+                        &self.language,
+                        self.bridge.node_tracker(),
+                        &uri,
+                        snapshot_tree,
+                        &snapshot.text,
+                        injection_query.as_ref(),
+                        snapshot.incarnation,
+                    )),
+                };
 
             if all_regions.is_empty() {
                 return Ok(None);


### PR DESCRIPTION
Follows #1067 (merged); rebased onto the latest `main`.

## Summary

Semantic-token readers used to wait for virtual-region content resolution before receiving a parse snapshot, although they need only the tree and injection discovery. Publish those inputs from inside the populate work unit as soon as discovery is ready, then enrich that exact snapshot after resolution finishes.

The two stages have a restricted contract:

- `ResolvedRegions` bundles the bridge and whole-document views under one settings generation. `None` means unavailable (including skipped/cancelled resolution); present empty vectors mean the query found no regions. Partial view publication and conflicting generation stamps are no longer representable.
- `install_parse` admits initial parse results and tree-less-placeholder upgrades, but rejects equal-version replacement snapshots even when they carry a clone of the published tree. `complete_parse` names the exact initially published `Arc`; the store/channel check identity under their guards and construct the enriched snapshot from those existing inputs. Completion cannot swap text, tree, discovery, or the shared lazy layer-tree cell, and no tree-sitter child-ID heuristic is needed.
- The coordinator records the initial outcome once outside the compute work unit, preserving it through a contained panic. The initial publication/placeholder-upgrade outcome stays separate from completion-time currency. An intervening edit can leave a consistent stale snapshot enriched, but cannot authorize current-version downstream work; a newer publish, reload, or close/reopen rejects completion of the displaced snapshot.
- Cancellation still joins the populate work unit. Missing resolution retains inline fallback. Store-based region readers share lifetime/version/generation validation, while readers already bound to a snapshot validate its own regions rather than pairing its tree with a newer store result.

The parse-snapshot ADR documents the resulting contract. Tests cover early token-reader release, shared layer-tree caching, exact-snapshot admission, immutable issued snapshots, duplicate completion and watch notifications, edits with/without resolved regions, reload/reopen/newer-publish rejection, and unavailable/empty/stale reader results.

## Performance evidence

The original implementation was measured against #1067 with eight alternating A/B pairs. Results were mixed; no additional token-latency gain was established after the language-lookup memoization. This PR is justified by removing bridge-only work from token readers' dependency path. The subsequent structural simplifications have not been rebenchmarked, so this description makes no new latency claim. Whole-document discovery/highlight costs remain tracked in #1068.

## Verification

- `make check` (module registration, cargo check, production Clippy with warnings denied, formatting)
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- All three tests touched by the test-only Clippy cleanup pass individually
- `cargo test --lib --quiet`: 3,726 passed, 2 ignored
- `scripts/test_e2e.sh`: 445 E2E passed (1 ignored) + 79 integration passed, without retries
- `cargo test --bins --quiet`: 11 passed
- Independent reviews of publication/lifecycle/cancellation and region/readers/ADR changes: no actionable findings





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Semantic-token processing can begin sooner while injection details continue resolving in the background.
  - Injection discovery and resolved regions now remain consistent for the same document version.
  - Snapshot data is validated against the current document and semantic-token generation, reducing stale results.
  - Whole-document injection handling now uses generation-matched region data.
  - Parsing and refresh behavior better handles edits arriving during processing.

- **Documentation**
  - Architecture documentation updated to reflect the revised parsing and snapshot publication flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->