### PR TITLE
fix(lsp): fence delayed open downstream work

### DIFF
--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -272,7 +272,9 @@ the same epoch, so the loser's cache entries are the winner's.) There is one
 store: the **snapshot publish is the sole commit point**, and `Document::tree`
 and the incremental seed are derived from the published cell (Stage 3).
 `semanticTokens/refresh` gates on the publish; parse completion checks currency
-again after resolution. The open parse and successful install reparse return their producing
+again after resolution. The off-ingress open parse first checks the incarnation captured by its
+registering handler, before reading text or recording language. The open parse
+and successful install reparse return their producing
 `ParseLineage` (incarnation and content version). Their injection follow-ups must
 validate that lineage and a current tree under the lifecycle lock before
 cancelling or replacing eager work, and preserve that target through settle

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -271,12 +271,14 @@ admission; those commits are equivalent, keyed by the same tree coordinates unde
 the same epoch, so the loser's cache entries are the winner's.) There is one
 store: the **snapshot publish is the sole commit point**, and `Document::tree`
 and the incremental seed are derived from the published cell (Stage 3).
-`semanticTokens/refresh` gates on the publish; the tree-dependent downstream
-(`mark_parse_finished`, the open parse's follow-ups) gates on `current`, which is
-refused only when the inputs moved on or an equal-version sibling already landed
-the same tree — in either case the next pass seeds from the published snapshot, a
-self-correcting perf blip, never a served inconsistency. So no reader-visible
-divergence can arise.
+`semanticTokens/refresh` gates on the publish; parse completion checks currency
+again after resolution. The interactive open parse returns its producing
+`ParseLineage` (incarnation and content version). Its injection follow-up must
+validate that lineage and a current tree under the lifecycle lock before
+cancelling or replacing eager work, and preserve that target through settle
+retries. Synthetic diagnostic preparation also checks the producing revision.
+A same-version region enrichment preserves the lineage; an edit or reopen does
+not. A completion-time Boolean alone cannot authorize later side effects.
 
 ### 3. Reader contract — non-blocking, three classes
 
@@ -572,8 +574,8 @@ inside the existing safety contracts at each step:
   and the cell admits it, reported *current* iff it parsed the document's content
   version; a stale-but-consistent parse publishes as not current. The **snapshot
   publish is the sole commit point** — `semanticTokens/refresh` gates on the
-  publish result, the tree-dependent downstream (`mark_parse_finished`, the open
-  parse's follow-ups) on `current` (§2). `latest_snapshot` retains a servable
+  publish result; completion checks currency, and the interactive open follow-up
+  validates the producing revision again at admission (§2). `latest_snapshot` retains a servable
   (stale) tree across an edit, while `Document::tree` — derived from the same
   cell — reads as absent until the reparse lands, so no reader sees a tree that
   predates the text. The populate pass runs *before* the install, on

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -272,13 +272,15 @@ the same epoch, so the loser's cache entries are the winner's.) There is one
 store: the **snapshot publish is the sole commit point**, and `Document::tree`
 and the incremental seed are derived from the published cell (Stage 3).
 `semanticTokens/refresh` gates on the publish; parse completion checks currency
-again after resolution. The interactive open parse returns its producing
-`ParseLineage` (incarnation and content version). Its injection follow-up must
+again after resolution. The open parse and successful install reparse return their producing
+`ParseLineage` (incarnation and content version). Their injection follow-ups must
 validate that lineage and a current tree under the lifecycle lock before
 cancelling or replacing eager work, and preserve that target through settle
 retries. Synthetic diagnostic preparation also checks the producing revision.
 A same-version region enrichment preserves the lineage; an edit or reopen does
-not. A completion-time Boolean alone cannot authorize later side effects.
+not. A completion-time Boolean alone cannot authorize later side effects. Installation
+eligibility alone also grants no follow-up: a current tree supplied by another
+parse returns no producing lineage to the waiting installer.
 
 ### 3. Reader contract — non-blocking, three classes
 
@@ -574,7 +576,7 @@ inside the existing safety contracts at each step:
   and the cell admits it, reported *current* iff it parsed the document's content
   version; a stale-but-consistent parse publishes as not current. The **snapshot
   publish is the sole commit point** — `semanticTokens/refresh` gates on the
-  publish result; completion checks currency, and the interactive open follow-up
+  publish result; completion checks currency, and the open follow-up
   validates the producing revision again at admission (§2). `latest_snapshot` retains a servable
   (stale) tree across an edit, while `Document::tree` — derived from the same
   cell — reads as absent until the reparse lands, so no reader sees a tree that

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -278,7 +278,13 @@ and successful install reparse return their producing
 `ParseLineage` (incarnation and content version). Their injection follow-ups must
 validate that lineage and a current tree under the lifecycle lock before
 cancelling or replacing eager work, and preserve that target through settle
-retries. Synthetic diagnostic preparation also checks the producing revision.
+retries. Before releasing that lock, a pass claims the eager batch and registers
+its detached routing task. Routing inherits that batch's generation and cancellation
+token; it cannot cancel or replace a newer batch after awaiting a provider. Its
+owned routing-token guard releases only that pass's virtual-URI tokens on completion
+or cancellation, including cancellation before the task first runs. Both routing
+and spawned child opens count toward batch completion.
+Synthetic diagnostic preparation also checks the producing revision.
 A same-version region enrichment preserves the lineage; an edit or reopen does
 not. A completion-time Boolean alone cannot authorize later side effects. Installation
 eligibility alone also grants no follow-up: a current tree supplied by another

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -116,6 +116,31 @@ struct EagerOpenBatch {
     cancel: CancellationToken,
 }
 
+/// Ownership of the eager batch claimed by an admitted lifecycle pass.
+/// Detached routing may only add work to this batch, never replace a later one.
+pub(crate) struct EagerOpenPass {
+    incarnation: u64,
+    generation: u64,
+    cancel: CancellationToken,
+    routing: VirtualRoutingGuard,
+}
+
+/// Release only the tokens owned by this pass, even if routing is aborted
+/// before its first poll. A newer token for the same virtual URI stays pending.
+struct VirtualRoutingGuard {
+    pool: Arc<LanguageServerPool>,
+    host_uri: Url,
+    tokens: HashMap<Url, Arc<tokio::sync::watch::Sender<bool>>>,
+}
+
+impl Drop for VirtualRoutingGuard {
+    fn drop(&mut self) {
+        for (uri, token) in &self.tokens {
+            self.pool.finish_virtual_routing(&self.host_uri, uri, token);
+        }
+    }
+}
+
 #[cfg(test)]
 pub(crate) struct ForceStartTestControl {
     pub(crate) before_admission: Arc<tokio::sync::Notify>,
@@ -1310,6 +1335,44 @@ impl BridgeCoordinator {
         groups
     }
 
+    fn begin_eager_open_pass(
+        &self,
+        uri: &Url,
+        incarnation: u64,
+        routing_tokens: HashMap<Url, Arc<tokio::sync::watch::Sender<bool>>>,
+    ) -> EagerOpenPass {
+        let (generation, cancel) = self.supersede_eager_open_tasks(uri);
+        EagerOpenPass {
+            incarnation,
+            generation,
+            cancel,
+            routing: VirtualRoutingGuard {
+                pool: self.pool_arc(),
+                host_uri: uri.clone(),
+                tokens: routing_tokens,
+            },
+        }
+    }
+
+    /// Claim and register routing while the caller still holds the document's
+    /// lifecycle lock. The outer task counts as unfinished until all routed
+    /// child handles have been registered, including for CLI waiters.
+    pub(crate) fn spawn_eager_open_routing<F, Fut>(
+        &self,
+        uri: &Url,
+        incarnation: u64,
+        routing_tokens: HashMap<Url, Arc<tokio::sync::watch::Sender<bool>>>,
+        route: F,
+    ) where
+        F: FnOnce(EagerOpenPass) -> Fut,
+        Fut: std::future::Future<Output = ()> + Send + 'static,
+    {
+        let pass = self.begin_eager_open_pass(uri, incarnation, routing_tokens);
+        let generation = pass.generation;
+        let task = tokio::spawn(route(pass));
+        self.push_or_abort_eager_open_handle(uri, task.abort_handle(), generation);
+    }
+
     /// Eagerly spawn language servers and open virtual documents for detected injections.
     ///
     /// Sending `didOpen` up front (not just a handshake) lets downstream servers
@@ -1319,136 +1382,149 @@ impl BridgeCoordinator {
         settings: &WorkspaceSettings,
         host_language: &str,
         host_uri: &Url,
-        incarnation: u64,
+        pass: EagerOpenPass,
         injections: Vec<BridgeInjection>,
-        routing_tokens: HashMap<Url, Arc<tokio::sync::watch::Sender<bool>>>,
     ) {
-        // Convert host_uri to ls_types::Uri for VirtualDocumentUri construction
-        let host_uri_lsp = match crate::lsp::lsp_impl::url_to_uri(host_uri) {
-            Ok(uri) => uri,
-            Err(e) => {
-                log::warn!(
-                    target: "kakehashi::bridge",
-                    "Failed to convert host URI for eager open, skipping: {}",
-                    e
-                );
+        let EagerOpenPass {
+            incarnation,
+            generation,
+            cancel,
+            routing,
+        } = pass;
+        let routing_work = async {
+            // Convert host_uri to ls_types::Uri for VirtualDocumentUri construction
+            let host_uri_lsp = match crate::lsp::lsp_impl::url_to_uri(host_uri) {
+                Ok(uri) => uri,
+                Err(e) => {
+                    log::warn!(
+                        target: "kakehashi::bridge",
+                        "Failed to convert host URI for eager open, skipping: {}",
+                        e
+                    );
+                    return;
+                }
+            };
+
+            // Empty means current settings resolve no server for any injection —
+            // the batch belongs to removed configuration and must stop.
+            let (routed, routing_superseded) = self
+                .route_virtual_injections(
+                    settings,
+                    host_language,
+                    host_uri,
+                    &host_uri_lsp,
+                    injections,
+                    None,
+                    Some(&routing.tokens),
+                )
+                .await;
+            if routing_superseded {
                 return;
             }
-        };
-
-        // Empty means current settings resolve no server for any injection —
-        // the batch belongs to removed configuration and must stop.
-        let (routed, routing_superseded) = self
-            .route_virtual_injections(
-                settings,
-                host_language,
-                host_uri,
-                &host_uri_lsp,
-                injections,
-                None,
-                Some(&routing_tokens),
-            )
-            .await;
-        if routing_superseded {
-            return;
-        }
-        let resolved_groups = Self::eager_open_groups_for_configs(routed);
-        if resolved_groups.is_empty() {
-            self.cancel_eager_open(host_uri);
-            return;
-        }
-
-        // Drop the regions already open on each server's connection. A single
-        // server can receive different routing answers for different virtual
-        // documents, so group by the complete resolved connection key rather
-        // than only by server name or rootless-ness.
-        let mut server_groups: HashMap<ConnectionKey, (String, ServerGroup)> = HashMap::new();
-        for (server_name, (config, group_injections)) in resolved_groups {
-            for injection in group_injections {
-                let routing_uri = super::protocol::VirtualDocumentUri::new(
-                    &host_uri_lsp,
-                    &injection.language,
-                    &injection.region_id,
-                );
-                let Ok(routing_uri) = Url::parse(&routing_uri.to_uri_string()) else {
-                    continue;
-                };
-                let connection_key = self
-                    .pool
-                    .resolved_connection_key(&server_name, &config, &routing_uri)
-                    .await;
-                let entry = server_groups
-                    .entry(connection_key)
-                    .or_insert_with(|| (server_name.clone(), (Arc::clone(&config), Vec::new())));
-                entry.1.1.push(injection);
+            let resolved_groups = Self::eager_open_groups_for_configs(routed);
+            if resolved_groups.is_empty() {
+                return;
             }
-        }
 
-        let mut pending_groups: HashMap<ConnectionKey, (String, ServerGroup)> = HashMap::new();
-        for (connection_key, (server_name, (config, group_injections))) in server_groups {
-            let pending: Vec<BridgeInjection> = group_injections
-                .into_iter()
-                .filter(|injection| {
-                    !self.injection_open_on_connection(&host_uri_lsp, &connection_key, injection)
-                })
-                .collect();
-            if !pending.is_empty() {
-                pending_groups.insert(connection_key, (server_name, (config, pending)));
-            }
-        }
-        let server_groups = pending_groups;
-
-        // Every resolved injection is already sent/open — preserve the batch.
-        if server_groups.is_empty() {
-            return;
-        }
-
-        // Supersede previous batch: abort + insert empty placeholder BEFORE spawning.
-        // This closes the race window between spawn and registration. The returned
-        // token (stored in the batch, already in the map) is `select!`ed on by each
-        // task body to close the spawn→register window the abort handle can't reach (#435).
-        let (generation, cancel) = self.supersede_eager_open_tasks(host_uri);
-
-        // Spawn one task per server group, registering each handle immediately
-        for (connection_key, (server_name, (config, group_injections))) in server_groups {
-            log::debug!(
-                target: "kakehashi::bridge",
-                "Eager open: spawning {} on {} with {} injections",
-                server_name,
-                connection_key,
-                group_injections.len()
-            );
-
-            let pool = self.pool_arc();
-            let host_uri_owned = host_uri.clone();
-            let host_uri_lsp = host_uri_lsp.clone();
-            let cancel = cancel.clone();
-
-            let task = tokio::spawn(async move {
-                tokio::select! {
-                    biased;
-                    // Cancelled during the spawn→register window (or later) —
-                    // bail before the side effect.
-                    _ = cancel.cancelled() => {}
-                    _ = pool.eager_open_virtual_documents(
-                        &server_name,
-                        &config,
-                        &host_uri_owned,
+            // Drop the regions already open on each server's connection. A single
+            // server can receive different routing answers for different virtual
+            // documents, so group by the complete resolved connection key rather
+            // than only by server name or rootless-ness.
+            let mut server_groups: HashMap<ConnectionKey, (String, ServerGroup)> = HashMap::new();
+            for (server_name, (config, group_injections)) in resolved_groups {
+                for injection in group_injections {
+                    let routing_uri = super::protocol::VirtualDocumentUri::new(
                         &host_uri_lsp,
-                        super::text_document::OpenExpectation {
-                            incarnation,
-                            // The eager batch opens wherever the host routes now.
-                            connection: None,
-                            expected_connection: Some(connection_key.clone()),
-                        },
-                        group_injections,
-                    ) => {}
+                        &injection.language,
+                        &injection.region_id,
+                    );
+                    let Ok(routing_uri) = Url::parse(&routing_uri.to_uri_string()) else {
+                        continue;
+                    };
+                    let connection_key = self
+                        .pool
+                        .resolved_connection_key(&server_name, &config, &routing_uri)
+                        .await;
+                    let entry = server_groups.entry(connection_key).or_insert_with(|| {
+                        (server_name.clone(), (Arc::clone(&config), Vec::new()))
+                    });
+                    entry.1.1.push(injection);
                 }
-            });
+            }
 
-            // Register immediately — if concurrent cancel removed the entry
-            // or the generation is stale, the handle is aborted instead of leaked.
-            self.push_or_abort_eager_open_handle(host_uri, task.abort_handle(), generation);
+            let mut pending_groups: HashMap<ConnectionKey, (String, ServerGroup)> = HashMap::new();
+            for (connection_key, (server_name, (config, group_injections))) in server_groups {
+                let pending: Vec<BridgeInjection> = group_injections
+                    .into_iter()
+                    .filter(|injection| {
+                        !self.injection_open_on_connection(
+                            &host_uri_lsp,
+                            &connection_key,
+                            injection,
+                        )
+                    })
+                    .collect();
+                if !pending.is_empty() {
+                    pending_groups.insert(connection_key, (server_name, (config, pending)));
+                }
+            }
+            let server_groups = pending_groups;
+
+            // Every resolved injection is already sent/open; this routing task
+            // can finish the admitted batch without spawning child opens.
+            if server_groups.is_empty() {
+                return;
+            }
+
+            // The lifecycle pass already claimed the batch. Reuse its generation:
+            // routing must not replace a batch created by an edit during the wait.
+
+            // Spawn one task per server group, registering each handle immediately
+            for (connection_key, (server_name, (config, group_injections))) in server_groups {
+                log::debug!(
+                    target: "kakehashi::bridge",
+                    "Eager open: spawning {} on {} with {} injections",
+                    server_name,
+                    connection_key,
+                    group_injections.len()
+                );
+
+                let pool = self.pool_arc();
+                let host_uri_owned = host_uri.clone();
+                let host_uri_lsp = host_uri_lsp.clone();
+                let cancel = cancel.clone();
+
+                let task = tokio::spawn(async move {
+                    tokio::select! {
+                        biased;
+                        // Cancelled during the spawn→register window (or later) —
+                        // bail before the side effect.
+                        _ = cancel.cancelled() => {}
+                        _ = pool.eager_open_virtual_documents(
+                            &server_name,
+                            &config,
+                            &host_uri_owned,
+                            &host_uri_lsp,
+                            super::text_document::OpenExpectation {
+                                incarnation,
+                                // The eager batch opens wherever the host routes now.
+                                connection: None,
+                                expected_connection: Some(connection_key.clone()),
+                            },
+                            group_injections,
+                        ) => {}
+                    }
+                });
+
+                // Register immediately — if concurrent cancel removed the entry
+                // or the generation is stale, the handle is aborted instead of leaked.
+                self.push_or_abort_eager_open_handle(host_uri, task.abort_handle(), generation);
+            }
+        };
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => {}
+            _ = routing_work => {}
         }
     }
 
@@ -1891,13 +1967,12 @@ impl BridgeCoordinator {
     ///
     /// Precondition: the `didOpen` that triggered the eager spawn has been
     /// **awaited to completion** (CLI mode awaits `did_open_impl`, which
-    /// registers every handle before returning). `supersede` inserts an
-    /// empty placeholder batch before the handles are pushed, so a caller
-    /// polling *concurrently with registration* could observe a zero-handle
-    /// batch as "finished"; conversely an empty batch must stay "finished"
-    /// here, because documents with no bridge-capable injections keep zero
-    /// handles forever and treating that as pending would stall them for
-    /// the caller's whole timeout.
+    /// registers the outer routing handle before returning). Routing registers
+    /// its child open handles before finishing, so the batch stays unfinished
+    /// across that handoff. `supersede` still briefly inserts an empty placeholder
+    /// before outer registration; callers must not poll during that synchronous
+    /// admission. A document with no bridge-capable injections needs no task,
+    /// so an absent or empty batch remains finished.
     pub(crate) fn eager_open_tasks_finished(&self, uri: &Url) -> bool {
         self.eager_open_tasks
             .get(uri)
@@ -3202,6 +3277,91 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancelled_unpolled_routing_releases_only_its_own_tokens() {
+        let coordinator = BridgeCoordinator::new();
+        let host_uri = Url::parse("file:///cancel-routing.md").unwrap();
+        let old_uri = Url::parse("file:///old-virtual.lua").unwrap();
+        let shared_uri = Url::parse("file:///shared-virtual.lua").unwrap();
+        let tokens = HashMap::from([
+            (
+                old_uri.clone(),
+                coordinator.pool.begin_virtual_routing(&host_uri, &old_uri),
+            ),
+            (
+                shared_uri.clone(),
+                coordinator
+                    .pool
+                    .begin_virtual_routing(&host_uri, &shared_uri),
+            ),
+        ]);
+        coordinator.spawn_eager_open_routing(&host_uri, 1, tokens, |pass| async move {
+            let _pass = pass;
+            std::future::pending::<()>().await;
+        });
+        assert!(
+            !coordinator.eager_open_tasks_finished(&host_uri),
+            "routing is part of the tracked batch before its first poll"
+        );
+        let replacement = coordinator
+            .pool
+            .begin_virtual_routing(&host_uri, &shared_uri);
+        // This current-thread test has not yielded since spawn, so the routing
+        // body has never run. Its captured guard must still release the tokens.
+        coordinator.cancel_eager_open(&host_uri);
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            coordinator
+                .pool
+                .wait_for_virtual_routing(&host_uri, &old_uri),
+        )
+        .await
+        .expect("aborted routing releases its waiter");
+        assert!(
+            coordinator
+                .pool
+                .is_virtual_routing_current(&host_uri, &shared_uri, &replacement)
+        );
+        assert!(
+            !*replacement.borrow(),
+            "old cleanup must not complete the replacement token"
+        );
+        coordinator
+            .pool
+            .finish_virtual_routing(&host_uri, &shared_uri, &replacement);
+    }
+
+    #[tokio::test]
+    async fn old_eager_routing_cannot_cancel_a_new_regions_batch() {
+        let coordinator = BridgeCoordinator::new();
+        let host_uri = Url::parse("file:///stale-routing.md").unwrap();
+        let old_injections = vec![injection("rust", "old-region")];
+        let old_routing =
+            coordinator.begin_virtual_routing_for_injections(&host_uri, &old_injections);
+        let old_pass = coordinator.begin_eager_open_pass(&host_uri, 1, old_routing);
+
+        // A subsequent edit discovers another region. Its routing token does
+        // not supersede the old region's token, but its eager batch owns the URI.
+        coordinator
+            .begin_virtual_routing_for_injections(&host_uri, &[injection("rust", "new-region")]);
+        let (_, newer_batch) = coordinator.supersede_eager_open_tasks(&host_uri);
+        coordinator
+            .eager_spawn_and_open_documents(
+                &WorkspaceSettings::default(),
+                "markdown",
+                &host_uri,
+                old_pass,
+                old_injections,
+            )
+            .await;
+
+        assert!(
+            !newer_batch.is_cancelled(),
+            "old empty routing must not cancel the new edit's batch"
+        );
+        coordinator.cancel_eager_open(&host_uri);
+    }
+
+    #[tokio::test]
     async fn eager_open_spawns_a_task_for_every_group_not_just_the_first() {
         // `eager_open_groups` deciding on two servers is worthless if the
         // dispatch loop below it only acts on one — the push-only server would
@@ -3215,16 +3375,16 @@ mod tests {
         }
         let host_uri = Url::parse("file:///test.md").unwrap();
         let injections = vec![injection("rust", "r1")];
-        coordinator.begin_virtual_routing_for_injections(&host_uri, &injections);
+        let routing_tokens =
+            coordinator.begin_virtual_routing_for_injections(&host_uri, &injections);
 
         coordinator
             .eager_spawn_and_open_documents(
                 &settings,
                 "markdown",
                 &host_uri,
-                1,
+                coordinator.begin_eager_open_pass(&host_uri, 1, routing_tokens),
                 injections,
-                HashMap::new(),
             )
             .await;
 

--- a/src/lsp/lsp_impl/coordinator.rs
+++ b/src/lsp/lsp_impl/coordinator.rs
@@ -8,4 +8,4 @@ pub(crate) use diagnostic::DiagnosticScheduler;
 pub(crate) use diagnostic_publisher::{DiagnosticPublisher, DiagnosticPush};
 pub(crate) use injection::{InjectionCoordinator, ParseWait};
 pub(crate) use install::InstallCoordinator;
-pub(crate) use parse::ParseCoordinator;
+pub(crate) use parse::{ParseCoordinator, ParseLineage};

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -235,6 +235,29 @@ impl DiagnosticScheduler {
     /// `textDocument/publishDiagnostics`.
     pub(crate) fn spawn_synthetic_diagnostic_task(&self, uri: Url) {
         let snapshot_data = self.prepare_diagnostic_snapshot(&uri);
+        self.spawn_prepared_synthetic_diagnostic_task(uri, snapshot_data);
+    }
+
+    pub(crate) fn spawn_synthetic_diagnostic_task_for_parse(
+        &self,
+        uri: Url,
+        parsed: super::parse::ParseLineage,
+    ) {
+        let snapshot_data = self
+            .snapshot_preparer
+            .prepare_diagnostic_snapshot_when_current(
+                &uri,
+                parsed.incarnation,
+                parsed.content_version,
+            );
+        self.spawn_prepared_synthetic_diagnostic_task(uri, snapshot_data);
+    }
+
+    fn spawn_prepared_synthetic_diagnostic_task(
+        &self,
+        uri: Url,
+        snapshot_data: Option<DiagnosticSnapshot>,
+    ) {
         let Some(lineage) = snapshot_data.as_ref().map(|snapshot| snapshot.lineage) else {
             return;
         };

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1921,7 +1921,7 @@ mod tests {
         );
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), Some("rust"), None)
+            .parse_document(uri.clone(), Some("rust"), None, None)
             .await;
 
         let publisher = DiagnosticPublisher::new(server);
@@ -1983,7 +1983,7 @@ mod tests {
         );
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), Some("rust"), None)
+            .parse_document(uri.clone(), Some("rust"), None, None)
             .await;
 
         // The parked writer: mutation + pending mark stamped, republish not
@@ -2042,7 +2042,7 @@ mod tests {
         );
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), Some("rust"), None)
+            .parse_document(uri.clone(), Some("rust"), None, None)
             .await;
         let publisher = DiagnosticPublisher::new(server);
         // Establish a recorded set and clear the seed's lag so nothing but
@@ -2251,7 +2251,7 @@ mod tests {
         );
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), Some("rust"), None)
+            .parse_document(uri.clone(), Some("rust"), None, None)
             .await;
         let publisher = DiagnosticPublisher::new(server);
         publisher.publish_pull_layer(&uri, Vec::new()).await;
@@ -2419,7 +2419,7 @@ mod tests {
         );
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), Some("rust"), None)
+            .parse_document(uri.clone(), Some("rust"), None, None)
             .await;
 
         let publisher = DiagnosticPublisher::new(server);
@@ -2498,7 +2498,7 @@ mod tests {
         );
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), Some("rust"), None)
+            .parse_document(uri.clone(), Some("rust"), None, None)
             .await;
 
         let publisher = DiagnosticPublisher::new(server);
@@ -2573,7 +2573,7 @@ mod tests {
         );
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), Some("rust"), None)
+            .parse_document(uri.clone(), Some("rust"), None, None)
             .await;
 
         let publisher = DiagnosticPublisher::new(server);

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -22,6 +22,21 @@ use crate::lsp::lsp_impl::{build_notifier, detect_document_language};
 use super::InstallCoordinator;
 use super::install::InstallCoordinatorDeps;
 
+#[derive(Clone, Copy)]
+enum InjectionTarget {
+    Incarnation(u64),
+    Parsed(super::parse::ParseLineage),
+}
+
+impl InjectionTarget {
+    fn matches(self, document: &crate::document::Document) -> bool {
+        match self {
+            Self::Incarnation(incarnation) => document.incarnation() == incarnation,
+            Self::Parsed(lineage) => lineage.matches(document) && document.has_current_tree(),
+        }
+    }
+}
+
 /// `Clone` is a cheap refcount bump of the shared coordinators (every field is a
 /// `Client` / `Arc<_>` / `AutoInstallManager`, all `Clone`); it lets
 /// `process_injections` hand an owned handle to a spawned off-ingress install task.
@@ -274,7 +289,21 @@ impl InjectionCoordinator {
         self.process_injections_after_lifecycle_lock(
             uri,
             forward_did_change,
-            Some(incarnation),
+            Some(InjectionTarget::Incarnation(incarnation)),
+            std::future::ready(()),
+        )
+        .await
+    }
+
+    pub(crate) async fn process_injections_for_parse(
+        &self,
+        uri: &Url,
+        lineage: super::parse::ParseLineage,
+    ) -> bool {
+        self.process_injections_after_lifecycle_lock(
+            uri,
+            false,
+            Some(InjectionTarget::Parsed(lineage)),
             std::future::ready(()),
         )
         .await
@@ -284,7 +313,7 @@ impl InjectionCoordinator {
         &self,
         uri: &Url,
         forward_did_change: bool,
-        required_incarnation: Option<u64>,
+        required: Option<InjectionTarget>,
         after_lifecycle_lock: F,
     ) -> bool
     where
@@ -298,14 +327,18 @@ impl InjectionCoordinator {
         let edit_lock = self.documents.edit_lock(uri);
         let _lifecycle_guard = edit_lock.lock().await;
         after_lifecycle_lock.await;
-        let Some(incarnation) = self.documents.get(uri).map(|doc| doc.incarnation()) else {
-            self.bridge.cancel_eager_open(uri);
+        let Some(document) = self.documents.get(uri) else {
+            if required.is_none() {
+                self.bridge.cancel_eager_open(uri);
+            }
             self.documents.remove_edit_lock_if_unshared(uri, &edit_lock);
             return false;
         };
-        if required_incarnation.is_some_and(|required| incarnation != required) {
+        if required.is_some_and(|target| !target.matches(&document)) {
             return false;
         }
+        let incarnation = document.incarnation();
+        drop(document);
 
         // Stored language first (see `document_language`): parser-aware
         // detection answers `None` while the language is still publishing,
@@ -339,6 +372,7 @@ impl InjectionCoordinator {
                     &host_language,
                     forward_did_change,
                     incarnation,
+                    required,
                 );
             }
             self.documents.remove_edit_lock_if_unshared(uri, &edit_lock);
@@ -606,6 +640,7 @@ impl InjectionCoordinator {
         host_language: &str,
         forward_did_change: bool,
         incarnation: u64,
+        required: Option<InjectionTarget>,
     ) {
         const INJECTION_RETRY_BUDGET: std::time::Duration = std::time::Duration::from_secs(10);
         const INJECTION_RETRY_POLL: std::time::Duration = std::time::Duration::from_millis(50);
@@ -613,10 +648,17 @@ impl InjectionCoordinator {
         // same window re-runs the pass once, when the language settles; a
         // close and reopen in the meantime gets its own waiter, since this
         // one exits at its lifetime check.
-        let Some(claim) = self
-            .settle_retry_waiters
-            .claim("injection", uri, Some(incarnation))
-        else {
+        let Some(claim) = self.settle_retry_waiters.claim(
+            if matches!(required, Some(InjectionTarget::Parsed(_))) {
+                // An open retry is revision-bound and may become a no-op.
+                // It cannot satisfy the edit path's latest-revision retry.
+                "open-injection"
+            } else {
+                "injection"
+            },
+            uri,
+            Some(incarnation),
+        ) else {
             return;
         };
         let this = self.clone();
@@ -652,9 +694,13 @@ impl InjectionCoordinator {
                     // right now makes the rerun defer again, and its retry
                     // must be able to claim the slot this waiter held.
                     drop(claim);
-                    let _ = this
-                        .process_injections_for_incarnation(&uri, forward_did_change, incarnation)
-                        .await;
+                    let _ = Box::pin(this.process_injections_after_lifecycle_lock(
+                        &uri,
+                        forward_did_change,
+                        required.or(Some(InjectionTarget::Incarnation(incarnation))),
+                        std::future::ready(()),
+                    ))
+                    .await;
                     return;
                 }
                 if tokio::time::Instant::now() >= deadline {
@@ -898,7 +944,7 @@ fn parser_enabled_injection_language(language: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::parser_enabled_injection_language;
+    use super::{InjectionTarget, parser_enabled_injection_language};
 
     #[test]
     fn explicit_plaintext_does_not_request_a_parser() {
@@ -1089,16 +1135,21 @@ mod tests {
 
         let processed = server
             .injection_coordinator()
-            .process_injections_after_lifecycle_lock(&uri, false, Some(old_incarnation), async {
-                server.documents.remove_preserving_edit_lock(&uri);
-                let new_incarnation =
-                    server
-                        .documents
-                        .insert(uri.clone(), "new".to_string(), None, None);
-                assert_ne!(new_incarnation, old_incarnation);
-                let token = server.bridge.begin_test_eager_open_batch(&uri);
-                let _ = token_tx.send(token);
-            })
+            .process_injections_after_lifecycle_lock(
+                &uri,
+                false,
+                Some(InjectionTarget::Incarnation(old_incarnation)),
+                async {
+                    server.documents.remove_preserving_edit_lock(&uri);
+                    let new_incarnation =
+                        server
+                            .documents
+                            .insert(uri.clone(), "new".to_string(), None, None);
+                    assert_ne!(new_incarnation, old_incarnation);
+                    let token = server.bridge.begin_test_eager_open_batch(&uri);
+                    let _ = token_tx.send(token);
+                },
+            )
             .await;
         let token = token_rx.await.unwrap();
 
@@ -1106,6 +1157,80 @@ mod tests {
         assert!(
             !token.is_cancelled(),
             "a stale pass must not cancel the reopened lifetime's eager batch"
+        );
+    }
+
+    #[tokio::test]
+    async fn delayed_open_pass_does_not_cancel_edited_eager_batch() {
+        let (service, _socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
+        let server = service.inner();
+        let uri = Url::parse("file:///delayed-open.rs").unwrap();
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let original = "fn original() {}";
+        let incarnation = server.documents.insert(
+            uri.clone(),
+            original.into(),
+            None,
+            parser.parse(original, None),
+        );
+        let (token_tx, token_rx) = tokio::sync::oneshot::channel();
+        let processed = server
+            .injection_coordinator()
+            .process_injections_after_lifecycle_lock(
+                &uri,
+                false,
+                Some(InjectionTarget::Parsed(super::super::parse::ParseLineage {
+                    incarnation,
+                    content_version: 0,
+                })),
+                async {
+                    let edited = "fn edited() {}";
+                    server.documents.update_document(
+                        uri.clone(),
+                        edited.into(),
+                        parser.parse(edited, None),
+                    );
+                    assert!(server.documents.get(&uri).unwrap().has_current_tree());
+                    let _ = token_tx.send(server.bridge.begin_test_eager_open_batch(&uri));
+                },
+            )
+            .await;
+        let token = token_rx.await.unwrap();
+        assert!(
+            !token.is_cancelled(),
+            "the old open must not cancel the edit's eager batch"
+        );
+        assert!(!processed);
+    }
+
+    #[tokio::test]
+    async fn deferred_open_does_not_consume_the_edits_retry_slot() {
+        let (service, _socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
+        let server = service.inner();
+        let uri = Url::parse("file:///deferred-open.rs").unwrap();
+        let incarnation = server
+            .documents
+            .insert(uri.clone(), String::new(), None, None);
+        let injection = server.injection_coordinator();
+        injection.retry_injection_pass_when_settled(
+            &uri,
+            "rust",
+            false,
+            incarnation,
+            Some(InjectionTarget::Parsed(super::super::parse::ParseLineage {
+                incarnation,
+                content_version: 0,
+            })),
+        );
+        let edit_retry = injection
+            .settle_retry_waiters
+            .claim("injection", &uri, Some(incarnation));
+        assert!(
+            edit_retry.is_some(),
+            "a stale open retry must not absorb the newer edit's retry"
         );
     }
 

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -1,5 +1,4 @@
-use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::collections::HashSet;
 
 use url::Url;
 
@@ -9,7 +8,7 @@ use crate::language::injection::{InjectionResolver, collect_all_injections};
 use crate::language::{DocumentParserPool, LanguageCoordinator, LanguageEvent};
 use crate::lsp::auto_install::AutoInstallManager;
 use crate::lsp::bridge::BridgeCoordinator;
-use crate::lsp::bridge::coordinator::BridgeInjection;
+use crate::lsp::bridge::coordinator::{BridgeInjection, EagerOpenPass};
 use crate::lsp::cache::CacheCoordinator;
 use crate::lsp::client::ClientNotifier;
 use crate::lsp::diagnostic_cache::{DiagnosticAggregator, DiagnosticSource};
@@ -436,21 +435,20 @@ impl InjectionCoordinator {
         // per-document lock promptly, while the detached task still observes
         // the same incarnation and is cancelled by the next close/rebuild.
         let coordinator = self.clone();
-        let uri = uri.clone();
+        let routing_uri = uri.clone();
         let routing_tokens = self
             .bridge
-            .begin_virtual_routing_for_injections(&uri, &injections);
-        tokio::spawn(async move {
-            coordinator
-                .eager_spawn_bridge_servers(
-                    &uri,
-                    incarnation,
-                    &host_language,
-                    injections,
-                    routing_tokens,
-                )
-                .await;
-        });
+            .begin_virtual_routing_for_injections(uri, &injections);
+        self.bridge.spawn_eager_open_routing(
+            uri,
+            incarnation,
+            routing_tokens,
+            move |pass| async move {
+                coordinator
+                    .eager_spawn_bridge_servers(&routing_uri, pass, &host_language, injections)
+                    .await;
+            },
+        );
         true
     }
 
@@ -594,21 +592,13 @@ impl InjectionCoordinator {
     pub(crate) async fn eager_spawn_bridge_servers(
         &self,
         uri: &Url,
-        incarnation: u64,
+        pass: EagerOpenPass,
         host_language: &str,
         injections: Vec<BridgeInjection>,
-        routing_tokens: HashMap<Url, Arc<tokio::sync::watch::Sender<bool>>>,
     ) {
         let settings = self.settings_manager.load_settings();
         self.bridge
-            .eager_spawn_and_open_documents(
-                &settings,
-                host_language,
-                uri,
-                incarnation,
-                injections,
-                routing_tokens,
-            )
+            .eager_spawn_and_open_documents(&settings, host_language, uri, pass, injections)
             .await;
     }
 

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -1241,6 +1241,60 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn open_admission_accepts_same_revision_region_enrichment() {
+        let (service, _socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
+        let server = service.inner();
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".into(), tree_sitter_rust::LANGUAGE.into());
+        let uri = Url::parse("file:///enriched-open.rs").unwrap();
+        let text = "fn main() {}";
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let incarnation = server.documents.insert(
+            uri.clone(),
+            text.into(),
+            Some("rust".into()),
+            parser.parse(text, None),
+        );
+        let view = server.documents.latest_snapshot(&uri).unwrap();
+        let first = view.slot.snapshot.unwrap();
+        let lineage = super::super::parse::ParseLineage {
+            incarnation,
+            content_version: view.content_version,
+        };
+        assert!(server.documents.complete_parse(
+            &uri,
+            crate::document::LanguageCheck::Expect(Some("rust")),
+            &first,
+            Some(crate::document::snapshot::ResolvedRegions::empty(
+                server.settings_manager.settings_generation()
+            )),
+        ));
+        let enriched = server
+            .documents
+            .latest_snapshot(&uri)
+            .unwrap()
+            .slot
+            .snapshot
+            .unwrap();
+        assert!(
+            !Arc::ptr_eq(&first, &enriched),
+            "enrichment replaces the immutable snapshot"
+        );
+        assert!(
+            server
+                .injection_coordinator()
+                .process_injections_for_parse(&uri, lineage)
+                .await,
+            "same-revision enrichment must retain open downstream eligibility"
+        );
+    }
+
     /// Publish `tree` as `uri`'s current parse snapshot under `language`,
     /// the way a settled parse would.
     fn publish_test_snapshot(

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -694,13 +694,20 @@ impl InjectionCoordinator {
                     // right now makes the rerun defer again, and its retry
                     // must be able to claim the slot this waiter held.
                     drop(claim);
-                    let _ = Box::pin(this.process_injections_after_lifecycle_lock(
-                        &uri,
-                        forward_did_change,
-                        required.or(Some(InjectionTarget::Incarnation(incarnation))),
-                        std::future::ready(()),
-                    ))
-                    .await;
+                    match required {
+                        Some(InjectionTarget::Parsed(lineage)) => {
+                            let _ = this.process_injections_for_parse(&uri, lineage).await;
+                        }
+                        _ => {
+                            let _ = this
+                                .process_injections_for_incarnation(
+                                    &uri,
+                                    forward_did_change,
+                                    incarnation,
+                                )
+                                .await;
+                        }
+                    }
                     return;
                 }
                 if tokio::time::Instant::now() >= deadline {

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -64,6 +64,14 @@ pub(super) struct InstallCoordinatorDeps {
     pub(super) bridge: std::sync::Arc<BridgeCoordinator>,
 }
 
+/// Installation/lifetime eligibility is distinct from ownership of a parse.
+/// A sibling may supply the tree while this install is waiting.
+#[derive(Default)]
+pub(crate) struct InstallCompletion {
+    pub(crate) same_lifetime: bool,
+    pub(crate) parsed: Option<super::parse::ParseLineage>,
+}
+
 pub(crate) struct InstallCoordinator {
     client: Client,
     language: std::sync::Arc<LanguageCoordinator>,
@@ -172,6 +180,8 @@ impl InstallCoordinator {
     /// Delegates to `AutoInstallManager::try_install()`, dispatches its events, and
     /// reloads on success. An `AlreadyInstalling` caller waits for the shared
     /// install claim, then reloads its own document when the parser artifact exists.
+    /// `parsed` names only a parse published by this call; successful recovery
+    /// through a sibling's tree does not authorize open downstream work.
     pub(crate) async fn maybe_auto_install_language(
         &self,
         language: &str,
@@ -179,24 +189,29 @@ impl InstallCoordinator {
         is_injection: bool,
         expected_incarnation: Option<u64>,
         allow_recovery: bool,
-    ) -> bool {
+    ) -> InstallCompletion {
+        let mut parsed = None;
         if !self.same_document_incarnation(&uri, expected_incarnation) {
-            return false;
+            return InstallCompletion::default();
         }
 
         if self.language.has_parser_available(language) {
             if !is_injection && self.same_document_incarnation(&uri, expected_incarnation) {
-                self.parse_coordinator()
+                parsed = self
+                    .parse_coordinator()
                     .reparse_installed_document(uri.clone(), language, expected_incarnation)
                     .await;
             }
             if !self.same_document_incarnation(&uri, expected_incarnation) {
-                return false;
+                return InstallCompletion::default();
             }
             let recovered =
                 self.install_reparse_recovered(language, &uri, is_injection, expected_incarnation);
             if recovered {
-                return true;
+                return InstallCompletion {
+                    same_lifetime: true,
+                    parsed,
+                };
             }
         }
         let mut result = self.auto_install.try_install(language).await;
@@ -204,22 +219,26 @@ impl InstallCoordinator {
         self.dispatch_install_events(language, &result.events).await;
 
         if let Some(data_dir) = result.outcome.data_dir().cloned() {
-            self.reload_language_after_install(
-                language,
-                &data_dir,
-                uri.clone(),
-                is_injection,
-                expected_incarnation,
-                Some(&mut result),
-            )
-            .await;
+            parsed = self
+                .reload_language_after_install(
+                    language,
+                    &data_dir,
+                    uri.clone(),
+                    is_injection,
+                    expected_incarnation,
+                    Some(&mut result),
+                )
+                .await;
             let recovered =
                 self.install_reparse_recovered(language, &uri, is_injection, expected_incarnation);
             if recovered {
-                return true;
+                return InstallCompletion {
+                    same_lifetime: true,
+                    parsed,
+                };
             }
             drop(result);
-            return false;
+            return InstallCompletion::default();
         }
 
         // Every no-reparse outcome lands here — Failed/Unsupported/NoDataDir as
@@ -254,7 +273,8 @@ impl InstallCoordinator {
                 && self.same_document_incarnation(&uri, expected_incarnation)
             {
                 if !is_injection {
-                    self.parse_coordinator()
+                    parsed = self
+                        .parse_coordinator()
                         .reparse_installed_document(uri.clone(), language, expected_incarnation)
                         .await;
                 }
@@ -264,7 +284,10 @@ impl InstallCoordinator {
                     is_injection,
                     expected_incarnation,
                 ) {
-                    return true;
+                    return InstallCompletion {
+                        same_lifetime: true,
+                        parsed,
+                    };
                 }
                 if allow_recovery {
                     return Box::pin(self.maybe_auto_install_language(
@@ -276,7 +299,7 @@ impl InstallCoordinator {
                     ))
                     .await;
                 }
-                return false;
+                return InstallCompletion::default();
             }
             if terminal == crate::lsp::auto_install::InstallOutcome::Abandoned
                 && self.same_document_incarnation(&uri, expected_incarnation)
@@ -294,7 +317,10 @@ impl InstallCoordinator {
         } else {
             result.complete_claim();
         }
-        self.same_document_incarnation(&uri, expected_incarnation)
+        InstallCompletion {
+            same_lifetime: self.same_document_incarnation(&uri, expected_incarnation),
+            parsed,
+        }
     }
 
     /// Reload a language after installation and optionally re-parse the document.
@@ -310,7 +336,7 @@ impl InstallCoordinator {
         is_injection: bool,
         expected_incarnation: Option<u64>,
         claim: Option<&mut InstallResult>,
-    ) {
+    ) -> Option<super::parse::ParseLineage> {
         let reload = lock_settings_reload().await;
         let settings_snapshot = self.settings_manager.load_settings_pair();
         let (updated_raw_settings, updated_settings) = updated_settings_after_install(
@@ -348,7 +374,9 @@ impl InstallCoordinator {
             // injection reaches this same per-URI path after the claim completes.
             self.parse_coordinator()
                 .reparse_installed_document(uri, language, expected_incarnation)
-                .await;
+                .await
+        } else {
+            None
         }
     }
 
@@ -733,7 +761,7 @@ mod tests {
             data_dir: std::path::PathBuf::from("/installed"),
         });
 
-        assert!(waiter.await);
+        assert!(waiter.await.same_lifetime);
         assert!(server.documents.get(&first).unwrap().tree().is_some());
         assert!(server.documents.get(&second).unwrap().tree().is_some());
     }
@@ -770,7 +798,7 @@ mod tests {
             .register("rust".to_string(), tree_sitter_rust::LANGUAGE.into());
         drop(claim);
 
-        assert!(waiter.await);
+        assert!(waiter.await.same_lifetime);
         assert!(server.documents.get(&uri).unwrap().tree().is_some());
     }
 
@@ -890,6 +918,77 @@ mod tests {
         assert!(server.documents.get(&uri).unwrap().tree().is_none());
     }
 
+    #[tokio::test]
+    async fn available_parser_reports_only_its_own_parse() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".into(), tree_sitter_rust::LANGUAGE.into());
+        let uri = Url::parse("file:///own-install.rs").unwrap();
+        let incarnation = server.documents.insert(
+            uri.clone(),
+            "fn main() {}".into(),
+            Some("rust".into()),
+            None,
+        );
+        let install = server.install_coordinator();
+        let first = install
+            .maybe_auto_install_language("rust", uri.clone(), false, Some(incarnation), true)
+            .await;
+        assert!(first.same_lifetime);
+        let parsed = first.parsed.expect("this install published the parse");
+        assert!(parsed.matches(&server.documents.get(&uri).unwrap()));
+        let second = install
+            .maybe_auto_install_language("rust", uri.clone(), false, Some(incarnation), true)
+            .await;
+        assert!(
+            second.same_lifetime,
+            "already parsed is still successful recovery"
+        );
+        assert!(
+            second.parsed.is_none(),
+            "a current tree alone does not grant downstream work"
+        );
+    }
+
+    #[tokio::test]
+    async fn install_completion_cannot_cancel_a_newer_edits_eager_batch() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".into(), tree_sitter_rust::LANGUAGE.into());
+        let uri = Url::parse("file:///delayed-install.rs").unwrap();
+        let incarnation =
+            server
+                .documents
+                .insert(uri.clone(), "fn old() {}".into(), Some("rust".into()), None);
+        let completion = server
+            .install_coordinator()
+            .maybe_auto_install_language("rust", uri.clone(), false, Some(incarnation), true)
+            .await;
+        let parsed = completion.parsed.expect("install's own parse");
+        server
+            .documents
+            .update_document(uri.clone(), "fn edited() {}".into(), None);
+        server.parse_coordinator().reparse_latest(&uri, None).await;
+        assert!(server.documents.get(&uri).unwrap().has_current_tree());
+        let token = server.bridge.begin_test_eager_open_batch(&uri);
+        assert!(
+            !server
+                .injection_coordinator()
+                .process_injections_for_parse(&uri, parsed)
+                .await
+        );
+        assert!(
+            !token.is_cancelled(),
+            "a delayed install must leave the edit's batch intact"
+        );
+    }
+
     // `start_paused`: the healthy path returns without awaiting, so the bound
     // below needs no wall-clock time; a regressed guard instead parks on the
     // completion wait, the runtime goes idle, and the deadline fires at once.
@@ -937,7 +1036,7 @@ mod tests {
         )
         .await
         .expect("a stale task must return without awaiting an install");
-        assert!(!stale);
+        assert!(!stale.same_lifetime);
         assert!(
             tokio::time::timeout(std::time::Duration::from_millis(10), socket.next())
                 .await

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -746,7 +746,7 @@ mod tests {
             .language
             .language_registry_for_parallel()
             .register("rust".to_string(), tree_sitter_rust::LANGUAGE.into());
-        server
+        let owner_parse = server
             .install_coordinator()
             .reload_language_after_install(
                 "rust",
@@ -761,7 +761,19 @@ mod tests {
             data_dir: std::path::PathBuf::from("/installed"),
         });
 
-        assert!(waiter.await.same_lifetime);
+        let completion = waiter.await;
+        assert!(completion.same_lifetime);
+        assert!(
+            owner_parse
+                .expect("owner produced a parse")
+                .matches(&server.documents.get(&first).unwrap())
+        );
+        assert!(
+            completion
+                .parsed
+                .expect("waiter produced its own parse")
+                .matches(&server.documents.get(&second).unwrap())
+        );
         assert!(server.documents.get(&first).unwrap().tree().is_some());
         assert!(server.documents.get(&second).unwrap().tree().is_some());
     }
@@ -798,7 +810,14 @@ mod tests {
             .register("rust".to_string(), tree_sitter_rust::LANGUAGE.into());
         drop(claim);
 
-        assert!(waiter.await.same_lifetime);
+        let completion = waiter.await;
+        assert!(completion.same_lifetime);
+        assert!(
+            completion
+                .parsed
+                .expect("takeover produced a parse")
+                .matches(&server.documents.get(&uri).unwrap())
+        );
         assert!(server.documents.get(&uri).unwrap().tree().is_some());
     }
 

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -10,6 +10,21 @@ use url::Url;
 use crate::lsp::lsp_impl::{Kakehashi, build_notifier};
 use crate::lsp::settings_manager::SettingsManager;
 
+/// The document revision whose parse may drive downstream work. Enriching
+/// its region views keeps this identity; an edit or reopen does not.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ParseLineage {
+    pub(crate) incarnation: u64,
+    pub(crate) content_version: u64,
+}
+
+impl ParseLineage {
+    pub(crate) fn matches(self, document: &crate::document::Document) -> bool {
+        document.incarnation() == self.incarnation
+            && document.content_version() == self.content_version
+    }
+}
+
 /// Inputs of the initial snapshot. Region completion reuses that published
 /// snapshot directly and cannot submit these inputs again.
 struct SnapshotInputs {
@@ -510,22 +525,15 @@ impl ParseCoordinator {
     /// advance is a document already gone (a `didClose` removed it): its watermark
     /// channel is gone too, so its readers have already fallen back.
     ///
-    /// Returns `true` iff **this** call's install published the current tree
-    /// (i.e. it is the parse whose tree is now current). The off-ingress open caller gates its
-    /// tree-dependent downstream (`process_injections(forward=false)`, the deferred
-    /// refresh, the synthetic diagnostic) on this — **not** on "the document has a
-    /// tree": a `didChange` racing this parse can move the text on and let the edit
-    /// reparse publish the newer tree (and run `process_injections(forward=true)`)
-    /// first; this parse's install then reports not current, and re-checking `tree().is_some()` would
-    /// wrongly see the edit's tree and re-run the *open* downstream over it,
-    /// superseding the edit's eager-open batch. Gating on the own-install result is the
-    /// same discipline `reparse_latest` follows for its `populate_injections`.
+    /// Return the revision published by this parse only when it is current at
+    /// completion. Callers must validate it again at downstream admission: an
+    /// edit or reopen may win while this task is suspended after publication.
     pub(crate) async fn parse_document(
         &self,
         uri: Url,
         language_id: Option<&str>,
         ticket: Option<u64>,
-    ) -> bool {
+    ) -> Option<ParseLineage> {
         let mut events = Vec::new();
 
         // Read the text the registering didOpen already stored (a refcount bump, not
@@ -539,7 +547,7 @@ impl ParseCoordinator {
         // wakes its readers (they fall back). Unreachable while this parse is inline on
         // the writer ticket (a `didClose` is gated behind the open); the guard is for
         // the off-ingress open flip (#6), where a `didClose`/reopen can race it.
-        let Some((text, incarnation, content_version, version_cancel)) =
+        let (text, incarnation, content_version, version_cancel) =
             self.documents.get(&uri).map(|doc| {
                 (
                     doc.text_arc(),
@@ -547,10 +555,7 @@ impl ParseCoordinator {
                     doc.content_version(),
                     doc.version_cancel_token(),
                 )
-            })
-        else {
-            return false;
-        };
+            })?;
 
         // Publish the watermark on whichever path resolves the parse below, but
         // **only if this lifetime is still current**: a close + reopen re-seeds the
@@ -640,11 +645,12 @@ impl ParseCoordinator {
                 }
                 advance_watermark();
                 self.notifier().log_language_events(&events).await;
-                // `current` is exactly "this call published the current tree": false when a
-                // racing `didChange`/reopen moved the text or incarnation on and the
-                // edit reparse won, in which case the open downstream must NOT re-run
-                // over the edit's tree.
-                return installed.current_at_completion;
+                // Carry the producing revision across this await. Admission
+                // must still reject an edit/reopen that won after completion.
+                return installed.current_at_completion.then_some(ParseLineage {
+                    incarnation,
+                    content_version,
+                });
             }
 
             // Parse produced no tree (timeout / parser unavailable / join error) but
@@ -672,7 +678,7 @@ impl ParseCoordinator {
             }
             advance_watermark();
             self.notifier().log_language_events(&events).await;
-            return false;
+            return None;
         }
 
         // No language detected at all → store no language, no tree.
@@ -696,7 +702,7 @@ impl ParseCoordinator {
         }
         advance_watermark();
         self.notifier().log_language_events(&events).await;
-        false
+        None
     }
 
     /// Re-parse a document after its parser finished installing, **off the

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -732,12 +732,14 @@ impl ParseCoordinator {
     /// tree lands (or another parse wins). Sustained editing falls back to the
     /// reader's on-demand parse; the parse actor replaces this with a proper
     /// coalescing loop.
+    /// Return the revision this call published, if it completed current.
+    /// A tree already supplied by another parse grants no downstream work.
     pub(crate) async fn reparse_installed_document(
         &self,
         uri: Url,
         installed_language: &str,
         required_incarnation: Option<u64>,
-    ) {
+    ) -> Option<ParseLineage> {
         /// Bound on the convergence retries (a burst of edits landing exactly as
         /// the install completes); past this the reader on-demand parse covers it.
         const MAX_REPARSE_ATTEMPTS: usize = 8;
@@ -757,20 +759,18 @@ impl ParseCoordinator {
         // text legitimately changes within a lifetime (a `didChange`), so only the
         // text is re-read per attempt.
         let (language_name, expected_language_id, expected_incarnation) = {
-            let Some(doc) = self.documents.get(&uri) else {
-                return;
-            };
+            let doc = self.documents.get(&uri)?;
             if doc.has_current_tree() {
-                return;
+                return None;
             }
             if required_incarnation.is_some_and(|required| doc.incarnation() != required) {
-                return;
+                return None;
             }
             let language_name =
                 self.language
                     .detect_language(uri.path(), doc.text(), None, doc.language_id());
             if language_name.is_some() && language_name.as_deref() != Some(installed_language) {
-                return;
+                return None;
             }
             (
                 language_name,
@@ -782,7 +782,7 @@ impl ParseCoordinator {
             // Give-up: release a parked first-parse waiter (bootstrap-gated).
             self.documents
                 .publish_giveup_snapshot(&uri, expected_incarnation);
-            return;
+            return None;
         };
         let load_result = self
             .language
@@ -793,9 +793,10 @@ impl ParseCoordinator {
             self.documents
                 .publish_giveup_snapshot(&uri, expected_incarnation);
             self.notifier().log_language_events(&events).await;
-            return;
+            return None;
         }
 
+        let mut completed = None;
         for _ in 0..MAX_REPARSE_ATTEMPTS {
             // Re-read the latest text each attempt. Gone => closed (no resurrect);
             // already has a tree => a concurrent parse won; a changed incarnation =>
@@ -884,6 +885,10 @@ impl ParseCoordinator {
                 ));
             }
             if installed.current_at_completion {
+                completed = Some(ParseLineage {
+                    incarnation: expected_incarnation,
+                    content_version,
+                });
                 break;
             }
             // Not current: the text moved under us (a concurrent `didChange`
@@ -899,6 +904,7 @@ impl ParseCoordinator {
         self.documents
             .publish_giveup_snapshot(&uri, expected_incarnation);
         self.notifier().log_language_events(&events).await;
+        completed
     }
 
     /// Re-parse `uri`'s **latest** store text off the ingress path, for the

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -533,6 +533,7 @@ impl ParseCoordinator {
         uri: Url,
         language_id: Option<&str>,
         ticket: Option<u64>,
+        expected_incarnation: Option<u64>,
     ) -> Option<ParseLineage> {
         let mut events = Vec::new();
 
@@ -548,13 +549,16 @@ impl ParseCoordinator {
         // the writer ticket (a `didClose` is gated behind the open); the guard is for
         // the off-ingress open flip (#6), where a `didClose`/reopen can race it.
         let (text, incarnation, content_version, version_cancel) =
-            self.documents.get(&uri).map(|doc| {
-                (
+            self.documents.get(&uri).and_then(|doc| {
+                if expected_incarnation.is_some_and(|expected| doc.incarnation() != expected) {
+                    return None;
+                }
+                Some((
                     doc.text_arc(),
                     doc.incarnation(),
                     doc.content_version(),
                     doc.version_cancel_token(),
-                )
+                ))
             })?;
 
         // Publish the watermark on whichever path resolves the parse below, but

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -549,7 +549,7 @@ mod tests {
         assert!(
             server
                 .parse_coordinator()
-                .parse_document(uri.clone(), Some("rust"), None)
+                .parse_document(uri.clone(), Some("rust"), None, None)
                 .await
                 .is_some()
         );
@@ -574,7 +574,7 @@ mod tests {
                 assert!(
                     server
                         .parse_coordinator()
-                        .parse_document(uri.clone(), Some("go"), None)
+                        .parse_document(uri.clone(), Some("go"), None, None)
                         .await
                         .is_some()
                 );

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -551,6 +551,7 @@ mod tests {
                 .parse_coordinator()
                 .parse_document(uri.clone(), Some("rust"), None)
                 .await
+                .is_some()
         );
         let params = NodeParams {
             text_document: TextDocumentIdentifier {
@@ -575,6 +576,7 @@ mod tests {
                         .parse_coordinator()
                         .parse_document(uri.clone(), Some("go"), None)
                         .await
+                        .is_some()
                 );
             })
             .await

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -447,6 +447,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stale_open_cannot_register_diagnostics_for_an_edited_document() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+        server.bridge.insert_ready_test_connection("rust_ls").await;
+        let uri = Url::parse("file:///test/stale-open-diagnostic.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn original() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        let original = server
+            .parse_coordinator()
+            .parse_document(uri.clone(), Some("rust"), None, None)
+            .await
+            .expect("open parse completes");
+        server
+            .documents
+            .update_document(uri.clone(), "fn edited() {}".to_string(), None);
+        let edited = server
+            .parse_coordinator()
+            .parse_document(uri.clone(), Some("rust"), None, None)
+            .await
+            .expect("edited parse completes");
+        assert_eq!(original.incarnation, edited.incarnation);
+        assert_ne!(original.content_version, edited.content_version);
+        assert!(!server.synthetic_diagnostics.has_active_task(&uri));
+
+        spawn_synthetic_diagnostic_for_parse(
+            &server.documents,
+            &server.diagnostic_scheduler(),
+            uri.clone(),
+            original,
+            std::future::ready(()),
+        )
+        .await;
+        assert!(
+            !server.synthetic_diagnostics.has_active_task(&uri),
+            "stale open must not register a task using the edited tree"
+        );
+
+        spawn_synthetic_diagnostic_for_parse(
+            &server.documents,
+            &server.diagnostic_scheduler(),
+            uri.clone(),
+            edited,
+            std::future::ready(()),
+        )
+        .await;
+        assert!(
+            server.synthetic_diagnostics.has_active_task(&uri),
+            "the current parse must be eligible for diagnostic registration"
+        );
+        server.synthetic_diagnostics.remove_document(&uri);
+    }
+
+    #[tokio::test]
     async fn delayed_open_parse_cannot_relabel_a_reopened_document() {
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -244,7 +244,7 @@ impl Kakehashi {
             }
         } else if self.is_cli_mode() {
             self.parse_coordinator()
-                .parse_document(uri.clone(), Some(&language_id), ticket)
+                .parse_document(uri.clone(), Some(&language_id), ticket, Some(incarnation))
                 .await;
             if !deferred_events.is_empty() {
                 self.notifier().log_language_events(&deferred_events).await;
@@ -274,7 +274,12 @@ impl Kakehashi {
             let deferred = std::mem::take(&mut deferred_events);
             tokio::spawn(async move {
                 let landed = parse
-                    .parse_document(parse_uri.clone(), Some(parse_language_id.as_str()), ticket)
+                    .parse_document(
+                        parse_uri.clone(),
+                        Some(parse_language_id.as_str()),
+                        ticket,
+                        Some(incarnation),
+                    )
                     .await;
                 // Publication grants a revision, not a permanent permission.
                 // The downstream rechecks it under its lifecycle lock so a
@@ -385,7 +390,7 @@ mod tests {
         );
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), Some("rust"), None)
+            .parse_document(uri.clone(), Some("rust"), None, None)
             .await;
 
         let (locked_tx, locked_rx) = tokio::sync::oneshot::channel();
@@ -439,6 +444,39 @@ mod tests {
             !server.synthetic_diagnostics.has_active_task(&uri),
             "didClose must remove the install recovery diagnostic registration"
         );
+    }
+
+    #[tokio::test]
+    async fn delayed_open_parse_cannot_relabel_a_reopened_document() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".into(), tree_sitter_rust::LANGUAGE.into());
+        let uri = Url::parse("file:///test/delayed-open.rs").unwrap();
+        let original =
+            server
+                .documents
+                .insert(uri.clone(), "fn old() {}".into(), Some("rust".into()), None);
+        server.documents.remove(&uri);
+        let reopened =
+            server
+                .documents
+                .insert(uri.clone(), "package main".into(), Some("go".into()), None);
+        assert_ne!(original, reopened);
+        // The spawned old-open task starts only after the new lifetime exists.
+        let result = server
+            .parse_coordinator()
+            .parse_document(uri.clone(), Some("rust"), None, Some(original))
+            .await;
+        assert!(
+            result.is_none(),
+            "the delayed open must not parse the new lifetime"
+        );
+        let document = server.documents.get(&uri).unwrap();
+        assert_eq!(document.language_id(), Some("go"));
+        assert!(document.tree().is_none());
     }
 
     #[tokio::test]
@@ -1243,7 +1281,7 @@ print("hello")
             .insert(uri.clone(), text.clone(), Some("rust".to_string()), None);
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), Some("rust"), None)
+            .parse_document(uri.clone(), Some("rust"), None, None)
             .await;
 
         let snapshot = server
@@ -1281,7 +1319,7 @@ print("hello")
         );
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), Some("rust"), None)
+            .parse_document(uri.clone(), Some("rust"), None, None)
             .await;
         assert!(
             server
@@ -1351,7 +1389,7 @@ print("hello")
 
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), Some("rust"), None)
+            .parse_document(uri.clone(), Some("rust"), None, None)
             .await;
 
         assert!(
@@ -1384,7 +1422,7 @@ print("hello")
         );
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), Some("rust"), None)
+            .parse_document(uri.clone(), Some("rust"), None, None)
             .await;
         assert!(
             server
@@ -1750,7 +1788,7 @@ print("hello")
             .insert(uri.clone(), text.clone(), Some("rust".to_string()), None);
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), Some("rust"), None)
+            .parse_document(uri.clone(), Some("rust"), None, None)
             .await;
 
         let snapshot = server
@@ -1792,7 +1830,7 @@ print("hello")
         );
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), Some("rust"), None)
+            .parse_document(uri.clone(), Some("rust"), None, None)
             .await;
 
         let snapshot = server

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -6,11 +6,11 @@ use super::super::{Kakehashi, build_notifier, uri_to_url};
 use crate::document::DocumentStore;
 use crate::language::LanguageEvent;
 
-async fn spawn_synthetic_diagnostic_for_incarnation<F>(
+async fn spawn_synthetic_diagnostic_for_parse<F>(
     documents: &DocumentStore,
     diagnostic_scheduler: &crate::lsp::lsp_impl::coordinator::DiagnosticScheduler,
     uri: url::Url,
-    incarnation: u64,
+    lineage: crate::lsp::lsp_impl::coordinator::ParseLineage,
     after_lifecycle_lock: F,
 ) where
     F: std::future::Future<Output = ()>,
@@ -22,10 +22,10 @@ async fn spawn_synthetic_diagnostic_for_incarnation<F>(
         documents.remove_edit_lock_if_unshared(&uri, &edit_lock);
         return;
     };
-    let eligible = document.incarnation() == incarnation && document.has_current_tree();
+    let eligible = lineage.matches(&document) && document.has_current_tree();
     drop(document);
     if eligible {
-        diagnostic_scheduler.spawn_synthetic_diagnostic_task(uri);
+        diagnostic_scheduler.spawn_synthetic_diagnostic_task_for_parse(uri, lineage);
     }
 }
 
@@ -143,7 +143,7 @@ impl Kakehashi {
                     // spawn is pure wasted work and races the bridge-state sweep.
                     let is_cli_mode = self.is_cli_mode();
                     tokio::spawn(async move {
-                        let same_lifetime = install
+                        let completion = install
                             .maybe_auto_install_language(
                                 &lang,
                                 install_uri.clone(),
@@ -152,32 +152,16 @@ impl Kakehashi {
                                 true,
                             )
                             .await;
-                        if !same_lifetime {
+                        if !completion.same_lifetime {
                             return;
                         }
-                        // The skipped inline parse meant the handler's
-                        // process_injections (below) ran with no tree. Now that the
-                        // off-ingress reparse may have produced one, run the normal
-                        // post-parse injection workflow — injected-language install
-                        // and eager bridge spawn — which also keeps that injected
-                        // install off the ingress ticket. forward=false: open path.
-                        //
-                        // Gate on the document actually having a tree: install can
-                        // fail or be deduped (AlreadyInstalling) with no reparse, and
-                        // process_injections would otherwise cancel the eager-open
-                        // for a still-tree-less document.
-                        let has_tree = documents.get(&install_uri).is_some_and(|doc| {
-                            doc.incarnation() == incarnation && doc.has_current_tree()
-                        });
-                        if has_tree {
-                            let same_lifetime = injection
-                                .process_injections_for_incarnation(
-                                    &install_uri,
-                                    false,
-                                    incarnation,
-                                )
-                                .await;
-                            if !same_lifetime {
+                        // Only a parse published by this install grants open
+                        // downstream work. A sibling's current tree does not.
+                        if let Some(lineage) = completion.parsed {
+                            if !injection
+                                .process_injections_for_parse(&install_uri, lineage)
+                                .await
+                            {
                                 return;
                             }
                             // Re-fire the proactive synthetic diagnostic now that a
@@ -187,11 +171,11 @@ impl Kakehashi {
                             // first open of a just-installed parser. Skipped in CLI
                             // mode (#489), matching the handler's own gate.
                             if !is_cli_mode {
-                                spawn_synthetic_diagnostic_for_incarnation(
+                                spawn_synthetic_diagnostic_for_parse(
                                     &documents,
                                     &diagnostic_scheduler,
                                     install_uri,
-                                    incarnation,
+                                    lineage,
                                     std::future::ready(()),
                                 )
                                 .await;
@@ -278,6 +262,7 @@ impl Kakehashi {
             let parse = self.parse_coordinator();
             let injection = self.injection_coordinator();
             let diagnostic_scheduler = self.diagnostic_scheduler();
+            let documents = std::sync::Arc::clone(&self.documents);
             let client = self.client.clone();
             let settings_manager = std::sync::Arc::clone(&self.settings_manager);
             let parse_uri = uri.clone();
@@ -306,8 +291,14 @@ impl Kakehashi {
                             .log_language_events(&deferred)
                             .await;
                     }
-                    diagnostic_scheduler
-                        .spawn_synthetic_diagnostic_task_for_parse(parse_uri, lineage);
+                    spawn_synthetic_diagnostic_for_parse(
+                        &documents,
+                        &diagnostic_scheduler,
+                        parse_uri,
+                        lineage,
+                        std::future::ready(()),
+                    )
+                    .await;
                 }
             });
         }
@@ -360,11 +351,14 @@ mod tests {
         let weak_lock = std::sync::Arc::downgrade(&edit_lock);
         drop(edit_lock);
 
-        spawn_synthetic_diagnostic_for_incarnation(
+        spawn_synthetic_diagnostic_for_parse(
             &server.documents,
             &server.diagnostic_scheduler(),
             uri,
-            1,
+            crate::lsp::lsp_impl::coordinator::ParseLineage {
+                incarnation: 1,
+                content_version: 0,
+            },
             std::future::ready(()),
         )
         .await;
@@ -400,11 +394,14 @@ mod tests {
         let scheduler = server.diagnostic_scheduler();
         let recovery_uri = uri.clone();
         let recovery = tokio::spawn(async move {
-            spawn_synthetic_diagnostic_for_incarnation(
+            spawn_synthetic_diagnostic_for_parse(
                 &documents,
                 &scheduler,
                 recovery_uri,
-                incarnation,
+                crate::lsp::lsp_impl::coordinator::ParseLineage {
+                    incarnation,
+                    content_version: 0,
+                },
                 async move {
                     let _ = locked_tx.send(());
                     let _ = release_rx.await;

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -291,24 +291,23 @@ impl Kakehashi {
                 let landed = parse
                     .parse_document(parse_uri.clone(), Some(parse_language_id.as_str()), ticket)
                     .await;
-                // Run the open downstream only when THIS parse's install published the
-                // current tree — not merely when "a tree exists". A `didChange` racing
-                // this open parse can move the text on and let the edit reparse publish
-                // the newer tree (and run `process_injections(forward=true)`) first;
-                // this parse is then reported not current (`landed == false`). Re-running the open downstream
-                // (`process_injections(forward=false)`) over the edit's tree would
-                // supersede the edit's eager-open batch. When `landed` is false the
-                // edit reparse owns the current tree and already ran the correct
-                // downstream, so there is nothing for the open path to do. (A parse
-                // that produced no tree at all also returns false.)
-                if landed {
-                    injection.process_injections(&parse_uri, false).await;
+                // Publication grants a revision, not a permanent permission.
+                // The downstream rechecks it under its lifecycle lock so a
+                // delayed open cannot supersede the newer edit's eager batch.
+                if let Some(lineage) = landed {
+                    if !injection
+                        .process_injections_for_parse(&parse_uri, lineage)
+                        .await
+                    {
+                        return;
+                    }
                     if !deferred.is_empty() {
                         build_notifier(&client, &settings_manager)
                             .log_language_events(&deferred)
                             .await;
                     }
-                    diagnostic_scheduler.spawn_synthetic_diagnostic_task(parse_uri);
+                    diagnostic_scheduler
+                        .spawn_synthetic_diagnostic_task_for_parse(parse_uri, lineage);
                 }
             });
         }

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -1968,7 +1968,7 @@ mod tests {
 
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), Some("markdown"), None)
+            .parse_document(uri.clone(), Some("markdown"), None, None)
             .await;
 
         // The published snapshot must carry the derived discovery.
@@ -2047,7 +2047,7 @@ mod tests {
         // run before the first request — as didOpen arranges in production.
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), Some("lua"), None)
+            .parse_document(uri.clone(), Some("lua"), None, None)
             .await;
 
         // First request: semanticTokens/full to get the initial result_id.


### PR DESCRIPTION
An open parse can finish after an edit and cancel that edit’s eager injection work or schedule diagnostics against a different revision. Bind open and auto-install follow-ups to the incarnation and content version of the parse they actually produced, and revalidate under the lifecycle lock immediately before downstream work.

Installer success now distinguishes a surviving document lifetime from an owned parse completion. Deferred open retries retain that lineage and use a separate retry slot from edit work; same-revision region enrichment remains eligible. A delayed open also cannot begin parsing a replacement document after close/reopen. Detached eager routing retains its admitted batch generation, is tracked until child registration finishes, and releases only its own routing tokens on cancellation.

Validation: deterministic stale-open/eager-batch, retry-slot, region-enrichment, close/reopen, installer ownership, and synthetic-registration regressions; `make check`; all-target/all-feature Clippy; 3,735 library tests; 445 E2E and 79 integration tests passed (one E2E ignored).

Fixes #1066.

First PR in the follow-up stack; #1065, #1068, and #1063 follow separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale parsing results from triggering diagnostics or injection processing after a document is edited, reopened, or reparsed.
  * Improved delayed language installation and retry handling so newer document changes are not overwritten or cancelled by older work.
  * Preserved valid same-revision updates while rejecting outdated results.
  * Improved eager document opening by preventing stale batches from superseding newer work and ensuring routing resources are released.

* **Documentation**
  * Updated architecture guidance to require validating that follow-up actions still correspond to the revision that produced them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->