### PR TITLE
perf(cache): resolve only a document a bridge server handles a region of

### DIFF
--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -238,8 +238,10 @@ runnable bridge server, populate resolves only a document one of whose region
 languages — canonicalized the way the bridge routes — a server handles; a
 document nothing routes publishes a roster instead (every region's language
 and identity, no content), enough for the injected-grammar load and the closing
-of a virtual document a region used to have, and its whole-document readers
-resolve inline as they do without a runnable server; and emit the
+of a virtual document a region used to have; its diagnostic readers take that
+roster at its word (no virtual region to anchor or check), and its other
+whole-document readers resolve inline as they do without a runnable server;
+and emit the
 downstream — `semanticTokens/refresh`, injected-language forwarding, diagnostic
 republish — gated on the first install's result, after the upgrade, in the order
 the per-document-parse-scheduler loop already uses

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -233,7 +233,13 @@ out, from inside the populate work-unit, so the token readers wake without
 waiting for the resolution only the bridge and the whole-document readers
 consume; then the same version again, upgraded with the bridge / resolved
 regions once the pass has resolved (the equal-version regions upgrade above; a
-pass refused before the hand-off installs once, with no regions); and emit the
+pass refused before the hand-off installs once, with no regions). With a
+runnable bridge server, populate resolves only a document one of whose region
+languages — canonicalized the way the bridge routes — a server handles; a
+document nothing routes publishes a roster instead (every region's language
+and identity, no content), enough for the injected-grammar load and the closing
+of a virtual document a region used to have, and its whole-document readers
+resolve inline as they do without a runnable server; and emit the
 downstream — `semanticTokens/refresh`, injected-language forwarding, diagnostic
 republish — gated on the first install's result, after the upgrade, in the order
 the per-document-parse-scheduler loop already uses

--- a/src/document.rs
+++ b/src/document.rs
@@ -8,8 +8,8 @@ pub(crate) mod snapshot;
 
 // Re-export main types
 pub(crate) use injections::{
-    DiscoveredBridgeRegion, DiscoveredInjections, DiscoveredRegion, DiscoveredRegionCache,
-    SnapshotLayerTree,
+    BridgeRegions, BridgeRosterRegion, DiscoveredBridgeRegion, DiscoveredInjections,
+    DiscoveredRegion, DiscoveredRegionCache, SnapshotLayerTree,
 };
 pub(crate) use model::Document;
 pub use store::DocumentStore;

--- a/src/document/injections.rs
+++ b/src/document/injections.rs
@@ -97,12 +97,76 @@ pub(crate) struct DiscoveredInjections {
     pub regions: Vec<DiscoveredRegion>,
 }
 
+/// What one populate pass publishes for the **bridge** downstream
+/// (`process_injections` → eager spawn / didChange forwarding / auto-install),
+/// per document: either every region resolved with the content the bridge
+/// opens downstream — a runnable bridge server handles one of the document's
+/// region languages — or the roster of a document nothing routes. The two are
+/// distinct shapes on purpose: a roster region has no content to open, and
+/// "resolved" is a property of the document, not of a region, so a reader
+/// cannot mistake one region's content for its being routed.
+#[derive(Clone)]
+pub(crate) enum BridgeRegions {
+    /// Every region, with its virtual-document content; the pass resolved the
+    /// document because a runnable bridge server handles one of its region
+    /// languages. A region here is still only routed if the bridge's routing
+    /// rule names a server for its language.
+    Resolved(std::sync::Arc<Vec<DiscoveredBridgeRegion>>),
+    /// Every region's language and identity and nothing else: no runnable
+    /// server handles any of the document's region languages (or the
+    /// document has no regions), so nothing opens them — the roster still
+    /// drives the injected-grammar load and the closing of a virtual document
+    /// a region used to have.
+    Roster(std::sync::Arc<Vec<BridgeRosterRegion>>),
+}
+
+impl BridgeRegions {
+    /// The resolved regions, `None` for a roster.
+    pub(crate) fn resolved(&self) -> Option<&[DiscoveredBridgeRegion]> {
+        match self {
+            Self::Resolved(regions) => Some(regions),
+            Self::Roster(_) => None,
+        }
+    }
+
+    /// Whether nothing in the document is routed: a roster.
+    pub(crate) fn is_roster(&self) -> bool {
+        matches!(self, Self::Roster(_))
+    }
+
+    /// Every region's `(language, region_id)`, resolved or on the roster.
+    pub(crate) fn identities(&self) -> Vec<(&str, &str)> {
+        match self {
+            Self::Resolved(regions) => regions
+                .iter()
+                .map(|region| (region.language.as_str(), region.region_id.as_str()))
+                .collect(),
+            Self::Roster(regions) => regions
+                .iter()
+                .map(|region| (region.language.as_str(), region.region_id.as_str()))
+                .collect(),
+        }
+    }
+}
+
+/// One region of the roster a document nothing routes publishes: its language
+/// and identity, enough for the injected-grammar load and the closing of a
+/// virtual document it used to have; no content, because nothing opens it.
+#[derive(Clone)]
+pub(crate) struct BridgeRosterRegion {
+    /// The region's canonical language (see [`DiscoveredBridgeRegion::language`]).
+    pub language: String,
+    /// The region's tracker ULID (see [`DiscoveredBridgeRegion::region_id`]).
+    pub region_id: String,
+}
+
 /// One discovered injection region in the owned form the **bridge** downstream
 /// (`process_injections` → eager spawn / didChange forwarding / auto-install)
 /// consumes — the parse-pass twin of `BridgeInjection`, kept here so `document`
 /// need not depend on `lsp::bridge`. Built by `populate_injections` from the
 /// same single injection-query pass as everything else (never re-discovered on
-/// the downstream path), and carried on the `ParseSnapshot`.
+/// the downstream path), and carried on the `ParseSnapshot` as
+/// [`BridgeRegions::Resolved`].
 #[derive(Clone)]
 pub(crate) struct DiscoveredBridgeRegion {
     /// Resolved injection language, shared by eager lifecycle messages and
@@ -116,14 +180,8 @@ pub(crate) struct DiscoveredBridgeRegion {
     pub region_id: String,
     /// The exact virtual-document text the bridge opens downstream (excluded
     /// prefixes removed; an `injection.combined` group preserves host line
-    /// numbers with empty lines and uses spaces for later gaps on a line):
-    /// `Some` for every region of a document one of whose region languages
-    /// a runnable bridge server handles, `None` for every region of a
-    /// document none routes — those regions are on the roster, their
-    /// language and identity still drive the injected-grammar load and the
-    /// closing of a virtual document they used to have, but nothing opens
-    /// them.
-    pub content: Option<String>,
+    /// numbers with empty lines and uses spaces for later gaps on a line).
+    pub content: String,
 }
 
 /// One pre-parsed injection layer of a document, in document-order DFS —

--- a/src/document/injections.rs
+++ b/src/document/injections.rs
@@ -134,18 +134,21 @@ impl BridgeRegions {
         matches!(self, Self::Roster(_))
     }
 
-    /// Every region's `(language, region_id)`, resolved or on the roster.
-    pub(crate) fn identities(&self) -> Vec<(&str, &str)> {
-        match self {
-            Self::Resolved(regions) => regions
-                .iter()
-                .map(|region| (region.language.as_str(), region.region_id.as_str()))
-                .collect(),
-            Self::Roster(regions) => regions
-                .iter()
-                .map(|region| (region.language.as_str(), region.region_id.as_str()))
-                .collect(),
-        }
+    /// Every region's `(language, region_id)`, resolved or on the roster,
+    /// borrowed: one of the two chained halves is always empty.
+    pub(crate) fn identities(&self) -> impl Iterator<Item = (&str, &str)> {
+        let (resolved, roster): (&[DiscoveredBridgeRegion], &[BridgeRosterRegion]) = match self {
+            Self::Resolved(regions) => (regions, &[]),
+            Self::Roster(regions) => (&[], regions),
+        };
+        resolved
+            .iter()
+            .map(|region| (region.language.as_str(), region.region_id.as_str()))
+            .chain(
+                roster
+                    .iter()
+                    .map(|region| (region.language.as_str(), region.region_id.as_str())),
+            )
     }
 }
 

--- a/src/document/injections.rs
+++ b/src/document/injections.rs
@@ -117,10 +117,12 @@ pub(crate) struct DiscoveredBridgeRegion {
     /// The exact virtual-document text the bridge opens downstream (excluded
     /// prefixes removed; an `injection.combined` group preserves host line
     /// numbers with empty lines and uses spaces for later gaps on a line):
-    /// `Some` for a region a runnable bridge server handles, `None` for one
-    /// no server handles — the region is on the roster, its language and
-    /// identity still drive the injected-grammar install and the closing of
-    /// a virtual document it used to have, but nothing opens it.
+    /// `Some` for every region of a document one of whose region languages
+    /// a runnable bridge server handles, `None` for every region of a
+    /// document none routes — those regions are on the roster, their
+    /// language and identity still drive the injected-grammar load and the
+    /// closing of a virtual document they used to have, but nothing opens
+    /// them.
     pub content: Option<String>,
 }
 

--- a/src/document/injections.rs
+++ b/src/document/injections.rs
@@ -114,10 +114,14 @@ pub(crate) struct DiscoveredBridgeRegion {
     /// the query-pattern/language discriminator so same-range alternatives
     /// remain distinct within the document incarnation.
     pub region_id: String,
-    /// The exact virtual-document text the bridge opens downstream: excluded
-    /// prefixes are removed, while an `injection.combined` group preserves host
-    /// line numbers with empty lines and uses spaces for later gaps on a line.
-    pub content: String,
+    /// The exact virtual-document text the bridge opens downstream (excluded
+    /// prefixes removed; an `injection.combined` group preserves host line
+    /// numbers with empty lines and uses spaces for later gaps on a line):
+    /// `Some` for a region a runnable bridge server handles, `None` for one
+    /// no server handles — the region is on the roster, its language and
+    /// identity still drive the injected-grammar install and the closing of
+    /// a virtual document it used to have, but nothing opens it.
+    pub content: Option<String>,
 }
 
 /// One pre-parsed injection layer of a document, in document-order DFS —

--- a/src/document/snapshot.rs
+++ b/src/document/snapshot.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use tree_sitter::Tree;
 
-use super::injections::{DiscoveredBridgeRegion, DiscoveredInjections, SnapshotLayerTree};
+use super::injections::{BridgeRegions, DiscoveredInjections, SnapshotLayerTree};
 use crate::language::injection::ResolvedInjection;
 
 /// The reserved terminal incarnation `didClose` installs in a slot
@@ -65,20 +65,22 @@ pub(crate) struct ParseSnapshot {
     /// binding: text, tree, and regions are one value, so the regions can
     /// never be consumed against a different tree.
     pub(crate) injection_regions: Option<Arc<DiscoveredInjections>>,
-    /// The bridge downstream's region list, derived by the same populate pass
+    /// The bridge downstream's regions, derived by the same populate pass
     /// (`None` when populate didn't run for this snapshot or no bridge server
-    /// was configured — the downstream then resolves inline; `Some(empty)`
-    /// means genuinely no regions). Stamped with the settings generation the
+    /// was configured — the downstream then resolves inline; otherwise the
+    /// document's regions resolved with content, or the roster of a document
+    /// nothing routes, see [`BridgeRegions`]). Stamped with the settings generation the
     /// discovery ran under, like `resolved_regions`: a reload can change the
     /// injection query without publishing a new snapshot, and the consumer
     /// must fall back inline rather than open virtual documents for regions
     /// the new query would not discover.
-    pub(crate) bridge_regions: Option<(u64, Arc<Vec<DiscoveredBridgeRegion>>)>,
+    pub(crate) bridge_regions: Option<(u64, BridgeRegions)>,
     /// Fully resolved injection regions (`InjectionResolver::resolve_all`'s
     /// shape) from the same populate pass, for the whole-document readers —
     /// pull/push diagnostics, documentSymbol/Color, formatting's virt layer —
     /// which previously each re-ran the injection query per request. Same
-    /// `None`/`Some(empty)` semantics as `bridge_regions`.
+    /// `None` semantics as `bridge_regions`; `Some(empty)` means genuinely no
+    /// regions.
     /// Stamped with the settings generation the populate pass ran under: a
     /// reload (which can change injection resolution) bumps the generation
     /// WITHOUT publishing a new snapshot, so consumers gate on the stamp and
@@ -299,7 +301,7 @@ mod tests {
 
     fn with_regions(mut snapshot: ParseSnapshot, bridge: bool, resolved: bool) -> ParseSnapshot {
         if bridge {
-            snapshot.bridge_regions = Some((1, Arc::new(Vec::new())));
+            snapshot.bridge_regions = Some((1, BridgeRegions::Roster(Arc::new(Vec::new()))));
         }
         if resolved {
             snapshot.resolved_regions = Some((1, Arc::new(Vec::new())));

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -657,24 +657,24 @@ impl DocumentStore {
 
     /// The current snapshot's bridge roster, stamped with `current_generation`
     /// (see [`current_resolved_regions`](Self::current_resolved_regions)). A
-    /// roster with no content-bearing entry is definitive: the parse looked,
-    /// and no runnable server handles any of the document's region
-    /// languages, so nothing was routed and no virtual document exists —
-    /// bridge-side readers skip their work instead of resolving inline.
+    /// roster is definitive: the parse looked, and no runnable server handles
+    /// any of the document's region languages, so nothing was routed and no
+    /// virtual document exists — bridge-side readers skip their work instead
+    /// of resolving inline.
     /// `None` means the parse could not look (or the roster is stale or
     /// reload-stale): resolve inline.
     pub(crate) fn current_bridge_regions(
         &self,
         uri: &Url,
         current_generation: u64,
-    ) -> Option<std::sync::Arc<Vec<crate::document::DiscoveredBridgeRegion>>> {
+    ) -> Option<crate::document::BridgeRegions> {
         let view = self.latest_snapshot(uri)?;
         let snapshot = view.slot.snapshot?;
         if snapshot.parsed_version != view.content_version {
             return None;
         }
         let (stamped_generation, regions) = snapshot.bridge_regions.as_ref()?;
-        (*stamped_generation == current_generation).then(|| std::sync::Arc::clone(regions))
+        (*stamped_generation == current_generation).then(|| regions.clone())
     }
 
     /// Subscribe to `uri`'s snapshot-slot changes for a **bounded** wait (the
@@ -1289,7 +1289,10 @@ mod tests {
                 resolved_regions: None,
                 layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
             };
-            snapshot.bridge_regions = Some((1, Arc::new(Vec::new())));
+            snapshot.bridge_regions = Some((
+                1,
+                crate::document::BridgeRegions::Roster(Arc::new(Vec::new())),
+            ));
             Arc::new(snapshot)
         };
 
@@ -1402,7 +1405,10 @@ mod tests {
                 resolved_regions: None,
                 layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
             };
-            snapshot.bridge_regions = Some((1, Arc::new(Vec::new())));
+            snapshot.bridge_regions = Some((
+                1,
+                crate::document::BridgeRegions::Roster(Arc::new(Vec::new())),
+            ));
             store.install_parse(
                 &uri,
                 LanguageCheck::Expect(Some("markdown")),

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -655,6 +655,28 @@ impl DocumentStore {
         (*stamped_generation == current_generation).then(|| std::sync::Arc::clone(regions))
     }
 
+    /// The current snapshot's bridge roster, stamped with `current_generation`
+    /// (see [`current_resolved_regions`](Self::current_resolved_regions)). A
+    /// roster with no content-bearing entry is definitive: the parse looked,
+    /// and no runnable server handles any of the document's region
+    /// languages, so nothing was routed and no virtual document exists —
+    /// bridge-side readers skip their work instead of resolving inline.
+    /// `None` means the parse could not look (or the roster is stale or
+    /// reload-stale): resolve inline.
+    pub(crate) fn current_bridge_regions(
+        &self,
+        uri: &Url,
+        current_generation: u64,
+    ) -> Option<std::sync::Arc<Vec<crate::document::DiscoveredBridgeRegion>>> {
+        let view = self.latest_snapshot(uri)?;
+        let snapshot = view.slot.snapshot?;
+        if snapshot.parsed_version != view.content_version {
+            return None;
+        }
+        let (stamped_generation, regions) = snapshot.bridge_regions.as_ref()?;
+        (*stamped_generation == current_generation).then(|| std::sync::Arc::clone(regions))
+    }
+
     /// Subscribe to `uri`'s snapshot-slot changes for a **bounded** wait (the
     /// first-parse and explicit-action waits, the only two the parse-snapshot
     /// model permits). `None` for an unregistered/closed URI. The `Ref` is

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -4059,4 +4059,38 @@ mod tests {
             "Lua should have highlight queries"
         );
     }
+    /// The canonical language of an injection region, from its identifier
+    /// alone: the base mapping, the `plaintext` short-circuit and syntect's
+    /// token lookup need no content, so populate can decide whether a region
+    /// is routable before it extracts the region's content. An identifier
+    /// those steps do not resolve is answered `None` — its language would
+    /// come from the content's first line, which only a resolution sees.
+    #[test]
+    fn canonical_language_from_identifier_answers_without_content_or_not_at_all() {
+        let coordinator = LanguageCoordinator::new();
+        assert_eq!(
+            coordinator.canonical_injection_language_from_identifier("py"),
+            Some("python".to_string())
+        );
+        assert_eq!(
+            coordinator.canonical_injection_language_from_identifier("plaintext"),
+            Some("plaintext".to_string())
+        );
+        coordinator.set_base_mapping("rmd", "markdown");
+        assert_eq!(
+            coordinator.canonical_injection_language_from_identifier("rmd"),
+            Some("markdown".to_string()),
+            "a base mapping wins before any detection"
+        );
+        assert_eq!(
+            coordinator.canonical_injection_language_from_identifier("no-such-language"),
+            None,
+            "an identifier only the content could resolve is not guessed"
+        );
+        assert_eq!(
+            coordinator.canonical_injection_language("no-such-language", "#!/usr/bin/env python\n"),
+            "python",
+            "the full resolution still consults the content for it"
+        );
+    }
 }

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1282,19 +1282,33 @@ impl LanguageCoordinator {
     /// `python`/`javascript` unless the explicit identifier itself has an
     /// eligible base mapping (for example, `py.base`).
     pub(crate) fn canonical_injection_language(&self, identifier: &str, content: &str) -> String {
-        if let Some(base) = self.resolve_base(identifier) {
-            return base;
-        }
-        if identifier == "plaintext" {
-            return identifier.to_string();
-        }
-        if let Some(candidate) = super::heuristic::detect_from_token(identifier) {
-            return self.resolve_base(&candidate).unwrap_or(candidate);
+        if let Some(canonical) = self.canonical_injection_language_from_identifier(identifier) {
+            return canonical;
         }
         if let Some(candidate) = super::heuristic::detect_from_first_line(content) {
             return self.resolve_base(&candidate).unwrap_or(candidate);
         }
         identifier.to_string()
+    }
+
+    /// The content-free prefix of [`Self::canonical_injection_language`]: the
+    /// base mapping, the `plaintext` short-circuit and syntect's token lookup.
+    /// `None` when only the content's first line could tell — the caller
+    /// then either resolves the region in full or treats it as unknown; it
+    /// never guesses. Lets populate decide whether a region is routable
+    /// before it extracts the region's content.
+    pub(crate) fn canonical_injection_language_from_identifier(
+        &self,
+        identifier: &str,
+    ) -> Option<String> {
+        if let Some(base) = self.resolve_base(identifier) {
+            return Some(base);
+        }
+        if identifier == "plaintext" {
+            return Some(identifier.to_string());
+        }
+        super::heuristic::detect_from_token(identifier)
+            .map(|candidate| self.resolve_base(&candidate).unwrap_or(candidate))
     }
 
     fn detect_language_logged(

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1076,15 +1076,16 @@ impl BridgeCoordinator {
         self.pool.close_invalidated_docs(uri, ulids).await;
     }
 
-    /// Close the virtual documents of regions whose language moved on:
+    /// Close the virtual documents of regions whose routing moved on:
     /// `expected` is every live region's `(region_id, language)` — the
     /// snapshot's roster when it is current, else the regions the pass
-    /// resolved — so a region that stopped being routed closes the document
-    /// it used to have.
+    /// resolved — with `None` for a region on the roster that nothing routes
+    /// any more, so it closes the document it used to have whatever its
+    /// language.
     pub(crate) async fn close_replaced_docs(
         &self,
         uri: &Url,
-        expected: &[(String, String)],
+        expected: &[(String, Option<String>)],
     ) -> std::collections::HashSet<String> {
         self.pool.close_replaced_docs(uri, expected).await
     }

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1076,12 +1076,17 @@ impl BridgeCoordinator {
         self.pool.close_invalidated_docs(uri, ulids).await;
     }
 
+    /// Close the virtual documents of regions whose language moved on:
+    /// `expected` is every live region's `(region_id, language)` — the
+    /// snapshot's roster when it is current, else the regions the pass
+    /// resolved — so a region that stopped being routed closes the document
+    /// it used to have.
     pub(crate) async fn close_replaced_docs(
         &self,
         uri: &Url,
-        injections: &[BridgeInjection],
+        expected: &[(String, String)],
     ) -> std::collections::HashSet<String> {
-        self.pool.close_replaced_docs(uri, injections).await
+        self.pool.close_replaced_docs(uri, expected).await
     }
 
     /// Take the upstream notification receiver for forwarding to the editor.

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1272,7 +1272,7 @@ impl LanguageServerPool {
     pub(crate) async fn remove_replaced_virtual_docs(
         &self,
         host_uri: &Url,
-        expected_languages: &std::collections::HashMap<&str, &str>,
+        expected_languages: &std::collections::HashMap<&str, Option<&str>>,
     ) -> Vec<OpenedVirtualDoc> {
         self.document_tracker
             .remove_replaced_virtual_docs(host_uri, expected_languages)

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -742,11 +742,15 @@ impl DocumentTracker {
 
     /// Take opened documents whose URI no longer matches the expected URI for
     /// their still-live region. A content-based language change can preserve
-    /// the region ULID while changing the language-derived URI extension.
+    /// the region ULID while changing the language-derived URI extension;
+    /// `None` says the live region is no longer routed at all (a reload
+    /// changed the host's bridge filter or a server's languages), so its
+    /// document is taken whatever its language. A region absent from the map
+    /// was not seen by this pass and is left alone.
     pub(crate) async fn remove_replaced_virtual_docs(
         &self,
         host_uri: &Url,
-        expected_languages: &std::collections::HashMap<&str, &str>,
+        expected_languages: &std::collections::HashMap<&str, Option<&str>>,
     ) -> Vec<OpenedVirtualDoc> {
         let mut host_map = self.host_to_virtual.lock().await;
         let Some(docs) = host_map.get_mut(host_uri) else {
@@ -758,7 +762,7 @@ impl DocumentTracker {
             let Some(expected) = expected_languages.get(doc.virtual_uri.region_id()) else {
                 return true;
             };
-            let replaced = doc.virtual_uri.language() != *expected;
+            let replaced = expected.is_none_or(|language| doc.virtual_uri.language() != language);
             if replaced {
                 to_close.push(doc.clone());
             }

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -1530,7 +1530,7 @@ mod tests {
             .register_opened_document(&host_uri, &sibling_uri, &connection)
             .await;
 
-        let expected = std::collections::HashMap::from([(TEST_ULID_LUA_0, "python")]);
+        let expected = std::collections::HashMap::from([(TEST_ULID_LUA_0, Some("python"))]);
         let removed = tracker
             .remove_replaced_virtual_docs(&host_uri, &expected)
             .await;
@@ -1545,6 +1545,51 @@ mod tests {
         assert_eq!(
             remaining[0].virtual_uri.to_uri_string(),
             sibling_uri.to_uri_string()
+        );
+    }
+
+    /// A region that is still live but no longer routed — a reload changed
+    /// the host's bridge filter or the server's languages, not the region —
+    /// keeps its identity and language, so a language compare would keep
+    /// its old virtual document open on a server that no longer handles it.
+    /// The expected map says "no longer routed" explicitly, and the document
+    /// is taken like a replaced one.
+    #[tokio::test]
+    async fn remove_replaced_virtual_docs_takes_a_region_no_longer_routed() {
+        let tracker = DocumentTracker::new();
+        let host_uri = test_host_uri("region_no_longer_routed");
+        let unrouted_uri = VirtualDocumentUri::new(&url_to_uri(&host_uri), "lua", TEST_ULID_LUA_0);
+        let routed_uri =
+            VirtualDocumentUri::new(&url_to_uri(&host_uri), "python", TEST_ULID_PYTHON_0);
+        let connection = ConnectionKey::for_server("server");
+        tracker
+            .register_opened_document(&host_uri, &unrouted_uri, &connection)
+            .await;
+        tracker
+            .register_opened_document(&host_uri, &routed_uri, &connection)
+            .await;
+
+        let expected = std::collections::HashMap::from([
+            (TEST_ULID_LUA_0, None),
+            (TEST_ULID_PYTHON_0, Some("python")),
+        ]);
+        let removed = tracker
+            .remove_replaced_virtual_docs(&host_uri, &expected)
+            .await;
+
+        assert_eq!(
+            removed
+                .iter()
+                .map(|doc| doc.virtual_uri.to_uri_string())
+                .collect::<Vec<_>>(),
+            vec![unrouted_uri.to_uri_string()],
+            "the region nothing routes any more loses its virtual document"
+        );
+        let remaining = tracker.host_virtual_docs(&host_uri).await;
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(
+            remaining[0].virtual_uri.to_uri_string(),
+            routed_uri.to_uri_string()
         );
     }
 

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -242,11 +242,11 @@ impl LanguageServerPool {
     pub(crate) async fn close_replaced_docs(
         &self,
         host_uri: &Url,
-        injections: &[crate::lsp::bridge::coordinator::BridgeInjection],
+        expected: &[(String, String)],
     ) -> std::collections::HashSet<String> {
-        let expected_languages = injections
+        let expected_languages = expected
             .iter()
-            .map(|injection| (injection.region_id.as_str(), injection.language.as_str()))
+            .map(|(region_id, language)| (region_id.as_str(), language.as_str()))
             .collect();
         let to_close = self
             .remove_replaced_virtual_docs(host_uri, &expected_languages)

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -242,11 +242,11 @@ impl LanguageServerPool {
     pub(crate) async fn close_replaced_docs(
         &self,
         host_uri: &Url,
-        expected: &[(String, String)],
+        expected: &[(String, Option<String>)],
     ) -> std::collections::HashSet<String> {
         let expected_languages = expected
             .iter()
-            .map(|(region_id, language)| (region_id.as_str(), language.as_str()))
+            .map(|(region_id, language)| (region_id.as_str(), language.as_deref()))
             .collect();
         let to_close = self
             .remove_replaced_virtual_docs(host_uri, &expected_languages)

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -486,7 +486,7 @@ impl CacheCoordinator {
                         .map(|region| crate::document::DiscoveredBridgeRegion {
                             language: region.injection_language.clone(),
                             region_id: region.region.region_id.clone(),
-                            content: region.virtual_content.clone(),
+                            content: Some(region.virtual_content.clone()),
                         })
                         .collect()
                 });

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -95,12 +95,12 @@ pub(crate) struct InjectionDiscovery {
 pub(crate) struct PopulatedInjections {
     pub(crate) discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
     /// `None` when no bridge server is runnable — bridge readers then fall
-    /// back to inline resolution — vs `Some(empty)` for "ran, no regions"
-    /// (readers skip their work) vs the roster: every region's language and
-    /// identity, with content for every region iff a runnable server handles
-    /// one of the document's region languages (the resolution ran iff the
-    /// regions carry content).
-    pub(crate) bridge_regions: Option<Vec<crate::document::DiscoveredBridgeRegion>>,
+    /// back to inline resolution — vs the document's regions resolved with
+    /// content (a runnable server handles one of its region languages; the
+    /// resolution ran) vs the roster of a document nothing routes (every
+    /// region's language and identity; readers open nothing), an empty
+    /// roster for "ran, no regions".
+    pub(crate) bridge_regions: Option<crate::document::BridgeRegions>,
     /// `Some` iff the resolution ran (a runnable server handles one of the
     /// document's region languages); the whole-document readers resolve
     /// inline otherwise.
@@ -117,7 +117,9 @@ impl PopulatedInjections {
     pub(crate) fn empty(generation: u64) -> Self {
         Self {
             discovery: None,
-            bridge_regions: Some(Vec::new()),
+            bridge_regions: Some(crate::document::BridgeRegions::Roster(std::sync::Arc::new(
+                Vec::new(),
+            ))),
             resolved_regions: Some(Vec::new()),
             generation,
         }
@@ -508,40 +510,38 @@ impl CacheCoordinator {
             // a runnable server, `None`: populate runs on the pre-publish
             // critical path, and a bridge configured by a later reload
             // falls back to inline resolution.
-            let bridge_regions: Option<Vec<crate::document::DiscoveredBridgeRegion>> =
-                match &resolved {
-                    Some(resolved) => Some(
+            let bridge_regions: Option<crate::document::BridgeRegions> = match &resolved {
+                Some(resolved) => Some(crate::document::BridgeRegions::Resolved(
+                    std::sync::Arc::new(
                         resolved
                             .iter()
                             .map(|region| crate::document::DiscoveredBridgeRegion {
                                 language: region.injection_language.clone(),
                                 region_id: region.region.region_id.clone(),
-                                content: Some(region.virtual_content.clone()),
+                                content: region.virtual_content.clone(),
                             })
                             .collect(),
                     ),
-                    // Every identifier canonicalizes without content here:
-                    // one that could not would have made the document
-                    // routable above. (Memo hits: the names were just asked.)
-                    None if build_bridge_regions => Some(
+                )),
+                // Every identifier canonicalizes without content here:
+                // one that could not would have made the document
+                // routable above. (Memo hits: the names were just asked.)
+                None if build_bridge_regions => {
+                    Some(crate::document::BridgeRegions::Roster(std::sync::Arc::new(
                         regions
                             .iter()
                             .zip(&cacheable_regions)
-                            .map(
-                                |(info, cacheable)| crate::document::DiscoveredBridgeRegion {
-                                    language: language
-                                        .canonical_injection_language_from_identifier(
-                                            &info.language,
-                                        )
-                                        .unwrap_or_else(|| info.language.clone()),
-                                    region_id: cacheable.region_id.clone(),
-                                    content: None,
-                                },
-                            )
+                            .map(|(info, cacheable)| crate::document::BridgeRosterRegion {
+                                language: language
+                                    .canonical_injection_language_from_identifier(&info.language)
+                                    .unwrap_or_else(|| info.language.clone()),
+                                region_id: cacheable.region_id.clone(),
+                            })
                             .collect(),
-                    ),
-                    None => None,
-                };
+                    )))
+                }
+                None => None,
+            };
 
             // The whole-document readers' fully resolved regions, from the
             // same single query run — and from the SAME per-region ids and
@@ -1134,7 +1134,7 @@ mod tests {
             populated
                 .bridge_regions
                 .as_ref()
-                .is_some_and(|regions| regions.is_empty()),
+                .is_some_and(|regions| regions.identities().is_empty()),
             "a settled language without an injection query publishes a definitive empty set"
         );
     }
@@ -1206,8 +1206,9 @@ mod tests {
         );
         assert_eq!(
             populated.bridge_regions.as_ref().map(|regions| regions
-                .iter()
-                .map(|region| region.language.as_str())
+                .identities()
+                .into_iter()
+                .map(|(language, _)| language)
                 .collect::<Vec<_>>()),
             Some(vec!["python"; 9]),
             "resolution ran after the hand-off: it saw the mapping the hand-off installed"
@@ -1267,23 +1268,29 @@ mod tests {
 
         let unrouted = populate("unrouted.md", "```lua\nprint(1)\n```\n");
         let roster = unrouted.bridge_regions.expect("the roster is published");
+        assert!(roster.is_roster(), "no server handles lua: on the roster");
         assert_eq!(
             roster
-                .iter()
-                .map(|region| (region.language.as_str(), region.content.is_some()))
+                .identities()
+                .into_iter()
+                .map(|(language, _)| language)
                 .collect::<Vec<_>>(),
-            vec![("lua", false)],
-            "no server handles lua: on the roster, not resolved"
+            vec!["lua"],
+            "the roster names the region's language"
         );
         assert!(unrouted.resolved_regions.is_none());
 
         let routed = populate("routed.md", "```py\nprint(1)\n```\n");
         assert_eq!(
-            routed.bridge_regions.as_ref().map(|regions| regions
-                .iter()
-                .map(|region| (region.language.as_str(), region.content.is_some()))
-                .collect::<Vec<_>>()),
-            Some(vec![("python", true)]),
+            routed
+                .bridge_regions
+                .as_ref()
+                .and_then(|regions| regions.resolved())
+                .map(|regions| regions
+                    .iter()
+                    .map(|region| region.language.as_str())
+                    .collect::<Vec<_>>()),
+            Some(vec!["python"]),
             "a server handles python, which is what `py` canonicalizes to: resolved"
         );
         assert!(routed.resolved_regions.is_some());
@@ -1293,7 +1300,7 @@ mod tests {
             unknown
                 .bridge_regions
                 .as_ref()
-                .is_some_and(|regions| regions.iter().all(|region| region.content.is_some())),
+                .is_some_and(|regions| regions.resolved().is_some()),
             "an identifier only the content could canonicalize is resolved, not guessed"
         );
     }

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -94,12 +94,15 @@ pub(crate) struct InjectionDiscovery {
 /// All ride the `ParseSnapshot` the parse publishes.
 pub(crate) struct PopulatedInjections {
     pub(crate) discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
-    /// `None` when the resolution was skipped (no runnable bridge server) —
-    /// bridge readers then fall back to inline resolution — vs `Some(empty)`
-    /// for "ran, nothing matched" (readers skip their work).
+    /// `None` when no bridge server is runnable — bridge readers then fall
+    /// back to inline resolution — vs `Some(empty)` for "ran, no regions"
+    /// (readers skip their work) vs the roster: every region's language and
+    /// identity, with content only for the regions a runnable server handles
+    /// (the resolution ran iff any region has content).
     pub(crate) bridge_regions: Option<Vec<crate::document::DiscoveredBridgeRegion>>,
-    /// The same gate as `bridge_regions`: `None` exactly when it is, and the
-    /// whole-document readers then resolve inline.
+    /// `Some` iff the resolution ran (a runnable server handles one of the
+    /// document's region languages); the whole-document readers resolve
+    /// inline otherwise.
     pub(crate) resolved_regions: Option<Vec<crate::language::injection::ResolvedInjection>>,
     /// The settings generation this populate pass ran under — stamped onto
     /// the snapshot's `bridge_regions` and `resolved_regions` so reload-stale
@@ -463,17 +466,19 @@ impl CacheCoordinator {
             // Judged on the canonical language the bridge routes on; a
             // region whose identifier only its content could canonicalize
             // counts as routable, so it is resolved rather than guessed.
-            let routable = regions.iter().any(|info| {
-                language
-                    .canonical_injection_language_from_identifier(&info.language)
-                    .is_none_or(|canonical| bridged(&canonical))
-            });
+            let canonical: Vec<Option<String>> = regions
+                .iter()
+                .map(|info| language.canonical_injection_language_from_identifier(&info.language))
+                .collect();
+            let routable = canonical
+                .iter()
+                .any(|canonical| canonical.as_deref().is_none_or(bridged));
             log::trace!(
                 target: "kakehashi::populate",
                 "{uri}: {} regions, a bridge server handles one: {routable}",
                 regions.len()
             );
-            let resolved = if build_bridge_regions {
+            let resolved = if build_bridge_regions && routable {
                 let resolved = crate::language::injection::InjectionResolver::resolve_from_prebuilt_cancellable(
                     language,
                     &regions,
@@ -490,22 +495,42 @@ impl CacheCoordinator {
             // (parse-snapshot ADR §3, never discover twice): the exact
             // (resolved language, region_id, clean content) triple
             // `resolve_injection_data` used to re-derive by re-running the
-            // injection query per downstream pass. Gated on a bridge server
-            // actually being configured: populate runs on the pre-publish
-            // critical path, and the per-region content copies are pure
-            // waste for the (common) bridge-less deployment — `None` makes
-            // any late-configured bridge fall back to inline resolution.
+            // injection query per downstream pass. With a runnable bridge
+            // server a document nothing routes publishes a roster instead —
+            // every region's language and identity without the content
+            // copies, enough for the injected-grammar install and the
+            // closing of a virtual document a region used to have. Without
+            // a runnable server, `None`: populate runs on the pre-publish
+            // critical path, and a bridge configured by a later reload
+            // falls back to inline resolution.
             let bridge_regions: Option<Vec<crate::document::DiscoveredBridgeRegion>> =
-                resolved.as_ref().map(|resolved| {
-                    resolved
-                        .iter()
-                        .map(|region| crate::document::DiscoveredBridgeRegion {
-                            language: region.injection_language.clone(),
-                            region_id: region.region.region_id.clone(),
-                            content: Some(region.virtual_content.clone()),
-                        })
-                        .collect()
-                });
+                match &resolved {
+                    Some(resolved) => Some(
+                        resolved
+                            .iter()
+                            .map(|region| crate::document::DiscoveredBridgeRegion {
+                                language: region.injection_language.clone(),
+                                region_id: region.region.region_id.clone(),
+                                content: Some(region.virtual_content.clone()),
+                            })
+                            .collect(),
+                    ),
+                    None if build_bridge_regions => Some(
+                        regions
+                            .iter()
+                            .zip(&cacheable_regions)
+                            .zip(canonical)
+                            .map(|((info, cacheable), canonical)| {
+                                crate::document::DiscoveredBridgeRegion {
+                                    language: canonical.unwrap_or_else(|| info.language.clone()),
+                                    region_id: cacheable.region_id.clone(),
+                                    content: None,
+                                }
+                            })
+                            .collect(),
+                    ),
+                    None => None,
+                };
 
             // The whole-document readers' fully resolved regions, from the
             // same single query run — and from the SAME per-region ids and

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -261,7 +261,7 @@ impl CacheCoordinator {
         tracker: &NodeTracker,
         entry_mint_epoch: (u64, u64),
         incarnation: u64,
-        build_bridge_regions: bool,
+        bridge_runnable: &dyn Fn() -> bool,
         bridged: &dyn Fn(&str) -> bool,
     ) -> Option<PopulatedInjections> {
         self.populate_injections_cancellable(
@@ -273,7 +273,7 @@ impl CacheCoordinator {
             tracker,
             entry_mint_epoch,
             incarnation,
-            build_bridge_regions,
+            bridge_runnable,
             bridged,
             &mut |_| {},
             None,
@@ -291,7 +291,7 @@ impl CacheCoordinator {
         tracker: &NodeTracker,
         entry_mint_epoch: (u64, u64),
         incarnation: u64,
-        build_bridge_regions: bool,
+        bridge_runnable: &dyn Fn() -> bool,
         bridged: &dyn Fn(&str) -> bool,
         on_discovered: &mut dyn FnMut(InjectionDiscovery),
         cancel: Option<&crate::cancel::CancelToken>,
@@ -466,19 +466,23 @@ impl CacheCoordinator {
             // Judged on the canonical language the bridge routes on; a
             // region whose identifier only its content could canonicalize
             // counts as routable, so it is resolved rather than guessed.
-            let canonical: Vec<Option<String>> = regions
-                .iter()
-                .map(|info| language.canonical_injection_language_from_identifier(&info.language))
-                .collect();
-            let routable = canonical
-                .iter()
-                .any(|canonical| canonical.as_deref().is_none_or(bridged));
+            // Both asked only now — after the generation stamp at the top
+            // of this pass — so settings a reload publishes in between
+            // pair with a stamp that stamp-checking readers reject.
+            let build_bridge_regions = bridge_runnable();
+            let routable = build_bridge_regions
+                && regions.iter().any(|info| {
+                    language
+                        .canonical_injection_language_from_identifier(&info.language)
+                        .as_deref()
+                        .is_none_or(bridged)
+                });
             log::trace!(
-                target: "kakehashi::populate",
+                target: "kakehashi::cache",
                 "{uri}: {} regions, a bridge server handles one: {routable}",
                 regions.len()
             );
-            let resolved = if build_bridge_regions && routable {
+            let resolved = if routable {
                 let resolved = crate::language::injection::InjectionResolver::resolve_from_prebuilt_cancellable(
                     language,
                     &regions,
@@ -515,18 +519,24 @@ impl CacheCoordinator {
                             })
                             .collect(),
                     ),
+                    // Every identifier canonicalizes without content here:
+                    // one that could not would have made the document
+                    // routable above. (Memo hits: the names were just asked.)
                     None if build_bridge_regions => Some(
                         regions
                             .iter()
                             .zip(&cacheable_regions)
-                            .zip(canonical)
-                            .map(|((info, cacheable), canonical)| {
-                                crate::document::DiscoveredBridgeRegion {
-                                    language: canonical.unwrap_or_else(|| info.language.clone()),
+                            .map(
+                                |(info, cacheable)| crate::document::DiscoveredBridgeRegion {
+                                    language: language
+                                        .canonical_injection_language_from_identifier(
+                                            &info.language,
+                                        )
+                                        .unwrap_or_else(|| info.language.clone()),
                                     region_id: cacheable.region_id.clone(),
                                     content: None,
-                                }
-                            })
+                                },
+                            )
                             .collect(),
                     ),
                     None => None,
@@ -1087,7 +1097,7 @@ mod tests {
                 &tracker,
                 tracker.mint_epoch(&uri),
                 1,
-                true,
+                &|| true,
                 &|_| true,
             )
             .expect("the pass ran");
@@ -1115,7 +1125,7 @@ mod tests {
                 &tracker,
                 tracker.mint_epoch(&uri),
                 1,
-                true,
+                &|| true,
                 &|_| true,
             )
             .expect("the pass ran");
@@ -1182,7 +1192,7 @@ mod tests {
                 &tracker,
                 tracker.mint_epoch(&uri),
                 1,
-                true,
+                &|| true,
                 &|_| true,
                 &mut on_discovered,
                 None,
@@ -1248,7 +1258,7 @@ mod tests {
                     &tracker,
                     tracker.mint_epoch(&uri),
                     1,
-                    true,
+                    &|| true,
                     &handles_python,
                 )
                 .expect("the pass ran")
@@ -1322,7 +1332,7 @@ mod tests {
             &tracker,
             tracker.mint_epoch(&uri),
             1,
-            true,
+            &|| true,
             &|_| true,
             &mut |_| {},
             Some(&cancel),
@@ -1373,7 +1383,7 @@ mod tests {
             &tracker,
             tracker.mint_epoch(&uri),
             1,
-            true,
+            &|| true,
             &|_| true,
             &mut |_| {},
             Some(&cancel),
@@ -1437,7 +1447,7 @@ print("hello")
             &tracker,
             tracker.mint_epoch(&uri),
             0,
-            true,
+            &|| true,
             &|_| true,
         );
 
@@ -1500,7 +1510,7 @@ print("hello")
             &tracker,
             tracker.mint_epoch(&uri),
             0,
-            true,
+            &|| true,
             &|_| true,
         );
 
@@ -1580,7 +1590,7 @@ print("hello")
             &tracker,
             tracker.mint_epoch(&uri),
             0,
-            true,
+            &|| true,
             &|_| true,
         );
 
@@ -1627,7 +1637,7 @@ print("goodbye")
             &tracker,
             tracker.mint_epoch(&uri),
             0,
-            true,
+            &|| true,
             &|_| true,
         );
 

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -1134,7 +1134,7 @@ mod tests {
             populated
                 .bridge_regions
                 .as_ref()
-                .is_some_and(|regions| regions.identities().is_empty()),
+                .is_some_and(|regions| regions.identities().next().is_none()),
             "a settled language without an injection query publishes a definitive empty set"
         );
     }
@@ -1207,7 +1207,6 @@ mod tests {
         assert_eq!(
             populated.bridge_regions.as_ref().map(|regions| regions
                 .identities()
-                .into_iter()
                 .map(|(language, _)| language)
                 .collect::<Vec<_>>()),
             Some(vec!["python"; 9]),
@@ -1272,7 +1271,6 @@ mod tests {
         assert_eq!(
             roster
                 .identities()
-                .into_iter()
                 .map(|(language, _)| language)
                 .collect::<Vec<_>>(),
             vec!["lua"],

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -97,8 +97,9 @@ pub(crate) struct PopulatedInjections {
     /// `None` when no bridge server is runnable — bridge readers then fall
     /// back to inline resolution — vs `Some(empty)` for "ran, no regions"
     /// (readers skip their work) vs the roster: every region's language and
-    /// identity, with content only for the regions a runnable server handles
-    /// (the resolution ran iff any region has content).
+    /// identity, with content for every region iff a runnable server handles
+    /// one of the document's region languages (the resolution ran iff the
+    /// regions carry content).
     pub(crate) bridge_regions: Option<Vec<crate::document::DiscoveredBridgeRegion>>,
     /// `Some` iff the resolution ran (a runnable server handles one of the
     /// document's region languages); the whole-document readers resolve

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -259,6 +259,7 @@ impl CacheCoordinator {
         entry_mint_epoch: (u64, u64),
         incarnation: u64,
         build_bridge_regions: bool,
+        bridged: &dyn Fn(&str) -> bool,
     ) -> Option<PopulatedInjections> {
         self.populate_injections_cancellable(
             uri,
@@ -270,6 +271,7 @@ impl CacheCoordinator {
             entry_mint_epoch,
             incarnation,
             build_bridge_regions,
+            bridged,
             &mut |_| {},
             None,
         )
@@ -287,6 +289,7 @@ impl CacheCoordinator {
         entry_mint_epoch: (u64, u64),
         incarnation: u64,
         build_bridge_regions: bool,
+        bridged: &dyn Fn(&str) -> bool,
         on_discovered: &mut dyn FnMut(InjectionDiscovery),
         cancel: Option<&crate::cancel::CancelToken>,
     ) -> Option<PopulatedInjections> {
@@ -457,6 +460,19 @@ impl CacheCoordinator {
             // One resolution for every consumer that needs resolved languages /
             // virtual content: the bridge regions and the whole-document
             // resolved regions below are two views of this single pass.
+            // Judged on the canonical language the bridge routes on; a
+            // region whose identifier only its content could canonicalize
+            // counts as routable, so it is resolved rather than guessed.
+            let routable = regions.iter().any(|info| {
+                language
+                    .canonical_injection_language_from_identifier(&info.language)
+                    .is_none_or(|canonical| bridged(&canonical))
+            });
+            log::trace!(
+                target: "kakehashi::populate",
+                "{uri}: {} regions, a bridge server handles one: {routable}",
+                regions.len()
+            );
             let resolved = if build_bridge_regions {
                 let resolved = crate::language::injection::InjectionResolver::resolve_from_prebuilt_cancellable(
                     language,
@@ -1047,6 +1063,7 @@ mod tests {
                 tracker.mint_epoch(&uri),
                 1,
                 true,
+                &|_| true,
             )
             .expect("the pass ran");
 
@@ -1074,6 +1091,7 @@ mod tests {
                 tracker.mint_epoch(&uri),
                 1,
                 true,
+                &|_| true,
             )
             .expect("the pass ran");
         assert!(
@@ -1140,6 +1158,7 @@ mod tests {
                 tracker.mint_epoch(&uri),
                 1,
                 true,
+                &|_| true,
                 &mut on_discovered,
                 None,
             )
@@ -1156,6 +1175,90 @@ mod tests {
                 .collect::<Vec<_>>()),
             Some(vec!["python"; 9]),
             "resolution ran after the hand-off: it saw the mapping the hand-off installed"
+        );
+    }
+
+    /// Resolution — extracting every region's virtual document — feeds only
+    /// the bridge servers routed to the regions' languages. With a runnable
+    /// server, populate resolves a document only when one of its regions
+    /// is in a language a server handles, judged on the canonical language
+    /// the bridge itself routes on (`py` is `python`); a region whose
+    /// identifier only its content could canonicalize is resolved rather
+    /// than guessed. A document nothing routes publishes a roster instead:
+    /// every region's language and identity, no content, no whole-document
+    /// resolution.
+    #[test]
+    fn populate_resolves_only_a_document_a_server_handles_a_region_of() {
+        use tree_sitter::Parser;
+
+        let cache = CacheCoordinator::new();
+        let tracker = NodeTracker::new();
+        let coordinator = LanguageCoordinator::new();
+        let language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let query = tree_sitter::Query::new(
+            &language,
+            "(fenced_code_block (info_string (language) @injection.language) \
+             (code_fence_content) @injection.content)",
+        )
+        .expect("valid markdown injection query");
+        coordinator
+            .query_store()
+            .insert_injection_query("markdown".to_string(), std::sync::Arc::new(query));
+        coordinator
+            .language_registry_for_parallel()
+            .register("markdown".to_string(), language.clone());
+        let mut parser = Parser::new();
+        parser.set_language(&language).unwrap();
+        let handles_python = |canonical: &str| canonical == "python";
+        let mut populate = |name: &str, text: &str| {
+            let uri = create_test_uri(name);
+            let tree = parser.parse(text, None).unwrap();
+            cache
+                .populate_injections(
+                    &uri,
+                    text,
+                    &tree,
+                    "markdown",
+                    &coordinator,
+                    &tracker,
+                    tracker.mint_epoch(&uri),
+                    1,
+                    true,
+                    &handles_python,
+                )
+                .expect("the pass ran")
+        };
+
+        let unrouted = populate("unrouted.md", "```lua\nprint(1)\n```\n");
+        let roster = unrouted.bridge_regions.expect("the roster is published");
+        assert_eq!(
+            roster
+                .iter()
+                .map(|region| (region.language.as_str(), region.content.is_some()))
+                .collect::<Vec<_>>(),
+            vec![("lua", false)],
+            "no server handles lua: on the roster, not resolved"
+        );
+        assert!(unrouted.resolved_regions.is_none());
+
+        let routed = populate("routed.md", "```py\nprint(1)\n```\n");
+        assert_eq!(
+            routed.bridge_regions.as_ref().map(|regions| regions
+                .iter()
+                .map(|region| (region.language.as_str(), region.content.is_some()))
+                .collect::<Vec<_>>()),
+            Some(vec![("python", true)]),
+            "a server handles python, which is what `py` canonicalizes to: resolved"
+        );
+        assert!(routed.resolved_regions.is_some());
+
+        let unknown = populate("unknown.md", "```no-such-language\nprint(1)\n```\n");
+        assert!(
+            unknown
+                .bridge_regions
+                .as_ref()
+                .is_some_and(|regions| regions.iter().all(|region| region.content.is_some())),
+            "an identifier only the content could canonicalize is resolved, not guessed"
         );
     }
 
@@ -1195,6 +1298,7 @@ mod tests {
             tracker.mint_epoch(&uri),
             1,
             true,
+            &|_| true,
             &mut |_| {},
             Some(&cancel),
         );
@@ -1245,6 +1349,7 @@ mod tests {
             tracker.mint_epoch(&uri),
             1,
             true,
+            &|_| true,
             &mut |_| {},
             Some(&cancel),
         );
@@ -1308,6 +1413,7 @@ print("hello")
             tracker.mint_epoch(&uri),
             0,
             true,
+            &|_| true,
         );
 
         // Verify we have one injection region
@@ -1370,6 +1476,7 @@ print("hello")
             tracker.mint_epoch(&uri),
             0,
             true,
+            &|_| true,
         );
 
         // The region still exists, but changing its dynamic language creates a
@@ -1449,6 +1556,7 @@ print("hello")
             tracker.mint_epoch(&uri),
             0,
             true,
+            &|_| true,
         );
 
         let regions = cache.get_injections(&uri).expect("should have injections");
@@ -1495,6 +1603,7 @@ print("goodbye")
             tracker.mint_epoch(&uri),
             0,
             true,
+            &|_| true,
         );
 
         let regions_after = cache.get_injections(&uri).expect("should have injections");

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -423,8 +423,8 @@ impl DiagnosticSnapshotPreparer {
                 .injection_query(&language_name)
                 .map(|injection_query| {
                     // A roster nothing routes (the parse looked; no runnable
-                    // server handles any region language, so no entry
-                    // carries content) means no region has a server to ask:
+                    // server handles any region language) means no region
+                    // has a server to ask:
                     // no contexts, and no inline resolution paying on every
                     // edit what the parse path declined. Generation-stamped,
                     // so a reload that configures a server resolves inline
@@ -432,7 +432,7 @@ impl DiagnosticSnapshotPreparer {
                     if self
                         .documents
                         .current_bridge_regions(uri, self.cache.semantic_token_generation())
-                        .is_some_and(|roster| roster.iter().all(|region| region.content.is_none()))
+                        .is_some_and(|regions| regions.is_roster())
                     {
                         return Vec::new();
                     }
@@ -773,11 +773,12 @@ mod tests {
                         injection_regions: None,
                         bridge_regions: Some((
                             generation,
-                            std::sync::Arc::new(vec![crate::document::DiscoveredBridgeRegion {
-                                language: "lua".to_string(),
-                                region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
-                                content: None,
-                            }]),
+                            crate::document::BridgeRegions::Roster(std::sync::Arc::new(vec![
+                                crate::document::BridgeRosterRegion {
+                                    language: "lua".to_string(),
+                                    region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
+                                },
+                            ])),
                         )),
                         resolved_regions: None,
                         layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
@@ -846,11 +847,13 @@ mod tests {
                         injection_regions: None,
                         bridge_regions: Some((
                             generation,
-                            std::sync::Arc::new(vec![crate::document::DiscoveredBridgeRegion {
-                                language: "lua".to_string(),
-                                region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
-                                content: Some("print(1)\n".to_string()),
-                            }]),
+                            crate::document::BridgeRegions::Resolved(std::sync::Arc::new(vec![
+                                crate::document::DiscoveredBridgeRegion {
+                                    language: "lua".to_string(),
+                                    region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
+                                    content: "print(1)\n".to_string(),
+                                },
+                            ])),
                         )),
                         resolved_regions: None,
                         layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -422,6 +422,20 @@ impl DiagnosticSnapshotPreparer {
             self.language
                 .injection_query(&language_name)
                 .map(|injection_query| {
+                    // A roster nothing routes (the parse looked; no runnable
+                    // server handles any region language, so no entry
+                    // carries content) means no region has a server to ask:
+                    // no contexts, and no inline resolution paying on every
+                    // edit what the parse path declined. Generation-stamped,
+                    // so a reload that configures a server resolves inline
+                    // below.
+                    if self
+                        .documents
+                        .current_bridge_regions(uri, self.cache.semantic_token_generation())
+                        .is_some_and(|roster| roster.iter().all(|region| region.content.is_none()))
+                    {
+                        return Vec::new();
+                    }
                     // Prefer the populate pass's regions riding the current
                     // parse snapshot (never discover twice, ADR §3); fall
                     // back to the inline resolution when absent/stale.

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -817,6 +817,64 @@ mod tests {
                 .is_none(),
             "a roster nothing routes must not be resolved inline"
         );
+
+        // The partner case: a roster whose regions carry content is a
+        // routed document, and its regions are resolved for contexts as
+        // before — the short-circuit reads the content, not the roster's
+        // presence. (No server handles lua here, so the resolution leaves
+        // its mark in the tracker rather than in a context.)
+        let routed = Url::parse("file:///test/routed-diagnostic.md").unwrap();
+        let incarnation = server.documents.insert(
+            routed.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let content_version = server.documents.get(&routed).unwrap().content_version();
+        assert!(
+            server
+                .documents
+                .install_parse(
+                    &routed,
+                    crate::document::LanguageCheck::Expect(Some("markdown")),
+                    std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
+                        text: std::sync::Arc::from(text),
+                        tree: Some(tree.clone()),
+                        language: Some("markdown".to_string()),
+                        parsed_version: content_version,
+                        incarnation,
+                        injection_regions: None,
+                        bridge_regions: Some((
+                            generation,
+                            std::sync::Arc::new(vec![crate::document::DiscoveredBridgeRegion {
+                                language: "lua".to_string(),
+                                region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
+                                content: Some("print(1)\n".to_string()),
+                            }]),
+                        )),
+                        resolved_regions: None,
+                        layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
+                    }),
+                )
+                .current
+        );
+        preparer
+            .prepare_diagnostic_snapshot_when_current(&routed, incarnation, content_version)
+            .expect("a current parse yields a diagnostic snapshot");
+        assert!(
+            server
+                .bridge
+                .node_tracker()
+                .lookup_in_layer(
+                    &routed,
+                    content.start_byte(),
+                    content.end_byte(),
+                    content.kind(),
+                    crate::language::injection::REGION_IDENTITY_LAYER_BASE,
+                )
+                .is_some(),
+            "a routed document's regions are resolved as before"
+        );
     }
 
     #[tokio::test]

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -703,6 +703,108 @@ mod tests {
         );
     }
 
+    /// The per-edit diagnostic snapshot builds a virt context per region a
+    /// server handles. A roster nothing routes (every region listed, none
+    /// with content: no runnable server handles any of their languages)
+    /// already answers that: no contexts — without resolving inline, which
+    /// would mint region identity and pay on every edit the resolution the
+    /// parse declined.
+    #[tokio::test]
+    async fn diagnostic_snapshot_takes_an_unrouted_roster_without_resolving() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let preparer = DiagnosticSnapshotPreparer::new(server);
+
+        let language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let query = tree_sitter::Query::new(
+            &language,
+            "(fenced_code_block (info_string (language) @injection.language) \
+             (code_fence_content) @injection.content)",
+        )
+        .expect("valid markdown injection query");
+        server
+            .language
+            .query_store()
+            .insert_injection_query("markdown".to_string(), std::sync::Arc::new(query));
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("markdown".to_string(), language.clone());
+
+        let uri = Url::parse("file:///test/unrouted-diagnostic.md").unwrap();
+        let text = "```lua\nprint(1)\n```\n";
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&language).unwrap();
+        let tree = parser.parse(text, None).unwrap();
+        let incarnation = server.documents.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let content_version = server.documents.get(&uri).unwrap().content_version();
+        let generation = server.cache.semantic_token_generation();
+        assert!(
+            server
+                .documents
+                .install_parse(
+                    &uri,
+                    crate::document::LanguageCheck::Expect(Some("markdown")),
+                    std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
+                        text: std::sync::Arc::from(text),
+                        tree: Some(tree.clone()),
+                        language: Some("markdown".to_string()),
+                        parsed_version: content_version,
+                        incarnation,
+                        injection_regions: None,
+                        bridge_regions: Some((
+                            generation,
+                            std::sync::Arc::new(vec![crate::document::DiscoveredBridgeRegion {
+                                language: "lua".to_string(),
+                                region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
+                                content: None,
+                            }]),
+                        )),
+                        resolved_regions: None,
+                        layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
+                    }),
+                )
+                .current
+        );
+
+        let prepared = preparer
+            .prepare_diagnostic_snapshot_when_current(&uri, incarnation, content_version)
+            .expect("a current parse yields a diagnostic snapshot");
+        assert!(
+            prepared.virt_contexts.is_empty(),
+            "nothing routed: no virt context"
+        );
+        let content = {
+            let mut node = tree
+                .root_node()
+                .descendant_for_byte_range(8, 9)
+                .expect("a node covers the fence content");
+            while node.kind() != "code_fence_content" {
+                node = node.parent().expect("the fence content encloses it");
+            }
+            node
+        };
+        assert!(
+            server
+                .bridge
+                .node_tracker()
+                .lookup_in_layer(
+                    &uri,
+                    content.start_byte(),
+                    content.end_byte(),
+                    content.kind(),
+                    crate::language::injection::REGION_IDENTITY_LAYER_BASE,
+                )
+                .is_none(),
+            "a roster nothing routes must not be resolved inline"
+        );
+    }
+
     #[tokio::test]
     async fn saved_diagnostic_snapshot_input_rejects_a_later_edit() {
         let (service, _socket) = LspService::new(Kakehashi::new);

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1759,7 +1759,7 @@ impl DiagnosticPublisher {
         if self
             .documents
             .current_bridge_regions(host, generation_before)
-            .is_some_and(|roster| roster.iter().all(|region| region.content.is_none()))
+            .is_some_and(|regions| regions.is_roster())
         {
             return settled().then_some(offsets);
         }
@@ -3573,11 +3573,12 @@ mod tests {
                         injection_regions: None,
                         bridge_regions: Some((
                             generation,
-                            std::sync::Arc::new(vec![crate::document::DiscoveredBridgeRegion {
-                                language: "lua".to_string(),
-                                region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
-                                content: None,
-                            }]),
+                            crate::document::BridgeRegions::Roster(std::sync::Arc::new(vec![
+                                crate::document::BridgeRosterRegion {
+                                    language: "lua".to_string(),
+                                    region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
+                                },
+                            ])),
                         )),
                         resolved_regions: None,
                         layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
@@ -3646,11 +3647,13 @@ mod tests {
                         injection_regions: None,
                         bridge_regions: Some((
                             generation,
-                            std::sync::Arc::new(vec![crate::document::DiscoveredBridgeRegion {
-                                language: "lua".to_string(),
-                                region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
-                                content: Some("print(1)\n".to_string()),
-                            }]),
+                            crate::document::BridgeRegions::Resolved(std::sync::Arc::new(vec![
+                                crate::document::DiscoveredBridgeRegion {
+                                    language: "lua".to_string(),
+                                    region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
+                                    content: "print(1)\n".to_string(),
+                                },
+                            ])),
                         )),
                         resolved_regions: None,
                         layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1749,6 +1749,20 @@ impl DiagnosticPublisher {
             // here removes queries, and "no query" would read as no regions.
             return settled().then_some(offsets);
         };
+        // A roster nothing routes (the parse looked; no runnable server
+        // handles any region language, so no entry carries content) means
+        // no virtual document exists whose diagnostics could need
+        // anchoring: nothing to resolve, and resolving inline here would
+        // pay on every edit what the parse path declined. Generation-
+        // stamped, so a reload that configures a server falls through to
+        // the inline resolution below.
+        if self
+            .documents
+            .current_bridge_regions(host, generation_before)
+            .is_some_and(|roster| roster.iter().all(|region| region.content.is_none()))
+        {
+            return settled().then_some(offsets);
+        }
 
         let resolved_regions = match self
             .documents

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -3503,6 +3503,111 @@ mod tests {
         );
     }
 
+    /// Populate publishes a roster — every region's language and identity,
+    /// no content — when no runnable server handles any of the document's
+    /// region languages: nothing was routed, so no virtual document exists
+    /// whose diagnostics would need anchoring. The publisher takes that at
+    /// its word — no regions to anchor — instead of resolving inline, which
+    /// would mint region identity and pay, on every edit, the resolution
+    /// the parse path just declined.
+    #[tokio::test]
+    async fn current_region_offsets_takes_an_unrouted_roster_without_resolving() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let publisher = DiagnosticPublisher::new(server);
+
+        let language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let query = tree_sitter::Query::new(
+            &language,
+            "(fenced_code_block (info_string (language) @injection.language) \
+             (code_fence_content) @injection.content)",
+        )
+        .expect("valid markdown injection query");
+        server
+            .language
+            .query_store()
+            .insert_injection_query("markdown".to_string(), std::sync::Arc::new(query));
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("markdown".to_string(), language.clone());
+
+        let uri = Url::parse("file:///test/unrouted.md").unwrap();
+        let text = "```lua\nprint(1)\n```\n";
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&language).unwrap();
+        let tree = parser.parse(text, None).unwrap();
+        let incarnation = server.documents.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let content_version = server.documents.get(&uri).unwrap().content_version();
+        let generation = server.cache.semantic_token_generation();
+        let landed = server
+            .documents
+            .get(&uri)
+            .map(|doc| {
+                doc.publish_snapshot(&std::sync::Arc::new(
+                    crate::document::snapshot::ParseSnapshot {
+                        text: std::sync::Arc::from(text),
+                        tree: Some(tree.clone()),
+                        language: Some("markdown".to_string()),
+                        parsed_version: content_version,
+                        incarnation,
+                        injection_regions: None,
+                        bridge_regions: Some((
+                            generation,
+                            std::sync::Arc::new(vec![crate::document::DiscoveredBridgeRegion {
+                                language: "lua".to_string(),
+                                region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
+                                content: None,
+                            }]),
+                        )),
+                        resolved_regions: None,
+                        layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
+                    },
+                ))
+            })
+            .unwrap_or(false);
+        assert!(landed, "test publish must land");
+
+        assert!(
+            publisher
+                .current_region_offsets(&uri)
+                .is_some_and(|offsets| offsets.is_empty()),
+            "nothing routed: no region to anchor, and the answer is definitive"
+        );
+        // The fence content is the one region the query names; inline
+        // resolution would have minted its identity in the region layer.
+        let content = tree
+            .root_node()
+            .descendant_for_byte_range(8, 9)
+            .and_then(|node| {
+                let mut node = node;
+                while node.kind() != "code_fence_content" {
+                    node = node.parent()?;
+                }
+                Some(node)
+            })
+            .expect("the fence content node");
+        assert!(
+            server
+                .bridge
+                .node_tracker()
+                .lookup_in_layer(
+                    &uri,
+                    content.start_byte(),
+                    content.end_byte(),
+                    content.kind(),
+                    crate::language::injection::REGION_IDENTITY_LAYER_BASE,
+                )
+                .is_none(),
+            "a roster nothing routes must not be resolved inline"
+        );
+    }
+
     #[tokio::test]
     async fn current_region_offsets_distinguishes_unknown_from_absent_geometry() {
         let (service, _socket) = LspService::new(Kakehashi::new);

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -3620,6 +3620,51 @@ mod tests {
                 .is_none(),
             "a roster nothing routes must not be resolved inline"
         );
+
+        // The partner case: a roster whose regions carry content is a
+        // routed document, and the publisher still anchors its regions —
+        // the short-circuit reads the content, not the roster's presence.
+        let routed = Url::parse("file:///test/routed.md").unwrap();
+        let incarnation = server.documents.insert(
+            routed.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let content_version = server.documents.get(&routed).unwrap().content_version();
+        let landed = server
+            .documents
+            .get(&routed)
+            .map(|doc| {
+                doc.publish_snapshot(&std::sync::Arc::new(
+                    crate::document::snapshot::ParseSnapshot {
+                        text: std::sync::Arc::from(text),
+                        tree: Some(tree.clone()),
+                        language: Some("markdown".to_string()),
+                        parsed_version: content_version,
+                        incarnation,
+                        injection_regions: None,
+                        bridge_regions: Some((
+                            generation,
+                            std::sync::Arc::new(vec![crate::document::DiscoveredBridgeRegion {
+                                language: "lua".to_string(),
+                                region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
+                                content: Some("print(1)\n".to_string()),
+                            }]),
+                        )),
+                        resolved_regions: None,
+                        layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
+                    },
+                ))
+            })
+            .unwrap_or(false);
+        assert!(landed, "test publish must land");
+        assert!(
+            publisher
+                .current_region_offsets(&routed)
+                .is_some_and(|offsets| !offsets.is_empty()),
+            "a routed document's regions are anchored as before"
+        );
     }
 
     #[tokio::test]

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -1371,7 +1371,7 @@ mod tests {
             &server.bridge.node_tracker_arc(),
             server.bridge.node_tracker_arc().mint_epoch(&uri),
             incarnation,
-            true,
+            &|| true,
             &|_| true,
         );
         let populated = populated.expect("current pass populates");
@@ -1561,7 +1561,7 @@ mod tests {
                 &server.bridge.node_tracker_arc(),
                 server.bridge.node_tracker_arc().mint_epoch(&uri),
                 server.documents.get(&uri).unwrap().incarnation(),
-                true,
+                &|| true,
                 &|_| true,
             )
             .expect("current pass populates");

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -263,7 +263,7 @@ impl InjectionCoordinator {
     }
 
     /// Every region on the current snapshot's roster as `(region_id,
-    /// language, routed)` — routed iff the pass resolved it with content —
+    /// language, resolved)` — resolved iff the pass gave it content —
     /// when a populate pass published one under the current settings
     /// generation; `None` when the pass could not look or the regions are
     /// stale, so the caller derives both the languages owed a grammar and
@@ -398,12 +398,26 @@ impl InjectionCoordinator {
             .iter()
             .map(|(_, language, _)| language.clone())
             .collect();
-        // A region nothing routes any more says so explicitly: its old
-        // virtual document is taken whatever its language.
+        // A region is routed iff the pass gave it content AND a server
+        // handles its language under the current settings: a document one
+        // of whose regions is routed is resolved in full, so content alone
+        // does not say. A region nothing routes any more says so
+        // explicitly: its old virtual document is taken whatever its
+        // language.
+        let settings = self.settings_manager.load_settings();
+        let routed = |language: &str| {
+            !self
+                .bridge
+                .cached_configs_for_injection_language(&settings, &host_language, language)
+                .is_empty()
+        };
         let expected: Vec<(String, Option<String>)> = roster
             .iter()
-            .map(|(region_id, language, routed)| {
-                (region_id.clone(), routed.then(|| language.clone()))
+            .map(|(region_id, language, resolved)| {
+                (
+                    region_id.clone(),
+                    (*resolved && routed(language)).then(|| language.clone()),
+                )
             })
             .collect();
         if injections.is_empty() && languages.is_empty() {

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -1155,6 +1155,76 @@ mod tests {
         assert!(landed, "test publish must land");
     }
 
+    /// A document none of the runnable servers route publishes a roster:
+    /// its regions' languages and identities, no content, nothing to open.
+    /// The injection pass still owes those regions their injected grammar
+    /// — highlighting needs it whether or not a server does — so the pass
+    /// must schedule the grammar load from the roster instead of returning
+    /// at "nothing to route".
+    #[tokio::test]
+    async fn an_unrouted_document_still_loads_its_injected_grammars() {
+        let (service, _socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
+        let server = service.inner();
+        let language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("markdown".to_string(), language.clone());
+        let text = "```lua\nprint(1)\n```\n";
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&language)
+            .expect("load markdown grammar");
+        let tree = parser.parse(text, None).expect("parse markdown");
+        let uri = Url::parse("file:///unrouted_roster.md").unwrap();
+        let incarnation =
+            server
+                .documents
+                .insert(uri.clone(), text.to_string(), Some("markdown".into()), None);
+        let content_version = server.documents.get(&uri).unwrap().content_version();
+        let generation = server.cache.semantic_token_generation();
+        let roster = vec![crate::document::DiscoveredBridgeRegion {
+            language: "lua".to_string(),
+            region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
+            content: None,
+        }];
+        assert!(
+            server
+                .documents
+                .install_parse(
+                    &uri,
+                    crate::document::LanguageCheck::Expect(Some("markdown")),
+                    std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
+                        text: std::sync::Arc::from(text),
+                        tree: Some(tree),
+                        language: Some("markdown".to_string()),
+                        parsed_version: content_version,
+                        incarnation,
+                        injection_regions: None,
+                        bridge_regions: Some((generation, std::sync::Arc::new(roster))),
+                        resolved_regions: None,
+                        layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
+                    }),
+                )
+                .current
+        );
+        assert!(!server.language.has_parser_available("lua"));
+
+        server
+            .injection_coordinator()
+            .process_injections(&uri, false)
+            .await;
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while tokio::time::Instant::now() < deadline && !server.language.has_parser_available("lua")
+        {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert!(
+            server.language.has_parser_available("lua"),
+            "the roster's languages drive the injected-grammar load"
+        );
+    }
     /// The snapshot fast path of `resolve_injection_data` must produce
     /// exactly what the inline (live-tree) resolution produces — the fast
     /// path's output is forwarded verbatim to downstream servers, so a

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -165,12 +165,18 @@ impl InjectionCoordinator {
             // query would not discover. Mismatch falls back inline below.
             && *stamped_generation == self.cache.semantic_token_generation()
         {
+            // Only the regions a server handles carry content and are
+            // routed; the rest of the roster informs the injected-grammar
+            // install and the closing of virtual documents (see
+            // `injection_languages`).
             let regions = bridge_regions
                 .iter()
-                .map(|region| BridgeInjection {
-                    language: region.language.clone(),
-                    region_id: region.region_id.clone(),
-                    content: region.content.clone(),
+                .filter_map(|region| {
+                    region.content.as_ref().map(|content| BridgeInjection {
+                        language: region.language.clone(),
+                        region_id: region.region_id.clone(),
+                        content: content.clone(),
+                    })
                 })
                 .collect();
             return settled().then_some(regions);

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -279,7 +279,6 @@ impl InjectionCoordinator {
             let resolved = !regions.is_roster();
             regions
                 .identities()
-                .into_iter()
                 .map(|(language, region_id)| {
                     (region_id.to_string(), language.to_string(), resolved)
                 })

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -169,7 +169,7 @@ impl InjectionCoordinator {
             // carries content for every region and is routed; a document
             // none routes carries none, and its roster informs the
             // injected-grammar load and the closing of virtual documents
-            // (see `roster_languages`).
+            // (see `roster_regions`).
             let regions = bridge_regions
                 .iter()
                 .filter_map(|region| {
@@ -262,12 +262,12 @@ impl InjectionCoordinator {
         settled().then_some(resolved)
     }
 
-    /// The languages of every region on the current snapshot's roster —
-    /// routed or not — when a populate pass published one under the current
-    /// settings generation; `None` when the pass could not look or the
-    /// regions are stale, so the caller derives the languages from what it
-    /// resolved inline.
-    fn roster_languages(&self, uri: &Url) -> Option<HashSet<String>> {
+    /// Every region on the current snapshot's roster as `(region_id,
+    /// language)` — routed or not — when a populate pass published one under
+    /// the current settings generation; `None` when the pass could not look
+    /// or the regions are stale, so the caller derives both the languages
+    /// owed a grammar and the replacement set from what it resolved inline.
+    fn roster_regions(&self, uri: &Url) -> Option<Vec<(String, String)>> {
         let view = self.documents.latest_snapshot(uri)?;
         let snapshot = view.slot.snapshot?;
         if snapshot.parsed_version != view.content_version {
@@ -277,7 +277,7 @@ impl InjectionCoordinator {
         (*stamped_generation == self.cache.semantic_token_generation()).then(|| {
             roster
                 .iter()
-                .map(|region| region.language.clone())
+                .map(|region| (region.region_id.clone(), region.language.clone()))
                 .collect()
         })
     }
@@ -381,9 +381,16 @@ impl InjectionCoordinator {
         // or not — the roster a document nothing routes publishes carries
         // them without content — falling back to the routed regions when
         // the pass resolved inline.
-        let languages: HashSet<String> = self
-            .roster_languages(uri)
-            .unwrap_or_else(|| injections.iter().map(|inj| inj.language.clone()).collect());
+        let roster = self.roster_regions(uri).unwrap_or_else(|| {
+            injections
+                .iter()
+                .map(|inj| (inj.region_id.clone(), inj.language.clone()))
+                .collect()
+        });
+        let languages: HashSet<String> = roster
+            .iter()
+            .map(|(_, language)| language.clone())
+            .collect();
         if injections.is_empty() && languages.is_empty() {
             self.bridge.cancel_eager_open(uri);
             return true;
@@ -392,11 +399,11 @@ impl InjectionCoordinator {
         // Stop the previous pass before closing a replaced language-bearing URI;
         // otherwise an old eager task can enqueue didOpen after the close and
         // resurrect the stale URI. The new batch is created below after cleanup.
-        // With nothing routed, a virtual document a region used to have is one
-        // to close: the replaced set is judged against the routed regions, so
-        // an unrouted document closes them all.
+        // Judged against every live region's language — the roster's when
+        // current — so a region that stopped being routed closes the
+        // virtual document it used to have.
         self.bridge.cancel_eager_open(uri);
-        let replaced_regions = self.bridge.close_replaced_docs(uri, &injections).await;
+        let replaced_regions = self.bridge.close_replaced_docs(uri, &roster).await;
         for region_id in replaced_regions {
             self.diagnostics
                 .evict_source(uri, &DiagnosticSource::Region(region_id));

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -1249,6 +1249,7 @@ mod tests {
             server.bridge.node_tracker_arc().mint_epoch(&uri),
             incarnation,
             true,
+            &|_| true,
         );
         let populated = populated.expect("current pass populates");
         let bridge_regions = populated.bridge_regions.expect("gate was true");
@@ -1438,6 +1439,7 @@ mod tests {
                 server.bridge.node_tracker_arc().mint_epoch(&uri),
                 server.documents.get(&uri).unwrap().incarnation(),
                 true,
+                &|_| true,
             )
             .expect("current pass populates");
         let bridge_regions = populated.bridge_regions.expect("gate was true");

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -1309,6 +1309,132 @@ mod tests {
             "the roster's languages drive the injected-grammar load"
         );
     }
+    /// A mixed document — one region a server handles, one nothing routes —
+    /// is resolved in full, so every region carries content; the region
+    /// nothing routes must still lose the virtual document it used to
+    /// have (a reload narrowed the server's languages), while the routed
+    /// region keeps its own.
+    #[tokio::test]
+    async fn a_region_nothing_routes_loses_its_virtual_document_beside_a_routed_one() {
+        use crate::config::WorkspaceSettings;
+        use crate::config::settings::BridgeServerConfig;
+        use crate::lsp::bridge::ConnectionKey;
+        use crate::lsp::bridge::VirtualDocumentUri;
+        use tower_lsp_server::ls_types::{DidOpenTextDocumentParams, TextDocumentItem};
+
+        let (service, mut socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
+        tokio::spawn(async move {
+            use futures::StreamExt;
+            while socket.next().await.is_some() {}
+        });
+        let server = service.inner();
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("markdown".to_string(), tree_sitter_md::LANGUAGE.into());
+        let markdown_language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let injection_query = tree_sitter::Query::new(
+            &markdown_language,
+            r#"
+            (fenced_code_block
+              (info_string
+                (language) @injection.language)
+              (code_fence_content) @injection.content)
+            "#,
+        )
+        .expect("valid markdown injection query");
+        server
+            .language
+            .query_store()
+            .insert_injection_query("markdown".to_string(), Arc::new(injection_query));
+        let mut language_servers = std::collections::HashMap::new();
+        language_servers.insert(
+            "python-bridge".to_string(),
+            BridgeServerConfig {
+                cmd: Some(vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    "cat > /dev/null".to_string(),
+                ]),
+                languages: Some(vec!["python".to_string()]),
+                initialization_options: None,
+                workspace_markers: None,
+                on_type_formatting_triggers: None,
+                prefer_shared_instance: None,
+                force_start: None,
+                enabled: None,
+                settings: None,
+            },
+        );
+        server.settings_manager.apply_settings(WorkspaceSettings {
+            auto_install: false,
+            language_servers,
+            ..Default::default()
+        });
+        server
+            .bridge
+            .insert_ready_test_connection("python-bridge")
+            .await;
+
+        let uri = Url::parse("file:///test/mixed_routing.md").expect("valid test URI");
+        let lsp_uri = crate::lsp::lsp_impl::url_to_uri(&uri).expect("URI should convert");
+        let text = "```py\nprint(1)\n```\n\n```lua\nprint(1)\n```\n";
+        server
+            .did_open_impl(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: lsp_uri.clone(),
+                    language_id: "markdown".to_string(),
+                    version: 1,
+                    text: text.to_string(),
+                },
+            })
+            .await;
+        let roster = || {
+            server
+                .documents
+                .latest_snapshot(&uri)
+                .and_then(|view| view.slot.snapshot)
+                .and_then(|snapshot| snapshot.bridge_regions.as_ref().map(|(_, r)| Arc::clone(r)))
+                .filter(|roster| roster.iter().all(|region| region.content.is_some()))
+        };
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while tokio::time::Instant::now() < deadline && roster().is_none() {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        let roster = roster().expect("the mixed document is resolved in full");
+        let region_id = |language: &str| {
+            roster
+                .iter()
+                .find(|region| region.language == language)
+                .map(|region| region.region_id.clone())
+                .unwrap_or_else(|| panic!("a {language} region on the roster"))
+        };
+        let lua_uri = VirtualDocumentUri::new(&lsp_uri, "lua", &region_id("lua"));
+        let python_uri = VirtualDocumentUri::new(&lsp_uri, "python", &region_id("python"));
+        let connection = ConnectionKey::for_server("python-bridge");
+        server
+            .bridge
+            .register_opened_document_for_test(&uri, &lua_uri, &connection)
+            .await;
+        server
+            .bridge
+            .register_opened_document_for_test(&uri, &python_uri, &connection)
+            .await;
+
+        server
+            .injection_coordinator()
+            .process_injections(&uri, false)
+            .await;
+
+        assert!(
+            !server.bridge.pool().is_document_opened(&lua_uri),
+            "no server handles lua: its virtual document is taken"
+        );
+        assert!(
+            server.bridge.pool().is_document_opened(&python_uri),
+            "python-bridge handles python: its virtual document stays"
+        );
+    }
     /// The snapshot fast path of `resolve_injection_data` must produce
     /// exactly what the inline (live-tree) resolution produces — the fast
     /// path's output is forwarded verbatim to downstream servers, so a

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -266,6 +266,26 @@ impl InjectionCoordinator {
     ///
     /// Resolves injection data once and reuses it across all three steps. Must be
     /// called AFTER parse_document so the AST is available.
+    /// The languages of every region on the current snapshot's roster —
+    /// routed or not — when a populate pass published one under the current
+    /// settings generation; `None` when the pass could not look or the
+    /// regions are stale, so the caller derives the languages from what it
+    /// resolved inline.
+    fn roster_languages(&self, uri: &Url) -> Option<HashSet<String>> {
+        let view = self.documents.latest_snapshot(uri)?;
+        let snapshot = view.slot.snapshot?;
+        if snapshot.parsed_version != view.content_version {
+            return None;
+        }
+        let (stamped_generation, roster) = snapshot.bridge_regions.as_ref()?;
+        (*stamped_generation == self.cache.semantic_token_generation()).then(|| {
+            roster
+                .iter()
+                .map(|region| region.language.clone())
+                .collect()
+        })
+    }
+
     pub(crate) async fn process_injections(&self, uri: &Url, forward_did_change: bool) {
         let _ = self
             .process_injections_after_lifecycle_lock(
@@ -356,7 +376,14 @@ impl InjectionCoordinator {
             self.documents.remove_edit_lock_if_unshared(uri, &edit_lock);
             return true;
         };
-        if injections.is_empty() {
+        // The languages owed an injected grammar: every region's, routed
+        // or not — the roster a document nothing routes publishes carries
+        // them without content — falling back to the routed regions when
+        // the pass resolved inline.
+        let languages: HashSet<String> = self
+            .roster_languages(uri)
+            .unwrap_or_else(|| injections.iter().map(|inj| inj.language.clone()).collect());
+        if injections.is_empty() && languages.is_empty() {
             self.bridge.cancel_eager_open(uri);
             return true;
         }
@@ -364,6 +391,9 @@ impl InjectionCoordinator {
         // Stop the previous pass before closing a replaced language-bearing URI;
         // otherwise an old eager task can enqueue didOpen after the close and
         // resurrect the stale URI. The new batch is created below after cleanup.
+        // With nothing routed, a virtual document a region used to have is one
+        // to close: the replaced set is judged against the routed regions, so
+        // an unrouted document closes them all.
         self.bridge.cancel_eager_open(uri);
         let replaced_regions = self.bridge.close_replaced_docs(uri, &injections).await;
         for region_id in replaced_regions {
@@ -376,9 +406,6 @@ impl InjectionCoordinator {
                 .forward_didchange_to_opened_docs(uri, incarnation, &injections)
                 .await;
         }
-
-        let languages: HashSet<String> =
-            injections.iter().map(|inj| inj.language.clone()).collect();
 
         // Re-home the injected-language parser install OFF this task (#480 liveness;
         // the parse-actor ADR's "PR-3"). When a region's injected language has no
@@ -408,6 +435,10 @@ impl InjectionCoordinator {
             }
         };
         tokio::spawn(install_task);
+        if injections.is_empty() {
+            // Nothing to route: the grammar load above is all the pass owes.
+            return true;
+        }
 
         // Routing may need to wait for a downstream provider to become ready.
         // Keep that wait out of the lifecycle pass: the pass must release its
@@ -1163,7 +1194,22 @@ mod tests {
     /// at "nothing to route".
     #[tokio::test]
     async fn an_unrouted_document_still_loads_its_injected_grammars() {
-        let (service, _socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
+        let (service, mut socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
+        // What the server tells the client: a grammar it could not load is
+        // reported there, so the load is observable whether it succeeds
+        // (the parser becomes available) or is refused (the report names it).
+        let told = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        {
+            let told = std::sync::Arc::clone(&told);
+            tokio::spawn(async move {
+                use futures::StreamExt;
+                while let Some(request) = socket.next().await {
+                    told.lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .push(format!("{request:?}"));
+                }
+            });
+        }
         let server = service.inner();
         let language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
         server
@@ -1215,13 +1261,20 @@ mod tests {
             .process_injections(&uri, false)
             .await;
 
+        let attempted = || {
+            server.language.has_parser_available("lua")
+                || told
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .iter()
+                    .any(|message| message.contains("lua"))
+        };
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
-        while tokio::time::Instant::now() < deadline && !server.language.has_parser_available("lua")
-        {
+        while tokio::time::Instant::now() < deadline && !attempted() {
             tokio::time::sleep(std::time::Duration::from_millis(5)).await;
         }
         assert!(
-            server.language.has_parser_available("lua"),
+            attempted(),
             "the roster's languages drive the injected-grammar load"
         );
     }

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -165,10 +165,11 @@ impl InjectionCoordinator {
             // query would not discover. Mismatch falls back inline below.
             && *stamped_generation == self.cache.semantic_token_generation()
         {
-            // Only the regions a server handles carry content and are
-            // routed; the rest of the roster informs the injected-grammar
-            // install and the closing of virtual documents (see
-            // `injection_languages`).
+            // A document one of whose region languages a server handles
+            // carries content for every region and is routed; a document
+            // none routes carries none, and its roster informs the
+            // injected-grammar load and the closing of virtual documents
+            // (see `roster_languages`).
             let regions = bridge_regions
                 .iter()
                 .filter_map(|region| {
@@ -261,11 +262,6 @@ impl InjectionCoordinator {
         settled().then_some(resolved)
     }
 
-    /// Process injected languages: resolve injection data, optionally forward didChange,
-    /// auto-install missing parsers, and eagerly open virtual documents.
-    ///
-    /// Resolves injection data once and reuses it across all three steps. Must be
-    /// called AFTER parse_document so the AST is available.
     /// The languages of every region on the current snapshot's roster —
     /// routed or not — when a populate pass published one under the current
     /// settings generation; `None` when the pass could not look or the
@@ -286,6 +282,11 @@ impl InjectionCoordinator {
         })
     }
 
+    /// Process injected languages: resolve injection data, optionally forward didChange,
+    /// auto-install missing parsers, and eagerly open virtual documents.
+    ///
+    /// Resolves injection data once and reuses it across all three steps. Must be
+    /// called AFTER parse_document so the AST is available.
     pub(crate) async fn process_injections(&self, uri: &Url, forward_did_change: bool) {
         let _ = self
             .process_injections_after_lifecycle_lock(
@@ -1211,6 +1212,14 @@ mod tests {
             });
         }
         let server = service.inner();
+        // No auto-install: the load either succeeds from the test data
+        // directory or is reported as a missing parser, never a download.
+        server
+            .settings_manager
+            .apply_settings(crate::config::WorkspaceSettings {
+                auto_install: false,
+                ..Default::default()
+            });
         let language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
         server
             .language
@@ -1267,7 +1276,7 @@ mod tests {
                     .lock()
                     .unwrap_or_else(|e| e.into_inner())
                     .iter()
-                    .any(|message| message.contains("lua"))
+                    .any(|message| message.contains("'lua'"))
         };
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
         while tokio::time::Instant::now() < deadline && !attempted() {

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -165,21 +165,21 @@ impl InjectionCoordinator {
             // query would not discover. Mismatch falls back inline below.
             && *stamped_generation == self.cache.semantic_token_generation()
         {
-            // A document one of whose region languages a server handles
-            // carries content for every region and is routed; a document
-            // none routes carries none, and its roster informs the
-            // injected-grammar load and the closing of virtual documents
-            // (see `roster_regions`).
-            let regions = bridge_regions
-                .iter()
-                .filter_map(|region| {
-                    region.content.as_ref().map(|content| BridgeInjection {
+            // A document one of whose region languages a server handles is
+            // resolved with content for every region; a document none
+            // routes publishes a roster, which routes nothing — it informs
+            // the injected-grammar load and the closing of virtual
+            // documents instead (see `roster_regions`).
+            let regions = bridge_regions.resolved().map_or_else(Vec::new, |regions| {
+                regions
+                    .iter()
+                    .map(|region| BridgeInjection {
                         language: region.language.clone(),
                         region_id: region.region_id.clone(),
-                        content: content.clone(),
+                        content: region.content.clone(),
                     })
-                })
-                .collect();
+                    .collect()
+            });
             return settled().then_some(regions);
         }
 
@@ -262,8 +262,8 @@ impl InjectionCoordinator {
         settled().then_some(resolved)
     }
 
-    /// Every region on the current snapshot's roster as `(region_id,
-    /// language, resolved)` — resolved iff the pass gave it content —
+    /// Every region on the current snapshot's bridge regions as `(region_id,
+    /// language, resolved)` — resolved iff the pass resolved the document —
     /// when a populate pass published one under the current settings
     /// generation; `None` when the pass could not look or the regions are
     /// stale, so the caller derives both the languages owed a grammar and
@@ -274,16 +274,14 @@ impl InjectionCoordinator {
         if snapshot.parsed_version != view.content_version {
             return None;
         }
-        let (stamped_generation, roster) = snapshot.bridge_regions.as_ref()?;
+        let (stamped_generation, regions) = snapshot.bridge_regions.as_ref()?;
         (*stamped_generation == self.cache.semantic_token_generation()).then(|| {
-            roster
-                .iter()
-                .map(|region| {
-                    (
-                        region.region_id.clone(),
-                        region.language.clone(),
-                        region.content.is_some(),
-                    )
+            let resolved = !regions.is_roster();
+            regions
+                .identities()
+                .into_iter()
+                .map(|(language, region_id)| {
+                    (region_id.to_string(), language.to_string(), resolved)
                 })
                 .collect()
         })
@@ -1274,11 +1272,12 @@ mod tests {
                 .insert(uri.clone(), text.to_string(), Some("markdown".into()), None);
         let content_version = server.documents.get(&uri).unwrap().content_version();
         let generation = server.cache.semantic_token_generation();
-        let roster = vec![crate::document::DiscoveredBridgeRegion {
-            language: "lua".to_string(),
-            region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
-            content: None,
-        }];
+        let roster = crate::document::BridgeRegions::Roster(std::sync::Arc::new(vec![
+            crate::document::BridgeRosterRegion {
+                language: "lua".to_string(),
+                region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
+            },
+        ]));
         assert!(
             server
                 .documents
@@ -1292,7 +1291,7 @@ mod tests {
                         parsed_version: content_version,
                         incarnation,
                         injection_regions: None,
-                        bridge_regions: Some((generation, std::sync::Arc::new(roster))),
+                        bridge_regions: Some((generation, roster)),
                         resolved_regions: None,
                         layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     }),
@@ -1408,8 +1407,12 @@ mod tests {
                 .documents
                 .latest_snapshot(&uri)
                 .and_then(|view| view.slot.snapshot)
-                .and_then(|snapshot| snapshot.bridge_regions.as_ref().map(|(_, r)| Arc::clone(r)))
-                .filter(|roster| roster.iter().all(|region| region.content.is_some()))
+                .and_then(|snapshot| {
+                    snapshot
+                        .bridge_regions
+                        .as_ref()
+                        .and_then(|(_, regions)| regions.resolved().map(<[_]>::to_vec))
+                })
         };
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
         while tokio::time::Instant::now() < deadline && roster().is_none() {
@@ -1552,7 +1555,7 @@ mod tests {
             .update_document(uri.clone(), text.to_string(), None);
         let content_version = server.documents.get(&uri).unwrap().content_version();
         publish(
-            Some((populated.generation, std::sync::Arc::new(bridge_regions))),
+            Some((populated.generation, bridge_regions)),
             content_version,
         );
         let fast = injection
@@ -1758,10 +1761,7 @@ mod tests {
                         parsed_version: content_version,
                         incarnation,
                         injection_regions: None,
-                        bridge_regions: Some((
-                            populated.generation,
-                            std::sync::Arc::new(bridge_regions),
-                        )),
+                        bridge_regions: Some((populated.generation, bridge_regions)),
                         resolved_regions: None,
                         layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
                     },

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -263,11 +263,12 @@ impl InjectionCoordinator {
     }
 
     /// Every region on the current snapshot's roster as `(region_id,
-    /// language)` — routed or not — when a populate pass published one under
-    /// the current settings generation; `None` when the pass could not look
-    /// or the regions are stale, so the caller derives both the languages
-    /// owed a grammar and the replacement set from what it resolved inline.
-    fn roster_regions(&self, uri: &Url) -> Option<Vec<(String, String)>> {
+    /// language, routed)` — routed iff the pass resolved it with content —
+    /// when a populate pass published one under the current settings
+    /// generation; `None` when the pass could not look or the regions are
+    /// stale, so the caller derives both the languages owed a grammar and
+    /// the replacement set from what it resolved inline.
+    fn roster_regions(&self, uri: &Url) -> Option<Vec<(String, String, bool)>> {
         let view = self.documents.latest_snapshot(uri)?;
         let snapshot = view.slot.snapshot?;
         if snapshot.parsed_version != view.content_version {
@@ -277,7 +278,13 @@ impl InjectionCoordinator {
         (*stamped_generation == self.cache.semantic_token_generation()).then(|| {
             roster
                 .iter()
-                .map(|region| (region.region_id.clone(), region.language.clone()))
+                .map(|region| {
+                    (
+                        region.region_id.clone(),
+                        region.language.clone(),
+                        region.content.is_some(),
+                    )
+                })
                 .collect()
         })
     }
@@ -384,12 +391,20 @@ impl InjectionCoordinator {
         let roster = self.roster_regions(uri).unwrap_or_else(|| {
             injections
                 .iter()
-                .map(|inj| (inj.region_id.clone(), inj.language.clone()))
+                .map(|inj| (inj.region_id.clone(), inj.language.clone(), true))
                 .collect()
         });
         let languages: HashSet<String> = roster
             .iter()
-            .map(|(_, language)| language.clone())
+            .map(|(_, language, _)| language.clone())
+            .collect();
+        // A region nothing routes any more says so explicitly: its old
+        // virtual document is taken whatever its language.
+        let expected: Vec<(String, Option<String>)> = roster
+            .iter()
+            .map(|(region_id, language, routed)| {
+                (region_id.clone(), routed.then(|| language.clone()))
+            })
             .collect();
         if injections.is_empty() && languages.is_empty() {
             self.bridge.cancel_eager_open(uri);
@@ -403,7 +418,7 @@ impl InjectionCoordinator {
         // current — so a region that stopped being routed closes the
         // virtual document it used to have.
         self.bridge.cancel_eager_open(uri);
-        let replaced_regions = self.bridge.close_replaced_docs(uri, &roster).await;
+        let replaced_regions = self.bridge.close_replaced_docs(uri, &expected).await;
         for region_id in replaced_regions {
             self.diagnostics
                 .evict_source(uri, &DiagnosticSource::Region(region_id));

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -73,10 +73,7 @@ impl InstallCheck {
 #[derive(Default)]
 struct PopulatedSnapshotRegions {
     discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
-    bridge_regions: Option<(
-        u64,
-        std::sync::Arc<Vec<crate::document::DiscoveredBridgeRegion>>,
-    )>,
+    bridge_regions: Option<(u64, crate::document::BridgeRegions)>,
     resolved_regions: Option<(
         u64,
         std::sync::Arc<Vec<crate::language::injection::ResolvedInjection>>,
@@ -502,7 +499,7 @@ impl ParseCoordinator {
                         discovery: populated.discovery,
                         bridge_regions: populated
                             .bridge_regions
-                            .map(|regions| (populated.generation, std::sync::Arc::new(regions))),
+                            .map(|regions| (populated.generation, regions)),
                         resolved_regions: populated
                             .resolved_regions
                             .map(|regions| (populated.generation, std::sync::Arc::new(regions))),

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -419,8 +419,7 @@ impl ParseCoordinator {
                 ),
             );
         };
-        let settings = self.settings_manager.load_settings();
-        let build_bridge_regions = settings.any_bridge_server_runnable();
+        let settings_manager = std::sync::Arc::clone(&self.settings_manager);
         let bridge = std::sync::Arc::clone(&self.bridge);
         let pool_uri = uri.clone();
         // The first install's verdict lives outside the work-unit too, so a
@@ -436,6 +435,8 @@ impl ParseCoordinator {
             let check = std::sync::Arc::clone(&check);
             let first = std::sync::Arc::clone(&first);
             move |cancel_for_work| {
+                let settings_cell = std::sync::OnceLock::new();
+                let settings = || settings_cell.get_or_init(|| settings_manager.load_settings());
                 let populated = cache.populate_injections_cancellable(
                     &pool_uri,
                     &inputs.text,
@@ -445,7 +446,11 @@ impl ParseCoordinator {
                     &tracker,
                     entry_mint_epoch,
                     inputs.incarnation,
-                    build_bridge_regions,
+                    // The settings are loaded on first use, i.e. after the
+                    // pass has taken its generation stamp: settings a reload
+                    // publishes in between then pair with a stamp the
+                    // stamp-checking readers reject, never the other way.
+                    &|| settings().any_bridge_server_runnable(),
                     // The routing rule the bridge itself applies to a region
                     // (host filter, spawnable command, `languages` list with
                     // its wildcard), asked with the canonical language it
@@ -455,7 +460,7 @@ impl ParseCoordinator {
                     &|canonical: &str| {
                         !bridge
                             .cached_configs_for_injection_language(
-                                &settings,
+                                settings(),
                                 &inputs.language_name,
                                 canonical,
                             )

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -447,6 +447,7 @@ impl ParseCoordinator {
                     entry_mint_epoch,
                     inputs.incarnation,
                     build_bridge_regions,
+                    &|_| true,
                     &mut |discovered| {
                         log::trace!(
                             target: "kakehashi::parse",

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -419,10 +419,9 @@ impl ParseCoordinator {
                 ),
             );
         };
-        let build_bridge_regions = self
-            .settings_manager
-            .load_settings()
-            .any_bridge_server_runnable();
+        let settings = self.settings_manager.load_settings();
+        let build_bridge_regions = settings.any_bridge_server_runnable();
+        let bridge = std::sync::Arc::clone(&self.bridge);
         let pool_uri = uri.clone();
         // The first install's verdict lives outside the work-unit too, so a
         // panic after the hand-off cannot lose a publish that already landed.
@@ -447,7 +446,21 @@ impl ParseCoordinator {
                     entry_mint_epoch,
                     inputs.incarnation,
                     build_bridge_regions,
-                    &|_| true,
+                    // The routing rule the bridge itself applies to a region
+                    // (host filter, spawnable command, `languages` list with
+                    // its wildcard), asked with the canonical language it
+                    // routes on and memoized per (host, language) pair, so
+                    // populate resolves exactly the documents the bridge
+                    // would route.
+                    &|canonical: &str| {
+                        !bridge
+                            .cached_configs_for_injection_language(
+                                &settings,
+                                &inputs.language_name,
+                                canonical,
+                            )
+                            .is_empty()
+                    },
                     &mut |discovered| {
                         log::trace!(
                             target: "kakehashi::parse",

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -1099,6 +1099,109 @@ mod tests {
         assert_ne!(id, diagnostic_result_id(&shrunk));
     }
 
+    /// The editor pulls diagnostics after every change. A document whose
+    /// roster nothing routes (every region listed, none with content) has
+    /// no virt region to ask a server about, and the pull must take that
+    /// answer from the roster instead of resolving every region inline —
+    /// minting region identity and paying, on every pull, the resolution
+    /// the parse path declined.
+    #[tokio::test]
+    async fn a_pull_takes_an_unrouted_roster_without_resolving() {
+        let (service, _socket) = tower_lsp_server::LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let query = tree_sitter::Query::new(
+            &language,
+            "(fenced_code_block (info_string (language) @injection.language) \
+             (code_fence_content) @injection.content)",
+        )
+        .expect("valid markdown injection query");
+        server
+            .language
+            .query_store()
+            .insert_injection_query("markdown".to_string(), std::sync::Arc::new(query));
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("markdown".to_string(), language.clone());
+        let uri = Url::parse("file:///test/unrouted_pull.md").unwrap();
+        let text = "```lua\nprint(1)\n```\n";
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&language).unwrap();
+        let tree = parser.parse(text, None).unwrap();
+        let incarnation = server.documents.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let content_version = server.documents.get(&uri).unwrap().content_version();
+        let generation = server.cache.semantic_token_generation();
+        assert!(
+            server
+                .documents
+                .install_parse(
+                    &uri,
+                    crate::document::LanguageCheck::Expect(Some("markdown")),
+                    std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
+                        text: std::sync::Arc::from(text),
+                        tree: Some(tree.clone()),
+                        language: Some("markdown".to_string()),
+                        parsed_version: content_version,
+                        incarnation,
+                        injection_regions: None,
+                        bridge_regions: Some((
+                            generation,
+                            std::sync::Arc::new(vec![crate::document::DiscoveredBridgeRegion {
+                                language: "lua".to_string(),
+                                region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
+                                content: None,
+                            }]),
+                        )),
+                        resolved_regions: None,
+                        layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
+                    }),
+                )
+                .current
+        );
+
+        let params = DocumentDiagnosticParams {
+            text_document: tower_lsp_server::ls_types::TextDocumentIdentifier {
+                uri: "file:///test/unrouted_pull.md".parse().expect("uri"),
+            },
+            identifier: None,
+            previous_result_id: None,
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        };
+        let _ = server.diagnostic_impl(params).await;
+
+        let content = {
+            let mut node = tree
+                .root_node()
+                .descendant_for_byte_range(8, 9)
+                .expect("a node covers the fence content");
+            while node.kind() != "code_fence_content" {
+                node = node.parent().expect("the fence content encloses it");
+            }
+            node
+        };
+        assert!(
+            server
+                .bridge
+                .node_tracker()
+                .lookup_in_layer(
+                    &uri,
+                    content.start_byte(),
+                    content.end_byte(),
+                    content.kind(),
+                    crate::language::injection::REGION_IDENTITY_LAYER_BASE,
+                )
+                .is_none(),
+            "a roster nothing routes must not be resolved inline by a pull"
+        );
+    }
+
     #[tokio::test]
     async fn degraded_pull_does_not_mark_the_change_served() {
         // The pull-side sibling of republish's geometry deferral: when the

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -203,6 +203,19 @@ impl Kakehashi {
                 .language
                 .injection_query(&language_name)
                 .map(|injection_query| {
+                    // A roster nothing routes (every region listed, none
+                    // with content: no runnable server handles any of their
+                    // languages) has no virt region to ask about — taken
+                    // from the roster, not resolved inline on every pull.
+                    // Generation-stamped, so a reload that configures a
+                    // server resolves inline below.
+                    if self
+                        .documents
+                        .current_bridge_regions(&uri, self.cache.semantic_token_generation())
+                        .is_some_and(|roster| roster.iter().all(|region| region.content.is_none()))
+                    {
+                        return std::sync::Arc::new(Vec::new());
+                    }
                     match self
                         .documents
                         .current_resolved_regions(&uri, self.cache.semantic_token_generation())

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -212,7 +212,7 @@ impl Kakehashi {
                     if self
                         .documents
                         .current_bridge_regions(&uri, self.cache.semantic_token_generation())
-                        .is_some_and(|roster| roster.iter().all(|region| region.content.is_none()))
+                        .is_some_and(|regions| regions.is_roster())
                     {
                         return std::sync::Arc::new(Vec::new());
                     }
@@ -1165,11 +1165,12 @@ mod tests {
                         injection_regions: None,
                         bridge_regions: Some((
                             generation,
-                            std::sync::Arc::new(vec![crate::document::DiscoveredBridgeRegion {
-                                language: "lua".to_string(),
-                                region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
-                                content: None,
-                            }]),
+                            crate::document::BridgeRegions::Roster(std::sync::Arc::new(vec![
+                                crate::document::BridgeRosterRegion {
+                                    language: "lua".to_string(),
+                                    region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
+                                },
+                            ])),
                         )),
                         resolved_regions: None,
                         layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -517,13 +517,6 @@ mod tests {
         );
     }
 
-    /// A parse publishes twice per version: the tree with its discovery as
-    /// soon as populate hands them out — releasing every reader parked on
-    /// the cell, the token readers above all — and the same version again,
-    /// upgraded with the bridge / resolved regions, once the resolution the
-    /// bridge consumes has run. With the resolution held, the first publish
-    /// is observable on its own: current, tree-bearing, regions absent, and
-    /// a token wait already returns it.
     /// The open parse resolves a document's regions only when the bridge's
     /// own routing rule (host filter, spawnable command, `languages` list)
     /// gives one of its region languages a server — judged on the canonical
@@ -652,6 +645,13 @@ mod tests {
         );
     }
 
+    /// A parse publishes twice per version: the tree with its discovery as
+    /// soon as populate hands them out — releasing every reader parked on
+    /// the cell, the token readers above all — and the same version again,
+    /// upgraded with the bridge / resolved regions, once the resolution the
+    /// bridge consumes has run. With the resolution held, the first publish
+    /// is observable on its own: current, tree-bearing, regions absent, and
+    /// a token wait already returns it.
     #[tokio::test]
     async fn did_open_publishes_the_tree_before_the_regions_are_resolved() {
         let (service, mut socket) = LspService::new(Kakehashi::new);

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -721,7 +721,7 @@ mod tests {
                         snapshot
                             .bridge_regions
                             .as_ref()
-                            .map(|(_, r)| r.identities().len()),
+                            .map(|(_, r)| r.identities().count()),
                         snapshot.resolved_regions.as_ref().map(|(_, r)| r.len()),
                     ))
             })

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -596,11 +596,12 @@ mod tests {
                 .and_then(|view| view.slot.snapshot)
                 .filter(|snapshot| snapshot.tree.is_some())
                 .and_then(|snapshot| {
-                    let (_, roster) = snapshot.bridge_regions.as_ref()?;
+                    let (_, regions) = snapshot.bridge_regions.as_ref()?;
                     Some((
-                        roster
-                            .iter()
-                            .map(|region| (region.language.clone(), region.content.is_some()))
+                        regions
+                            .identities()
+                            .into_iter()
+                            .map(|(language, _)| (language.to_string(), !regions.is_roster()))
                             .collect::<Vec<_>>(),
                         snapshot.resolved_regions.is_some(),
                     ))
@@ -717,7 +718,10 @@ mod tests {
                 let snapshot = view.slot.snapshot?;
                 (snapshot.parsed_version == view.content_version && snapshot.tree.is_some())
                     .then_some((
-                        snapshot.bridge_regions.as_ref().map(|(_, r)| r.len()),
+                        snapshot
+                            .bridge_regions
+                            .as_ref()
+                            .map(|(_, r)| r.identities().len()),
                         snapshot.resolved_regions.as_ref().map(|(_, r)| r.len()),
                     ))
             })

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -600,7 +600,6 @@ mod tests {
                     Some((
                         regions
                             .identities()
-                            .into_iter()
                             .map(|(language, _)| (language.to_string(), !regions.is_roster()))
                             .collect::<Vec<_>>(),
                         snapshot.resolved_regions.is_some(),

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -524,6 +524,134 @@ mod tests {
     /// bridge consumes has run. With the resolution held, the first publish
     /// is observable on its own: current, tree-bearing, regions absent, and
     /// a token wait already returns it.
+    /// The open parse resolves a document's regions only when the bridge's
+    /// own routing rule (host filter, spawnable command, `languages` list)
+    /// gives one of its region languages a server — judged on the canonical
+    /// language the bridge routes on, so a ```` ```py ```` fence is a
+    /// `python` region. A document nothing routes publishes its roster
+    /// (language and identity, no content) and no resolved regions. Pinned
+    /// at the parse coordinator so the gate cannot drift from the routing
+    /// the bridge applies when it opens virtual documents.
+    #[tokio::test]
+    async fn did_open_resolves_regions_only_for_a_language_a_server_handles() {
+        let (service, mut socket) = LspService::new(Kakehashi::new);
+        tokio::spawn(async move {
+            use futures::StreamExt;
+            while socket.next().await.is_some() {}
+        });
+        let server = service.inner();
+
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("markdown".to_string(), tree_sitter_md::LANGUAGE.into());
+        let markdown_language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let injection_query = Query::new(
+            &markdown_language,
+            r#"
+            (fenced_code_block
+              (info_string
+                (language) @injection.language)
+              (code_fence_content) @injection.content)
+            "#,
+        )
+        .expect("valid markdown injection query");
+        server
+            .language
+            .query_store()
+            .insert_injection_query("markdown".to_string(), std::sync::Arc::new(injection_query));
+
+        let mut language_servers = HashMap::new();
+        language_servers.insert(
+            "python-bridge".to_string(),
+            BridgeServerConfig {
+                cmd: Some(vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    "cat > /dev/null".to_string(),
+                ]),
+                languages: Some(vec!["python".to_string()]),
+                initialization_options: None,
+                workspace_markers: None,
+                on_type_formatting_triggers: None,
+                prefer_shared_instance: None,
+                force_start: None,
+                enabled: None,
+                settings: None,
+            },
+        );
+        server.settings_manager.apply_settings(WorkspaceSettings {
+            auto_install: false,
+            language_servers,
+            ..Default::default()
+        });
+        server
+            .bridge
+            .insert_ready_test_connection("python-bridge")
+            .await;
+
+        let open = |path: &str, fence: &str| {
+            let uri = Url::parse(path).expect("valid test URI");
+            let lsp_uri = crate::lsp::lsp_impl::url_to_uri(&uri).expect("URI should convert");
+            let text = format!("# Example\n\n```{fence}\nprint(1)\n```\n");
+            (uri, lsp_uri, text)
+        };
+        let regions_of = |uri: &Url| {
+            server
+                .documents
+                .latest_snapshot(uri)
+                .and_then(|view| view.slot.snapshot)
+                .filter(|snapshot| snapshot.tree.is_some())
+                .and_then(|snapshot| {
+                    let (_, roster) = snapshot.bridge_regions.as_ref()?;
+                    Some((
+                        roster
+                            .iter()
+                            .map(|region| (region.language.clone(), region.content.is_some()))
+                            .collect::<Vec<_>>(),
+                        snapshot.resolved_regions.is_some(),
+                    ))
+                })
+        };
+
+        let (unrouted, unrouted_lsp, unrouted_text) =
+            open("file:///test/resolve_gate_unrouted.md", "lua");
+        server
+            .did_open_impl(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: unrouted_lsp,
+                    language_id: "markdown".to_string(),
+                    version: 1,
+                    text: unrouted_text,
+                },
+            })
+            .await;
+        wait_until(|| regions_of(&unrouted).is_some()).await;
+        assert_eq!(
+            regions_of(&unrouted),
+            Some((vec![("lua".to_string(), false)], false)),
+            "no server handles lua: on the roster, nothing resolved"
+        );
+
+        let (routed, routed_lsp, routed_text) = open("file:///test/resolve_gate_routed.md", "py");
+        server
+            .did_open_impl(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: routed_lsp,
+                    language_id: "markdown".to_string(),
+                    version: 1,
+                    text: routed_text,
+                },
+            })
+            .await;
+        wait_until(|| regions_of(&routed).is_some_and(|(_, resolved)| resolved)).await;
+        assert_eq!(
+            regions_of(&routed),
+            Some((vec![("python".to_string(), true)], true)),
+            "python-bridge handles python, which `py` canonicalizes to: resolved"
+        );
+    }
+
     #[tokio::test]
     async fn did_open_publishes_the_tree_before_the_regions_are_resolved() {
         let (service, mut socket) = LspService::new(Kakehashi::new);


### PR DESCRIPTION
Stacked on #1069 (which is stacked on #1067).

## Summary

With a runnable bridge server, populate resolved every region of every document — extracting each region's virtual document — although the resolution feeds only the servers routed to the regions' languages. This PR makes populate judge per document and publish a **roster** for a document nothing routes.

- **Canonical, not raw.** `LanguageCoordinator::canonical_injection_language_from_identifier` is the content-free prefix of canonicalization (base map, `plaintext`, syntect's memoized token lookup); populate judges routability on it, so a ```` ```py ```` fence is a `python` region exactly as the bridge routes it at open time. An identifier only the content's first line could canonicalize counts as routable and is resolved, never guessed.
- **The bridge's own rule.** The predicate is `BridgeCoordinator::cached_configs_for_injection_language(settings, host, canonical)` — host filter, spawnable command, `languages` list with its wildcard — memoized per (host, language) pair, so populate resolves exactly the documents the bridge would route.
- **A roster, not "empty".** A document nothing routes publishes every region's canonical language and identity and no whole-document resolved regions. The snapshot's bridge regions are an enum, `BridgeRegions::Resolved` (every region with the content the bridge opens) or `BridgeRegions::Roster` (language and identity only), so the per-document rule is a type rather than a doc comment and a reader cannot take one region's content for its being routed. The injection pass takes the roster's languages for the injected-grammar load and hands `close_replaced_docs` every region's identity with its language only when the region is routed — content from the pass AND a server named by the bridge's own routing rule for its canonical language, since a mixed document is resolved in full — so a region that stopped being routed has its virtual document closed whether it sits on a roster or beside a routed region; only then does the pass return when nothing is routed. The fast path routes a resolved document's regions and nothing of a roster.
- **Diagnostics take the roster at its word.** `DocumentStore::current_bridge_regions` (current version, generation-stamped) lets the publisher's region geometry and the per-edit diagnostic snapshot skip inline resolution when the current bridge regions are a roster — the cost that, in an earlier form of this change, moved onto every edit instead of disappearing.
- **What the gate does not fire on.** An identifier syntect cannot canonicalize (Neovim's stock queries inject `markdown_inline` into every markdown paragraph and `comment` into every comment) counts as routable, so such documents are still resolved in full; treating a configured grammar name as canonical would also change the resolver's first-line override for explicit identifiers, which is a decision of its own (#1070).
- Tests pin the content-free canonicalization, the gate in populate (`lua` roster / `py` resolved / unknown identifier resolved), the parse-level wiring against a `python`-only server, the grammar load from a roster (observable through either outcome), and the two diagnostic short-circuits (node-tracker mint probe). ADR §2 records the roster.

### What this replaced

The first gate on this path keyed on the raw fence identifier and published a definitive-empty bridge set; local review found the routing drift and that the injection pass returned before injected-grammar auto-install and `close_replaced_docs`. Both are the reasons for the canonical predicate and the roster here.

## Measurement

`benches/semantic_tokens.rs`, alternating A/B pairs, this branch vs its base (#1069 head).

Controlled config (one runnable server for `toml`, so every fixture is unrouted), 8 pairs:

| scenario | base | this branch | Δ | sign |
|---|---|---|---|---|
| markdown_injections/edit_delta | 1.468 ms | 1.460 ms | −0.4 % | 2/6 |
| markdown_injections/open_first_token | 9.18 ms | 9.20 ms | +0.3 % | 6/2 |
| rust_large/edit_delta | 14.22 ms | 14.22 ms | −0.0 % | 4/4 |
| markdown_injections_large/full | 0.695 ms | 0.697 ms | −0.1 % | 4/4 |

Real local config (a wildcard server routes everything, so nothing is unrouted), 6 pairs: all mixed (rust edit +7.2 % at 4/2, markdown edit −2.4 % at 2/4, markdown open −0.5 % at 2/4).

(Measured at the gate's first form on this branch; the review fixes since — lazy settings after the generation stamp, the roster-judged `close_replaced_docs`, the pull-diagnostic short-circuit — are off the token path.) Token latency does not move, by construction: on top of #1069 the resolution already runs after the first install, off the path the token readers wait on. What this PR removes for an unrouted document is the resolution's work itself — the per-region content extraction, and the inline re-resolution the diagnostic paths ran — which is CPU per parse (≈ 0.5 ms on the 33 KB markdown fixture, ≈ 1 ms on the 1 MB rust one after #1067), not latency. Merge on that merit or hold; a wildcard-server configuration gets nothing from it.

## Verification

- `cargo fmt --check`, `cargo clippy -- -D warnings` clean
- `cargo test --lib` (3727 passed, 2 ignored); `scripts/test_e2e.sh` (445 + 79 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhEfVnacTxTiURX5ftDwmn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved handling of injected document regions when no compatible language server is available.
  - Injected grammars continue loading for syntax highlighting even when virtual documents cannot be created.
  - Virtual documents now close automatically when routing changes, while still-routed regions remain active.
  - Diagnostics and document analysis avoid creating unnecessary virtual regions for unrouted injections.

- **Documentation**
  - Updated the Parse Snapshot Architecture decision record to describe roster-based region handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->