### PR TITLE
fix(parse): reconcile provisional host language

### DIFF
--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -72,8 +72,8 @@ gates:
 - **Language detection is split by layer.** The input `language_id` starts as the
   client-declared LSP `languageId` that `didOpen` records. In the current
   store-backed path, an open parse can still write the detected language back to
-  `Document::language_id`. A current edit parse can also establish an unlabelled
-  document's language atomically with its tree publication; a stale parse cannot.
+  `Document::language_id`. A current edit parse can also refine a provisional
+  document label atomically with its tree publication; a stale parse cannot.
   The snapshot architecture separates the parser result by
   recording the parse result as the snapshot's own **derived** `language`. The
   snapshot carries the more-accurate detected language, and readers use the
@@ -195,9 +195,12 @@ fallback rather than turning an unavailable result into a definitive empty one.
   the version compare is only ever within one lifetime.
 - **Language checks guard captured input labels as well as incarnation.** Every
   reopen draws a fresh incarnation. Reparses preserve established labels with
-  `LanguageCheck::Expect`; an unlabelled edit uses `RecordIfUnchanged(None)` so
-  its current publish can establish the detected language without overwriting a
-  concurrent refinement. After such a publish, regions completion validates the
+  `LanguageCheck::Expect`. A label is provisional if absent, or if it differs
+  from the detected grammar and has no language configuration, eligible base,
+  available parser, or explicit bridge-server language declaration. Wildcard
+  bridge support alone does not establish a label. Provisional labels use
+  `RecordIfUnchanged(captured_label)` so a current publish can establish the
+  detected language without overwriting a concurrent refinement. After such a publish, regions completion validates the
   newly stored label, along with the exact first-published snapshot identity.
   A stale publish records no label and completion keeps the original expectation.
   The snapshot's detected language can still move with edited content (such as

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -72,7 +72,9 @@ gates:
 - **Language detection is split by layer.** The input `language_id` starts as the
   client-declared LSP `languageId` that `didOpen` records. In the current
   store-backed path, an open parse can still write the detected language back to
-  `Document::language_id`; the snapshot architecture separates that refinement by
+  `Document::language_id`. A current edit parse can also establish an unlabelled
+  document's language atomically with its tree publication; a stale parse cannot.
+  The snapshot architecture separates the parser result by
   recording the parse result as the snapshot's own **derived** `language`. The
   snapshot carries the more-accurate detected language, and readers use the
   snapshot's value instead of requiring a relabelled input document.
@@ -191,15 +193,15 @@ fallback rather than turning an unavailable result into a definitive empty one.
   still checks `incarnation == current_incarnation` (it is not an unconditional
   early-return), so a straggler publish from lifetime N is rejected against N+1 and
   the version compare is only ever within one lifetime.
-- **Language axis** is subsumed by incarnation for the *stored label*: every
-  reopen draws a fresh incarnation (so a relabel across lifetimes is already
-  rejected), and within one lifetime `Document::language_id` does not change —
-  the reparses' `LanguageCheck::Expect` guards exactly that. The *detected*
-  language a snapshot carries may still move within a lifetime (detection re-runs
-  on the edited text: a rewritten shebang), which is why the seed is bound to
-  the snapshot's grammar independently. The three-axis edit-path CAS
-  (`incarnation && text && language`) therefore reduces to `incarnation && version`
-  for admission, plus the language check on install.
+- **Language checks guard captured input labels as well as incarnation.** Every
+  reopen draws a fresh incarnation. Reparses preserve established labels with
+  `LanguageCheck::Expect`; an unlabelled edit uses `RecordIfUnchanged(None)` so
+  its current publish can establish the detected language without overwriting a
+  concurrent refinement. After such a publish, regions completion validates the
+  newly stored label, along with the exact first-published snapshot identity.
+  A stale publish records no label and completion keeps the original expectation.
+  The snapshot's detected language can still move with edited content (such as
+  a rewritten shebang), so incremental seeds remain bound to its grammar.
 - **Isolation is per-request re-resolution + incarnation validation, not cell identity.** A `latest_snapshot(uri)` call resolves the *current* cell from the
   store each time and never caches a `Receiver` across requests, and it validates
   `snapshot.incarnation == <live document incarnation>` before serving. To keep that
@@ -690,10 +692,10 @@ inside the existing safety contracts at each step:
   `didClose` removed. (It is *not* closed by Stage 1, which leaves the current
   inline-parse fallbacks — `try_parse_and_update_document`, `selection_range_impl` —
   in place; those are the vector, and they are removed in Stage 2.)
-- Latent language-detection staleness is closed as a side effect:
-  `ParseSnapshot.language` carries the *parse's* detected language, so readers
-  see the refined language without depending on `Document::language_id` being
-  rewritten or requiring a re-`didOpen`.
+- Snapshot readers see the parse's detected language directly through
+  `ParseSnapshot.language`. Store-label readers, including host bridge routing,
+  additionally need a current publish to refine an unlabelled document when the
+  open parse lost to an edit.
 - State and coupling shrink: two `watch` maps collapse to one, six store CAS /
   watermark methods to one publish primitive (tree writes done — `install_parse`;
   watermark advances pending), and the `pending_seed` invariant

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -697,7 +697,7 @@ inside the existing safety contracts at each step:
   in place; those are the vector, and they are removed in Stage 2.)
 - Snapshot readers see the parse's detected language directly through
   `ParseSnapshot.language`. Store-label readers, including host bridge routing,
-  additionally need a current publish to refine an unlabelled document when the
+  additionally need a current publish to refine a provisional document label when the
   open parse lost to an edit.
 - State and coupling shrink: two `watch` maps collapse to one, six store CAS /
   watermark methods to one publish primitive (tree writes done — `install_parse`;

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -72,7 +72,7 @@ gates:
 - **Language detection is split by layer.** The input `language_id` starts as the
   client-declared LSP `languageId` that `didOpen` records. In the current
   store-backed path, an open parse can still write the detected language back to
-  `Document::language_id`. A current edit parse can also refine a provisional
+  `Document::language_id`. A current edit or installer reparse can also refine a provisional
   document label atomically with its tree publication; a stale parse cannot.
   The snapshot architecture separates the parser result by
   recording the parse result as the snapshot's own **derived** `language`. The

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -730,6 +730,10 @@ pub(crate) struct ParseInstall {
     /// same entry guard as the publish, so a reparse's refresh gate needs no
     /// probe of its own that a racing give-up could invalidate.
     pub(crate) tree_upgrade: bool,
+    /// This current publish replaced an existing label with a detected grammar.
+    /// An already opened host must be reconciled even if an edit overtakes
+    /// completion. Unlabelled inputs have no provisional eager host open.
+    pub(crate) host_language_changed: bool,
 }
 
 impl DocumentStore {
@@ -826,6 +830,14 @@ impl DocumentStore {
                     // A provisional label is refined atomically with the current
                     // tree. A stale publish must not establish language for an edit
                     // whose own detection may have selected a different grammar.
+                    let host_language_changed = current
+                        && doc.language_id().is_some()
+                        && detected.is_some()
+                        && doc.language_id() != detected.as_deref()
+                        && matches!(
+                            language,
+                            LanguageCheck::Record | LanguageCheck::RecordIfUnchanged(_)
+                        );
                     if current
                         && matches!(
                             language,
@@ -838,6 +850,7 @@ impl DocumentStore {
                         current,
                         published,
                         tree_upgrade: published && fills_placeholder,
+                        host_language_changed,
                     }
                 });
         // Likewise a rejected `snapshot` (still owned here: the publish
@@ -925,7 +938,8 @@ mod tests {
             ParseInstall {
                 current: false,
                 published: true,
-                tree_upgrade: false
+                tree_upgrade: false,
+                host_language_changed: false,
             }
         );
         assert!(store.get(&uri).unwrap().tree().is_none());
@@ -975,7 +989,8 @@ mod tests {
             ParseInstall {
                 current: false,
                 published: true,
-                tree_upgrade: false
+                tree_upgrade: false,
+                host_language_changed: false,
             }
         );
         assert_eq!(
@@ -1271,7 +1286,8 @@ mod tests {
             ParseInstall {
                 current: true,
                 published: true,
-                tree_upgrade: false
+                tree_upgrade: false,
+                host_language_changed: false,
             },
             "same version, same lifetime: the current parse, whichever allocation it read"
         );
@@ -1301,7 +1317,8 @@ mod tests {
             ParseInstall {
                 current: true,
                 published: true,
-                tree_upgrade: false
+                tree_upgrade: false,
+                host_language_changed: false,
             }
         );
         let doc = store.get(&uri).unwrap();
@@ -1594,7 +1611,8 @@ mod tests {
             ParseInstall {
                 current: true,
                 published: true,
-                tree_upgrade: false
+                tree_upgrade: false,
+                host_language_changed: false,
             }
         );
         assert!(store.get(&uri).unwrap().tree().is_some(), "tree visible");

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -940,12 +940,14 @@ mod tests {
         );
     }
 
-    /// The open parse records its detected language only when it is current:
+    /// A recording parse changes the stored language only when it is current:
     /// one that lost the race to a `didChange` publishes as stale but must
     /// not relabel the document under the edit's reparse, which was captured
     /// against the stored label.
-    #[test]
-    fn install_parse_records_the_language_only_when_current() {
+    #[rstest::rstest]
+    #[case(LanguageCheck::Record)]
+    #[case(LanguageCheck::RecordIfUnchanged(Some("markdown")))]
+    fn install_parse_records_the_language_only_when_current(#[case] language: LanguageCheck<'_>) {
         let store = DocumentStore::new();
         let uri = Url::parse("file:///relabel.md").unwrap();
         let text = "# doc\n";
@@ -967,7 +969,7 @@ mod tests {
             incarnation,
         );
         Arc::get_mut(&mut snapshot).unwrap().language = Some("relabelled".to_string());
-        let outcome = store.install_parse(&uri, LanguageCheck::Record, snapshot);
+        let outcome = store.install_parse(&uri, language, snapshot);
         assert_eq!(
             outcome,
             ParseInstall {
@@ -979,17 +981,17 @@ mod tests {
         assert_eq!(
             store.get(&uri).unwrap().language_id(),
             Some("markdown"),
-            "a stale open parse must not relabel the document"
+            "a stale recording parse must not relabel the document"
         );
     }
 
-    /// A reparse checks the stored language and publishes the tree without
-    /// relabelling the document: detection may resolve a stored `sh` to its
+    /// A preserving reparse checks the stored language and publishes its tree
+    /// without relabelling the document: detection may resolve a stored `sh` to its
     /// `bash` base, and the stored id stays `sh` (the snapshot carries the
     /// detected name). The open parse, which checks nothing, records what it
     /// detected — the label a client-supplied `text` becomes `markdown`.
     #[test]
-    fn install_parse_relabels_only_on_the_open_parse() {
+    fn install_parse_preserves_checked_labels_and_records_open_detection() {
         let store = DocumentStore::new();
         let uri = Url::parse("file:///label.md").unwrap();
         let text = "# doc\n";
@@ -1044,9 +1046,31 @@ mod tests {
         assert!(store.get(&uri2).unwrap().tree().is_some());
     }
 
+    #[test]
+    fn provisional_publish_cannot_overwrite_a_concurrent_label_refinement() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///refined.md").unwrap();
+        let text: Arc<str> = Arc::from("# document");
+        let incarnation = store.insert(uri.clone(), text.to_string(), None, None);
+        let version = store.get(&uri).unwrap().content_version();
+        store
+            .documents
+            .get_mut(&uri)
+            .unwrap()
+            .record_language(Some("configured".into()));
+        let result = store.install_parse(
+            &uri,
+            LanguageCheck::RecordIfUnchanged(None),
+            parse_snapshot(&text, Some(markdown_tree(&text)), version, incarnation),
+        );
+        assert_eq!(result, ParseInstall::default());
+        assert_eq!(store.get(&uri).unwrap().language_id(), Some("configured"));
+        assert!(store.get(&uri).unwrap().tree().is_none());
+    }
+
     /// A same-language, identical-text reopen draws a new lifetime with the
     /// revision counter back at zero: the incarnation is the only input that
-    /// tells the prior lifetime's parse apart, in both check modes.
+    /// tells the prior lifetime's parse apart, in all language check modes.
     #[test]
     fn install_parse_rejects_the_prior_lifetime_after_an_identical_reopen() {
         let store = DocumentStore::new();
@@ -1082,6 +1106,7 @@ mod tests {
         for language in [
             LanguageCheck::Expect(Some("markdown")),
             LanguageCheck::Record,
+            LanguageCheck::RecordIfUnchanged(Some("markdown")),
         ] {
             let stale = store.install_parse(
                 &uri,

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -708,6 +708,9 @@ pub(crate) enum LanguageCheck<'a> {
     /// is rejected — a tree from the old grammar must not reach a relabelled
     /// reopen — and the stored language is left as it is.
     Expect(Option<&'a str>),
+    /// Refine a provisional label only when it still matches the captured input
+    /// and the snapshot is current. Configured labels use `Expect` instead.
+    RecordIfUnchanged(Option<&'a str>),
 }
 
 /// The outcome of [`DocumentStore::install_parse`].
@@ -744,7 +747,8 @@ impl DocumentStore {
         regions: Option<super::snapshot::ResolvedRegions>,
     ) -> bool {
         let current_at_completion = self.documents.get_mut(uri).is_some_and(|doc| {
-            if let LanguageCheck::Expect(language) = language
+            if let LanguageCheck::Expect(language) | LanguageCheck::RecordIfUnchanged(language) =
+                language
                 && doc.language_id() != language
             {
                 return false;
@@ -796,40 +800,46 @@ impl DocumentStore {
         // dropping a tree (and its layer trees, its region vectors) is not
         // free, and the shard's readers would wait on it otherwise.
         let mut evicted = None;
-        let outcome = self
-            .documents
-            .get_mut(uri)
-            .map_or_else(ParseInstall::default, |mut doc| {
-                evicted = doc.latest_snapshot_slot().snapshot;
-                if let LanguageCheck::Expect(expected) = language
-                    && doc.language_id() != expected
-                {
-                    return ParseInstall::default();
-                }
-                let parsed_current_version = snapshot.parsed_version == doc.content_version();
-                let detected = snapshot.language.clone();
-                // Read before the publish, under the same guard: the held
-                // snapshot is what this publish upgrades, if anything.
-                let fills_placeholder = has_tree
-                    && evicted.as_ref().is_some_and(|held| {
-                        held.parsed_version == version
-                            && held.incarnation == incarnation
-                            && held.tree.is_none()
-                    });
-                let published = doc.publish_snapshot(&snapshot);
-                let current = published && parsed_current_version;
-                // The reparses do not relabel (the snapshot carries the
-                // detected name for its own readers); only the open parse
-                // records what it detected.
-                if current && matches!(language, LanguageCheck::Record) {
-                    doc.record_language(detected);
-                }
-                ParseInstall {
-                    current,
-                    published,
-                    tree_upgrade: published && fills_placeholder,
-                }
-            });
+        let outcome =
+            self.documents
+                .get_mut(uri)
+                .map_or_else(ParseInstall::default, |mut doc| {
+                    evicted = doc.latest_snapshot_slot().snapshot;
+                    if let LanguageCheck::Expect(expected)
+                    | LanguageCheck::RecordIfUnchanged(expected) = language
+                        && doc.language_id() != expected
+                    {
+                        return ParseInstall::default();
+                    }
+                    let parsed_current_version = snapshot.parsed_version == doc.content_version();
+                    let detected = snapshot.language.clone();
+                    // Read before the publish, under the same guard: the held
+                    // snapshot is what this publish upgrades, if anything.
+                    let fills_placeholder = has_tree
+                        && evicted.as_ref().is_some_and(|held| {
+                            held.parsed_version == version
+                                && held.incarnation == incarnation
+                                && held.tree.is_none()
+                        });
+                    let published = doc.publish_snapshot(&snapshot);
+                    let current = published && parsed_current_version;
+                    // A provisional label is refined atomically with the current
+                    // tree. A stale publish must not establish language for an edit
+                    // whose own detection may have selected a different grammar.
+                    if current
+                        && matches!(
+                            language,
+                            LanguageCheck::Record | LanguageCheck::RecordIfUnchanged(_)
+                        )
+                    {
+                        doc.record_language(detected);
+                    }
+                    ParseInstall {
+                        current,
+                        published,
+                        tree_upgrade: published && fills_placeholder,
+                    }
+                });
         // Likewise a rejected `snapshot` (still owned here: the publish
         // borrows) — destroyed only after the guard is released.
         drop(evicted);

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1241,6 +1241,27 @@ impl LanguageCoordinator {
             && self.has_current_parser_registration(language_name, generation)
     }
 
+    /// Whether a stored host label carries parser or configuration identity
+    /// that a fallback parse must preserve. Explicit bridge languages count even
+    /// without a Tree-sitter parser; a wildcard server does not declare every
+    /// unknown client label to be a language.
+    pub(crate) fn is_declared_host_language(
+        &self,
+        language_id: &str,
+        settings: &WorkspaceSettings,
+    ) -> bool {
+        settings.languages.contains_key(language_id)
+            || self.resolve_base(language_id).is_some()
+            || self.has_parser_available(language_id)
+            || settings.language_servers.values().any(|server| {
+                server.languages.as_ref().is_some_and(|languages| {
+                    languages
+                        .iter()
+                        .any(|language| language != "*" && language == language_id)
+                })
+            })
+    }
+
     /// Parser-aware language-detection fallback chain for host documents;
     /// returns the first language with an available parser. Each stage is
     /// detect → base resolution → availability:

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -28,10 +28,13 @@ mod actor;
 mod client;
 mod client_progress;
 mod connection;
+#[cfg(all(test, unix))]
+pub(crate) use connection::BridgeReader;
 pub(crate) mod coordinator;
 pub(crate) mod envelope;
 mod inbound_request_registry;
 mod pool;
+pub(crate) use pool::HostLanguageAdmission;
 mod progress_registry;
 mod protocol;
 mod root_markers;
@@ -47,6 +50,8 @@ mod workspace;
 pub(crate) use actor::ForwardedRequestCancel;
 #[cfg(test)]
 pub(crate) use actor::OutboundMessage;
+#[cfg(all(test, unix))]
+pub(crate) use actor::RouteResult;
 pub(crate) use actor::UpstreamNotification;
 pub(crate) use actor::UpstreamRequest;
 pub(crate) use client_progress::{

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -609,6 +609,40 @@ impl BridgeCoordinator {
         self.pool.insert_connection(handle).await;
     }
 
+    #[cfg(all(test, unix))]
+    pub(crate) fn has_host_eager_batch_for_test(&self, uri: &Url) -> bool {
+        self.host_eager_open_tasks.contains_key(uri)
+    }
+
+    #[cfg(all(test, unix))]
+    pub(crate) async fn insert_recording_test_connection(
+        &self,
+        server_name: &str,
+        path: &std::path::Path,
+    ) -> Arc<super::pool::ConnectionHandle> {
+        use super::pool::{ConnectionKey, ConnectionState};
+        let (handle, _) = super::pool::test_helpers::create_handle_with_command(
+            ConnectionState::Ready,
+            ConnectionKey::for_server(server_name),
+            vec![
+                "sh".into(),
+                "-c".into(),
+                "cat > \"$1\"".into(),
+                "record".into(),
+                path.to_str().unwrap().into(),
+            ],
+            Some(tower_lsp_server::ls_types::ServerCapabilities {
+                hover_provider: Some(tower_lsp_server::ls_types::HoverProviderCapability::Simple(
+                    true,
+                )),
+                ..Default::default()
+            }),
+        )
+        .await;
+        self.pool.insert_connection(handle.clone()).await;
+        handle
+    }
+
     /// Register a virtual document as opened, so [`Self::resolve_virtual_uri`]
     /// can recover its host and region for a test-driven region push, without
     /// a real downstream connection.
@@ -1778,6 +1812,9 @@ impl BridgeCoordinator {
                 configs = async {
                     let lifecycle = pool.host_lifecycle_lock(&host_uri_owned);
                     let _guard = lifecycle.write().await;
+                    if !pool.accepts_host_language(&host_uri_owned, &language_id) {
+                        return Vec::new();
+                    }
                     Self::resolve_document_routing(
                         &pool,
                         &host_uri_owned,

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -305,7 +305,22 @@ pub(crate) struct HostVirtualContents {
     // container, so a stale publisher holding the old DashMap guard can only
     // mutate detached state that current didOpen readers cannot observe.
     pub(crate) incarnation: u64,
+    /// Only accepted parse-label promotions establish this admission fence.
+    /// Explicit aliases keep their existing canonical request behavior.
+    promoted_language: Option<HostLanguageAdmission>,
     contents: DashMap<String, DashMap<String, Arc<str>>>,
+}
+
+pub(crate) struct HostLanguageAdmission {
+    pub(crate) language: String,
+    pub(crate) settings_generation: u64,
+    pub(crate) current_settings_generation: Arc<dyn Fn() -> u64 + Send + Sync>,
+}
+
+impl HostLanguageAdmission {
+    fn is_current(&self) -> bool {
+        (self.current_settings_generation)() == self.settings_generation
+    }
 }
 
 type LatestVirtualContents = DashMap<Url, HostVirtualContents>;
@@ -1626,6 +1641,13 @@ impl LanguageServerPool {
     }
 
     pub(crate) fn clear_host_routing_suppression(&self, host_uri: &Url) {
+        self.clear_host_document_routing(host_uri);
+        self.finish_all_virtual_routing(host_uri);
+    }
+
+    /// A host-language promotion invalidates real-document routing, while a
+    /// newer edit's virtual routing pass continues to own its current regions.
+    pub(super) fn clear_host_document_routing(&self, host_uri: &Url) {
         let uri = host_uri.to_string();
         self.host_routing_suppressed
             .retain(|(doc_uri, _), _| doc_uri != &uri);
@@ -1638,7 +1660,6 @@ impl LanguageServerPool {
         self.host_routing_rootless
             .retain(|(doc_uri, _), _| doc_uri != &uri);
         self.finish_all_host_routing(host_uri);
-        self.finish_all_virtual_routing(host_uri);
     }
 
     pub(crate) fn clear_host_routing_for_connection(&self, connection_key: &ConnectionKey) {
@@ -2120,6 +2141,37 @@ impl LanguageServerPool {
         )
     }
 
+    pub(super) fn set_promoted_host_language(
+        &self,
+        uri: &Url,
+        incarnation: u64,
+        admission: HostLanguageAdmission,
+    ) -> bool {
+        let Some(mut host) = self.latest_virtual_contents.get_mut(uri) else {
+            return false;
+        };
+        if host.incarnation != incarnation {
+            return false;
+        }
+        if admission.is_current() {
+            host.promoted_language = Some(admission);
+        }
+        true
+    }
+
+    /// Call under the host lifecycle lock, before routing or syncing. A settings
+    /// change expires the fence so a preserved label can acquire a new canonical
+    /// base without an old promotion rejecting its valid request contexts.
+    pub(crate) fn accepts_host_language(&self, host_uri: &Url, language: &str) -> bool {
+        self.latest_virtual_contents
+            .get(host_uri)
+            .is_none_or(|host| {
+                host.promoted_language.as_ref().is_none_or(|admission| {
+                    !admission.is_current() || admission.language == language
+                })
+            })
+    }
+
     pub(crate) fn current_host_incarnation(&self, host_uri: &Url) -> Option<u64> {
         self.latest_virtual_contents
             .get(host_uri)
@@ -2154,6 +2206,7 @@ impl LanguageServerPool {
             host_uri.clone(),
             HostVirtualContents {
                 incarnation,
+                promoted_language: None,
                 contents: DashMap::new(),
             },
         );

--- a/src/lsp/bridge/pool/test_helpers.rs
+++ b/src/lsp/bridge/pool/test_helpers.rs
@@ -139,6 +139,11 @@ pub(in crate::lsp::bridge) async fn create_handle_with_key(
     create_handle_with_state_and_pid_keyed(state, key).await.0
 }
 
+#[cfg(unix)]
+pub(crate) fn advertise_routing_for_test(handle: &ConnectionHandle) {
+    handle.set_bridge_routing(true);
+}
+
 pub(in crate::lsp::bridge) async fn create_handle_accepting_textless_did_save(
     key: ConnectionKey,
 ) -> Arc<ConnectionHandle> {
@@ -226,14 +231,28 @@ pub(in crate::lsp::bridge) async fn create_handle_with_state_and_pid_keyed(
     state: ConnectionState,
     key: ConnectionKey,
 ) -> (Arc<ConnectionHandle>, u32) {
-    // Create a mock server process (sink — discards all input, no output)
-    let mut conn = AsyncBridgeConnection::spawn(vec![
-        "sh".to_string(),
-        "-c".to_string(),
-        "cat > /dev/null".to_string(),
-    ])
+    create_handle_with_command(
+        state,
+        key,
+        vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "cat > /dev/null".to_string(),
+        ],
+        None,
+    )
     .await
-    .expect("should spawn sink process");
+}
+
+pub(in crate::lsp::bridge) async fn create_handle_with_command(
+    state: ConnectionState,
+    key: ConnectionKey,
+    command: Vec<String>,
+    capabilities: Option<tower_lsp_server::ls_types::ServerCapabilities>,
+) -> (Arc<ConnectionHandle>, u32) {
+    let mut conn = AsyncBridgeConnection::spawn(command)
+        .await
+        .expect("should spawn sink process");
 
     // Split connection and spawn reader task (new architecture)
     let (writer, reader) = conn.split();
@@ -255,5 +274,8 @@ pub(in crate::lsp::bridge) async fn create_handle_with_state_and_pid_keyed(
         crate::lsp::bridge::WorkspaceFolderSet::new(None),
         std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
     ));
+    if let Some(capabilities) = capabilities {
+        handle.set_server_capabilities(capabilities);
+    }
     (handle, pid)
 }

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -356,6 +356,9 @@ impl LanguageServerPool {
     ) {
         let lifecycle = self.host_lifecycle_lock(host_uri);
         let _lifecycle_guard = lifecycle.write().await;
+        if !self.accepts_host_language(host_uri, language_id) {
+            return;
+        }
         let handle = match self
             .get_or_create_connection_wait_ready(
                 server_name,

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -212,6 +212,35 @@ impl LanguageServerPool {
         self.finish_all_host_routing(uri);
         let lifecycle = self.host_lifecycle_lock(uri);
         let _lifecycle_guard = lifecycle.write().await;
+        self.close_host_bridge_document_locked(uri).await;
+        self.clear_host_routing_suppression(uri);
+    }
+
+    /// Revalidate the store label after waiting for host requests, then fence
+    /// lazy requests before freeing downstream slots. The caller must not hold
+    /// its edit lock while waiting here: host responses can take many seconds.
+    pub(crate) async fn reconcile_host_language(
+        &self,
+        uri: &Url,
+        incarnation: u64,
+        admission: super::super::pool::HostLanguageAdmission,
+        still_current: impl Fn() -> bool + Send + Sync,
+    ) -> bool {
+        let Some(lifecycle) = self.existing_host_lifecycle_lock(uri) else {
+            return false;
+        };
+        let guard = lifecycle.write().await;
+        if !still_current() || !self.set_promoted_host_language(uri, incarnation, admission) {
+            drop(guard);
+            self.remove_host_lifecycle_lock_if_unshared(uri, &lifecycle);
+            return false;
+        }
+        self.close_host_bridge_document_locked(uri).await;
+        self.clear_host_document_routing(uri);
+        true
+    }
+
+    async fn close_host_bridge_document_locked(&self, uri: &Url) {
         self.invalidate_diagnostic_host(uri);
         let Ok(uri_lsp) = host_url_to_lsp_uri(uri) else {
             return;
@@ -248,7 +277,6 @@ impl LanguageServerPool {
             .map(|(doc_uri, connection_key)| (connection_key, doc_uri))
             .collect::<Vec<_>>();
         docs.retain(|(doc_uri, _), _| *doc_uri != uri_string);
-        self.clear_host_routing_suppression(uri);
         for key in closed_keys {
             self.invalidate_diagnostic_document(&key);
         }
@@ -579,6 +607,12 @@ impl LanguageServerPool {
         let connection_key = handle.key();
         self.wait_for_host_routing(doc.uri).await;
         let host_lifecycle = self.request_host_lifecycle(doc.uri).await?;
+        if !self.accepts_host_language(doc.uri, doc.language_id) {
+            return Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                "host language changed before request",
+            ));
+        }
         if self.is_host_routing_suppressed(doc.uri, connection_key) {
             return Err(io::Error::new(
                 io::ErrorKind::NotConnected,

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -929,6 +929,7 @@ impl InjectionCoordinator {
             settings_manager: std::sync::Arc::clone(&self.settings_manager),
             auto_install: self.auto_install.clone(),
             bridge: std::sync::Arc::clone(&self.bridge),
+            shutdown: self.shutdown.clone(),
         })
     }
 }

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -62,6 +62,7 @@ pub(super) struct InstallCoordinatorDeps {
     pub(super) settings_manager: std::sync::Arc<SettingsManager>,
     pub(super) auto_install: AutoInstallManager,
     pub(super) bridge: std::sync::Arc<BridgeCoordinator>,
+    pub(super) shutdown: tokio_util::sync::CancellationToken,
 }
 
 /// Installation/lifetime eligibility is distinct from ownership of a parse.
@@ -82,6 +83,7 @@ pub(crate) struct InstallCoordinator {
     settings_manager: std::sync::Arc<SettingsManager>,
     auto_install: AutoInstallManager,
     bridge: std::sync::Arc<BridgeCoordinator>,
+    shutdown: tokio_util::sync::CancellationToken,
 }
 
 impl InstallCoordinator {
@@ -96,6 +98,7 @@ impl InstallCoordinator {
             settings_manager: std::sync::Arc::clone(&server.settings_manager),
             auto_install: server.auto_install.clone(),
             bridge: std::sync::Arc::clone(&server.bridge),
+            shutdown: server.shutdown_token.clone(),
         })
     }
 
@@ -110,6 +113,7 @@ impl InstallCoordinator {
             settings_manager: deps.settings_manager,
             auto_install: deps.auto_install,
             bridge: deps.bridge,
+            shutdown: deps.shutdown,
         }
     }
 
@@ -441,6 +445,7 @@ impl InstallCoordinator {
             cache: std::sync::Arc::clone(&self.cache),
             settings_manager: std::sync::Arc::clone(&self.settings_manager),
             bridge: std::sync::Arc::clone(&self.bridge),
+            shutdown: self.shutdown.clone(),
         })
     }
 }

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -937,8 +937,12 @@ mod tests {
         assert!(server.documents.get(&uri).unwrap().tree().is_none());
     }
 
+    #[rstest::rstest]
+    #[case(None)]
+    #[case(Some("text"))]
+    #[case(Some("rust"))]
     #[tokio::test]
-    async fn available_parser_reports_only_its_own_parse() {
+    async fn available_parser_reports_only_its_own_parse(#[case] initial_label: Option<&str>) {
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
         server
@@ -949,7 +953,7 @@ mod tests {
         let incarnation = server.documents.insert(
             uri.clone(),
             "fn main() {}".into(),
-            Some("rust".into()),
+            initial_label.map(str::to_string),
             None,
         );
         let install = server.install_coordinator();
@@ -959,6 +963,10 @@ mod tests {
         assert!(first.same_lifetime);
         let parsed = first.parsed.expect("this install published the parse");
         assert!(parsed.matches(&server.documents.get(&uri).unwrap()));
+        assert_eq!(
+            server.documents.get(&uri).unwrap().language_id(),
+            Some("rust")
+        );
         let second = install
             .maybe_auto_install_language("rust", uri.clone(), false, Some(incarnation), true)
             .await;

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -156,6 +156,7 @@ pub(super) struct ParseCoordinatorDeps {
     pub(super) cache: std::sync::Arc<CacheCoordinator>,
     pub(super) settings_manager: std::sync::Arc<SettingsManager>,
     pub(super) bridge: std::sync::Arc<BridgeCoordinator>,
+    pub(super) shutdown: tokio_util::sync::CancellationToken,
 }
 
 pub(crate) struct ParseCoordinator {
@@ -167,6 +168,109 @@ pub(crate) struct ParseCoordinator {
     cache: std::sync::Arc<CacheCoordinator>,
     settings_manager: std::sync::Arc<SettingsManager>,
     bridge: std::sync::Arc<BridgeCoordinator>,
+    shutdown: tokio_util::sync::CancellationToken,
+}
+
+/// A label transition outlives the parse future that published it. Normal
+/// callers join the work; cancellation only detaches that join, while server
+/// shutdown still cancels the reconciliation through the shared token.
+#[derive(Clone)]
+struct HostLanguageReconciler {
+    language: std::sync::Arc<LanguageCoordinator>,
+    documents: std::sync::Arc<DocumentStore>,
+    bridge: std::sync::Arc<BridgeCoordinator>,
+    settings_manager: std::sync::Arc<SettingsManager>,
+    shutdown: tokio_util::sync::CancellationToken,
+    runtime: tokio::runtime::Handle,
+    settings_generation: u64,
+}
+
+impl HostLanguageReconciler {
+    fn spawn(
+        &self,
+        uri: &Url,
+        installed: crate::document::ParseInstall,
+        snapshot: &crate::document::snapshot::ParseSnapshot,
+    ) -> Option<tokio::task::JoinHandle<()>> {
+        if !installed.host_language_changed {
+            return None;
+        }
+        let this = self.clone();
+        let uri = uri.clone();
+        let language = snapshot.language.clone();
+        let incarnation = snapshot.incarnation;
+        Some(self.runtime.spawn(async move {
+            tokio::select! {
+                biased;
+                _ = this.shutdown.cancelled() => {}
+                _ = async {
+                    let still_current = || this.documents.get(&uri).is_some_and(|document| {
+                        document.incarnation() == incarnation
+                            && document.language_id() == language.as_deref()
+                    });
+                    let edit_lock = this.documents.edit_lock(&uri);
+                    let edit_guard = edit_lock.lock().await;
+                    if !still_current() {
+                        this.documents.remove_edit_lock_if_unshared(&uri, &edit_lock);
+                        return;
+                    }
+                    // Initial opens and debounce register under this same lock.
+                    // Cancel their old batch, then release ingress before waiting
+                    // for outstanding host requests to release the bridge lock.
+                    this.bridge.cancel_host_eager_open(&uri);
+                    drop(edit_guard);
+                    let settings_manager = this.settings_manager.clone();
+                    let admission = crate::lsp::bridge::HostLanguageAdmission {
+                        language: language.clone().expect("promotion carries a detected language"),
+                        settings_generation: this.settings_generation,
+                        current_settings_generation: std::sync::Arc::new(move || settings_manager.settings_generation()),
+                    };
+                    if !this.bridge.pool().reconcile_host_language(&uri, incarnation, admission, &still_current).await {
+                        if this.documents.get(&uri).is_none() {
+                            this.documents.remove_edit_lock_if_unshared(&uri, &edit_lock);
+                        }
+                        return;
+                    }
+                    // A later edit cannot erase an accepted language transition.
+                    // Re-admit against its lifetime/label, not its old version,
+                    // and read the latest text before registering replacement work.
+                    let _edit_guard = edit_lock.lock().await;
+                    let Some(document) = this.documents.get(&uri) else {
+                        this.documents.remove_edit_lock_if_unshared(&uri, &edit_lock);
+                        return;
+                    };
+                    if document.incarnation() != incarnation || document.language_id() != language.as_deref() {
+                        return;
+                    }
+                    let text = document.text_arc();
+                    let settings = this.settings_manager.load_settings_pair();
+                    // A reload can make the preserved label an alias for another
+                    // grammar while this task waits. Match current host contexts
+                    // instead of reopening with the pre-reload parser's name.
+                    let replacement = if settings.generation != this.settings_generation {
+                        this.language.detect_language(uri.path(), &text, None, document.language_id())
+                            .or_else(|| language.clone())
+                    } else {
+                        language.clone()
+                    };
+                    drop(document);
+                    if let Some(language) = replacement.as_deref() {
+                        this.bridge.eager_open_host_document_on_servers(
+                            &settings.settings, language, &uri, &text,
+                        );
+                    }
+                } => {}
+            }
+        }))
+    }
+}
+
+async fn join_host_reconciliation(uri: &Url, task: Option<tokio::task::JoinHandle<()>>) {
+    if let Some(task) = task
+        && let Err(error) = task.await
+    {
+        log::error!("Host language reconciliation failed for {uri:?}: {error}");
+    }
 }
 
 /// Run a populate work-unit cooperatively cancelled, but keep awaiting it.
@@ -200,6 +304,7 @@ impl ParseCoordinator {
             cache: std::sync::Arc::clone(&server.cache),
             settings_manager: std::sync::Arc::clone(&server.settings_manager),
             bridge: std::sync::Arc::clone(&server.bridge),
+            shutdown: server.shutdown_token.clone(),
         })
     }
 
@@ -213,7 +318,32 @@ impl ParseCoordinator {
             cache: deps.cache,
             settings_manager: deps.settings_manager,
             bridge: deps.bridge,
+            shutdown: deps.shutdown,
         }
+    }
+
+    fn host_language_reconciler(&self) -> HostLanguageReconciler {
+        HostLanguageReconciler {
+            language: self.language.clone(),
+            documents: self.documents.clone(),
+            bridge: self.bridge.clone(),
+            settings_manager: self.settings_manager.clone(),
+            shutdown: self.shutdown.clone(),
+            runtime: tokio::runtime::Handle::current(),
+            settings_generation: self.settings_manager.settings_generation(),
+        }
+    }
+
+    async fn install_and_reconcile(
+        &self,
+        uri: &Url,
+        check: crate::document::LanguageCheck<'_>,
+        snapshot: std::sync::Arc<crate::document::snapshot::ParseSnapshot>,
+    ) -> crate::document::ParseInstall {
+        let reconciler = self.host_language_reconciler();
+        let installed = self.documents.install_parse(uri, check, snapshot.clone());
+        join_host_reconciliation(uri, reconciler.spawn(uri, installed, &snapshot)).await;
+        installed
     }
 
     /// Shared parsing orchestration: run parser acquisition + parse logic as one
@@ -407,12 +537,12 @@ impl ParseCoordinator {
         // waits behind a stale publish and the evicted tree's teardown.
         let Some(entry_mint_epoch) = entry_mint_epoch else {
             return self
-                .documents
-                .install_parse(
+                .install_and_reconcile(
                     uri,
                     check.as_check(),
                     inputs.snapshot(PopulatedInjections::default()),
                 )
+                .await
                 .into();
         };
         let build_bridge_regions = self
@@ -425,8 +555,10 @@ impl ParseCoordinator {
         type First = (
             crate::document::ParseInstall,
             std::sync::Arc<crate::document::snapshot::ParseSnapshot>,
+            Option<tokio::task::JoinHandle<()>>,
         );
         let first = std::sync::Arc::new(std::sync::OnceLock::<First>::new());
+        let host_reconciler = self.host_language_reconciler();
         let regions = run_awaited_populate(&self.compute_pool, version_cancel, {
             let inputs = std::sync::Arc::clone(&inputs);
             let check = std::sync::Arc::clone(&check);
@@ -458,7 +590,8 @@ impl ParseCoordinator {
                             check.as_check(),
                             std::sync::Arc::clone(&snapshot),
                         );
-                        let _ = first.set((installed, snapshot));
+                        let reconciliation = host_reconciler.spawn(&pool_uri, installed, &snapshot);
+                        let _ = first.set((installed, snapshot, reconciliation));
                     },
                     Some(&cancel_for_work),
                 );
@@ -476,7 +609,11 @@ impl ParseCoordinator {
         // A work-unit the pool contained (it panicked) derived nothing: the
         // snapshot rides without regions, exactly as a refused pass.
         .unwrap_or_default();
-        match first.get() {
+        // The awaited work unit has dropped its cloned owner, even on panic.
+        let first = std::sync::Arc::into_inner(first)
+            .expect("populate work unit has completed")
+            .into_inner();
+        match first {
             // The pass handed its discovery out and the tree is published:
             // land the regions it resolved on the same version. Nothing to
             // land (skipped resolution, refused commit) publishes nothing —
@@ -484,7 +621,8 @@ impl ParseCoordinator {
             // the cell refused (a sibling parse of this version landed its
             // tree first) has nothing to upgrade: the regions would ride the
             // sibling's tree with a tree the readers never derived from.
-            Some((initial_install, first_snapshot)) => {
+            Some((initial_install, first_snapshot, reconciliation)) => {
+                join_host_reconciliation(uri, reconciliation).await;
                 let current_at_completion = initial_install.published
                     && self.documents.complete_parse(
                         uri,
@@ -499,18 +637,18 @@ impl ParseCoordinator {
                         } else {
                             check.as_check()
                         },
-                        first_snapshot,
+                        &first_snapshot,
                         regions.regions,
                     );
                 ParseCompletion {
-                    initial_install: *initial_install,
+                    initial_install,
                     current_at_completion,
                 }
             }
             // No hand-off: one install, whose currency is judged right now.
             None => self
-                .documents
-                .install_parse(uri, check.as_check(), inputs.snapshot(regions))
+                .install_and_reconcile(uri, check.as_check(), inputs.snapshot(regions))
+                .await
                 .into(),
         }
     }
@@ -690,20 +828,22 @@ impl ParseCoordinator {
             // through to the no-language path below which would null it out. Host
             // bridging needs only text + language (never a tree), so preserving the
             // language keeps a host-bridged document working after a parse failure.
-            let installed = self.documents.install_parse(
-                &uri,
-                crate::document::LanguageCheck::Record,
-                std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
-                    text: text.clone(),
-                    tree: None,
-                    language: Some(language_name.clone()),
-                    parsed_version: content_version,
-                    incarnation,
-                    injection_regions: None,
-                    regions: None,
-                    layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
-                }),
-            );
+            let installed = self
+                .install_and_reconcile(
+                    &uri,
+                    crate::document::LanguageCheck::Record,
+                    std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
+                        text: text.clone(),
+                        tree: None,
+                        language: Some(language_name.clone()),
+                        parsed_version: content_version,
+                        incarnation,
+                        injection_regions: None,
+                        regions: None,
+                        layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
+                    }),
+                )
+                .await;
             if installed.current {
                 self.documents
                     .mark_parse_finished(&uri, parse_generation, false);
@@ -714,20 +854,22 @@ impl ParseCoordinator {
         }
 
         // No language detected at all → store no language, no tree.
-        let installed = self.documents.install_parse(
-            &uri,
-            crate::document::LanguageCheck::Record,
-            std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
-                text: text.clone(),
-                tree: None,
-                language: None,
-                parsed_version: content_version,
-                incarnation,
-                injection_regions: None,
-                regions: None,
-                layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
-            }),
-        );
+        let installed = self
+            .install_and_reconcile(
+                &uri,
+                crate::document::LanguageCheck::Record,
+                std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
+                    text: text.clone(),
+                    tree: None,
+                    language: None,
+                    parsed_version: content_version,
+                    incarnation,
+                    injection_regions: None,
+                    regions: None,
+                    layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
+                }),
+            )
+            .await;
         if installed.current {
             self.documents
                 .mark_parse_finished(&uri, parse_generation, false);
@@ -1163,6 +1305,84 @@ impl ParseCoordinator {
 mod tests {
     use super::*;
     use tower_lsp_server::LspService;
+
+    #[rstest::rstest]
+    #[case(false)]
+    #[case(true)]
+    #[tokio::test]
+    async fn language_reconciliation_survives_a_newer_edit(#[case] reload_before_admission: bool) {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let uri = Url::parse("file:///test/sticky-promotion.rs").unwrap();
+        let incarnation =
+            server
+                .documents
+                .insert(uri.clone(), "old text".into(), Some("text".into()), None);
+        server.bridge.open_host_incarnation(&uri, incarnation).await;
+        server
+            .bridge
+            .pool()
+            .set_host_routing_by_server(&uri, "old-server", false);
+        let snapshot = std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
+            text: std::sync::Arc::from("old text"),
+            tree: None,
+            language: Some("rust".into()),
+            parsed_version: 0,
+            incarnation,
+            injection_regions: None,
+            regions: None,
+            layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
+        });
+        let reconciler = server.parse_coordinator().host_language_reconciler();
+        let installed = server.documents.install_parse(
+            &uri,
+            crate::document::LanguageCheck::RecordIfUnchanged(Some("text")),
+            snapshot.clone(),
+        );
+        assert!(installed.host_language_changed);
+        let lock = server.documents.edit_lock(&uri);
+        let guard = lock.lock().await;
+        let task = reconciler.spawn(&uri, installed, &snapshot).unwrap();
+        server
+            .documents
+            .update_document(uri.clone(), "newer text".into(), None);
+        if reload_before_admission {
+            server
+                .settings_manager
+                .apply_settings((*server.settings_manager.load_settings()).clone());
+        }
+        let virtual_uri = Url::parse("file:///test/current-injection.lua").unwrap();
+        let virtual_routing = server
+            .bridge
+            .pool()
+            .begin_virtual_routing(&uri, &virtual_uri);
+        drop(guard);
+        tokio::time::timeout(std::time::Duration::from_secs(2), task)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            server
+                .bridge
+                .pool()
+                .host_routing_by_server(&uri, "old-server"),
+            None,
+            "a newer edit must not strand the old routing decision"
+        );
+        assert_eq!(
+            server.bridge.pool().accepts_host_language(&uri, "text"),
+            reload_before_admission,
+            "a late old-generation reconciliation must not install a new fence"
+        );
+        assert_eq!(server.documents.get(&uri).unwrap().text(), "newer text");
+        assert!(
+            server
+                .bridge
+                .pool()
+                .is_virtual_routing_current(&uri, &virtual_uri, &virtual_routing),
+            "host reconciliation must preserve a newer edit's virtual routing pass"
+        );
+    }
 
     #[tokio::test]
     async fn reparse_without_detectable_language_publishes_giveup_snapshot() {

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -58,6 +58,7 @@ impl SnapshotInputs {
 enum InstallCheck {
     Record,
     Expect(Option<String>),
+    RecordIfUnchanged(Option<String>),
 }
 
 impl InstallCheck {
@@ -65,6 +66,9 @@ impl InstallCheck {
         match self {
             Self::Record => crate::document::LanguageCheck::Record,
             Self::Expect(language) => crate::document::LanguageCheck::Expect(language.as_deref()),
+            Self::RecordIfUnchanged(language) => {
+                crate::document::LanguageCheck::RecordIfUnchanged(language.as_deref())
+            }
         }
     }
 }
@@ -484,7 +488,17 @@ impl ParseCoordinator {
                 let current_at_completion = initial_install.published
                     && self.documents.complete_parse(
                         uri,
-                        check.as_check(),
+                        if initial_install.current
+                            && matches!(&*check, InstallCheck::RecordIfUnchanged(_))
+                        {
+                            // The first publish refined the provisional label.
+                            // Regions must validate the label that publish stored.
+                            crate::document::LanguageCheck::Expect(
+                                first_snapshot.language.as_deref(),
+                            )
+                        } else {
+                            check.as_check()
+                        },
                         first_snapshot,
                         regions.regions,
                     );
@@ -1072,7 +1086,11 @@ impl ParseCoordinator {
             let installed = self
                 .populate_and_install(
                     uri,
-                    InstallCheck::Expect(language_id.clone()),
+                    if language_id.is_none() {
+                        InstallCheck::RecordIfUnchanged(None)
+                    } else {
+                        InstallCheck::Expect(language_id.clone())
+                    },
                     SnapshotInputs {
                         text: text.clone(),
                         tree,

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -895,7 +895,7 @@ impl ParseCoordinator {
             let installed = self
                 .populate_and_install(
                     &uri,
-                    InstallCheck::Expect(expected_language_id.clone()),
+                    self.reparse_language_check(expected_language_id.clone(), &language_name),
                     SnapshotInputs {
                         text: text.clone(),
                         tree,

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -515,6 +515,20 @@ impl ParseCoordinator {
         }
     }
 
+    fn reparse_language_check(&self, language_id: Option<String>, detected: &str) -> InstallCheck {
+        let preserve = language_id.as_deref().is_some_and(|label| {
+            label == detected
+                || self
+                    .language
+                    .is_declared_host_language(label, &self.settings_manager.load_settings())
+        });
+        if preserve {
+            InstallCheck::Expect(language_id)
+        } else {
+            InstallCheck::RecordIfUnchanged(language_id)
+        }
+    }
+
     /// Parse the (already-registered) document at `uri` and publish the result.
     ///
     /// The registering `didOpen` inserts the document — **with its text** — before
@@ -1086,11 +1100,7 @@ impl ParseCoordinator {
             let installed = self
                 .populate_and_install(
                     uri,
-                    if language_id.is_none() {
-                        InstallCheck::RecordIfUnchanged(None)
-                    } else {
-                        InstallCheck::Expect(language_id.clone())
-                    },
+                    self.reparse_language_check(language_id.clone(), &language_name),
                     SnapshotInputs {
                         text: text.clone(),
                         tree,

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -1687,13 +1687,23 @@ print("hello")
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
         configure_rust_self_host(server);
+        let query = Query::new(
+            &tree_sitter_rust::LANGUAGE.into(),
+            r#"((line_comment) @injection.content (#set! injection.language "lua"))"#,
+        )
+        .unwrap();
+        server
+            .language
+            .query_store()
+            .insert_injection_query("rust".to_string(), std::sync::Arc::new(query));
         let uri = Url::parse("file:///test/installer-refinement.rs").unwrap();
         let incarnation = server.documents.insert(
             uri.clone(),
-            "fn installed() {}".to_string(),
+            "// print(1)\nfn installed() {}".to_string(),
             Some("text".to_string()),
             None,
         );
+        server.bridge.open_tracker_incarnation(&uri, incarnation);
         let parsed = server
             .parse_coordinator()
             .reparse_installed_document(uri.clone(), "rust", Some(incarnation))

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -1534,14 +1534,49 @@ print("hello")
         })
         .await
         .expect("the winning language selects the actual host server");
+        // Remove the first routing result so the next assertion must observe
+        // a fresh selection, rather than the connection opened above.
+        server.bridge.pool().close_host_bridge_document(&uri).await;
         server
             .documents
             .update_document(uri.clone(), "fn next_edit() {}".to_string(), None);
         parser.reparse_latest(&uri, Some(2)).await;
-        assert_eq!(
-            server.documents.get(&uri).unwrap().language_id(),
-            Some("rust")
+        let (label, text) = {
+            let document = server.documents.get(&uri).unwrap();
+            assert!(document.has_current_tree());
+            assert_eq!(document.language_id(), Some("rust"));
+            assert_eq!(
+                document
+                    .latest_snapshot_slot()
+                    .snapshot
+                    .unwrap()
+                    .language
+                    .as_deref(),
+                Some("rust")
+            );
+            (
+                document.language_id().unwrap().to_string(),
+                document.text().to_string(),
+            )
+        };
+        server.bridge.eager_open_host_document_on_servers(
+            &server.settings_manager.load_settings(),
+            &label,
+            &uri,
+            &text,
         );
+        timeout(Duration::from_secs(1), async {
+            while !server
+                .bridge
+                .pool()
+                .is_host_document_opened(&uri, "rust_ls")
+                .await
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the subsequent edit still selects the actual host server");
     }
 
     #[tokio::test]

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -1465,6 +1465,94 @@ print("hello")
     /// re-sync (the diagnostics-don't-follow-edits bug). This pins the mechanism:
     /// the snapshot is `None` with the tree cleared and valid again once the
     /// reparse restores it.
+    #[rstest::rstest]
+    #[case(None)]
+    #[case(Some("text"))]
+    #[tokio::test]
+    async fn winning_edit_establishes_language_after_a_delayed_open(
+        #[case] initial_label: Option<&str>,
+    ) {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+        server.bridge.insert_ready_test_connection("rust_ls").await;
+        let uri = Url::parse("file:///test/open-edit-language.rs").unwrap();
+        let incarnation = server.documents.insert(
+            uri.clone(),
+            "fn original() {}".to_string(),
+            initial_label.map(str::to_string),
+            None,
+        );
+        server.bridge.open_host_incarnation(&uri, incarnation).await;
+
+        let edit_lock = server.documents.edit_lock(&uri);
+        let lifecycle = edit_lock.lock().await;
+        let parser = server.parse_coordinator();
+        let mut open =
+            Box::pin(parser.parse_document(uri.clone(), initial_label, None, Some(incarnation)));
+        // parse_document captures its input before its first await. Holding
+        // lifecycle admission ensures it cannot finish publication on this poll.
+        std::future::poll_fn(|cx| {
+            assert!(std::future::Future::poll(open.as_mut(), cx).is_pending());
+            std::task::Poll::Ready(())
+        })
+        .await;
+        server
+            .documents
+            .update_document(uri.clone(), "fn edited() {}".to_string(), None);
+        drop(lifecycle);
+        parser.reparse_latest(&uri, Some(1)).await;
+        assert!(
+            open.await.is_none(),
+            "the old open owns no current completion"
+        );
+
+        let (label, text) = {
+            let document = server.documents.get(&uri).unwrap();
+            assert!(document.has_current_tree());
+            assert_eq!(document.language_id(), Some("rust"));
+            assert_eq!(
+                document
+                    .latest_snapshot_slot()
+                    .snapshot
+                    .unwrap()
+                    .language
+                    .as_deref(),
+                Some("rust")
+            );
+            (
+                document.language_id().unwrap().to_string(),
+                document.text().to_string(),
+            )
+        };
+        server.bridge.eager_open_host_document_on_servers(
+            &server.settings_manager.load_settings(),
+            &label,
+            &uri,
+            &text,
+        );
+        timeout(Duration::from_secs(1), async {
+            while !server
+                .bridge
+                .pool()
+                .is_host_document_opened(&uri, "rust_ls")
+                .await
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the winning language selects the actual host server");
+        server
+            .documents
+            .update_document(uri.clone(), "fn next_edit() {}".to_string(), None);
+        parser.reparse_latest(&uri, Some(2)).await;
+        assert_eq!(
+            server.documents.get(&uri).unwrap().language_id(),
+            Some("rust")
+        );
+    }
+
     #[tokio::test]
     async fn current_edit_parse_establishes_an_unlabelled_documents_language() {
         let (service, _socket) = LspService::new(Kakehashi::new);
@@ -1490,6 +1578,13 @@ print("hello")
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
         configure_rust_self_host(server);
+        let mut settings = (*server.settings_manager.load_settings()).clone();
+        settings
+            .language_servers
+            .get_mut("rust_ls")
+            .unwrap()
+            .languages = Some(vec!["*".into()]);
+        server.settings_manager.apply_settings(settings);
         let uri = Url::parse("file:///test/unresolved-label.rs").unwrap();
         server.documents.insert(
             uri.clone(),
@@ -1508,22 +1603,33 @@ print("hello")
         assert_eq!(document.language_id(), Some("rust"));
     }
 
+    #[rstest::rstest]
+    #[case(true)]
+    #[case(false)]
     #[tokio::test]
-    async fn current_edit_parse_preserves_configured_host_alias_routing() {
+    async fn current_edit_parse_preserves_declared_host_routing(#[case] configured_base: bool) {
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
         configure_rust_self_host(server);
         let mut settings = (*server.settings_manager.load_settings()).clone();
         let mut alias = settings.languages["rust"].clone();
-        alias.base = Some("rust".to_string());
-        settings.languages.insert("custom-rust".to_string(), alias);
+        if configured_base {
+            alias.base = Some("rust".to_string());
+            settings.languages.insert("custom-rust".to_string(), alias);
+        } else {
+            // Only the bridge server declares custom-rust. The wildcard enables
+            // host bridging without defining that label's Tree-sitter grammar.
+            settings.languages.insert("_".to_string(), alias);
+        }
         settings
             .language_servers
             .get_mut("rust_ls")
             .unwrap()
             .languages = Some(vec!["custom-rust".to_string()]);
         server.settings_manager.apply_settings(settings);
-        server.language.set_base_mapping("custom-rust", "rust");
+        if configured_base {
+            server.language.set_base_mapping("custom-rust", "rust");
+        }
         server.bridge.insert_ready_test_connection("rust_ls").await;
         let uri = Url::parse("file:///test/host-alias.rs").unwrap();
         let incarnation = server.documents.insert(
@@ -1582,6 +1688,37 @@ print("hello")
         assert_eq!(
             server.documents.get(&uri).unwrap().language_id(),
             Some("custom-rust")
+        );
+    }
+
+    #[tokio::test]
+    async fn installer_label_refinement_keeps_its_regions_completion() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+        let uri = Url::parse("file:///test/installer-refinement.rs").unwrap();
+        let incarnation = server.documents.insert(
+            uri.clone(),
+            "fn installed() {}".to_string(),
+            Some("text".to_string()),
+            None,
+        );
+        let parsed = server
+            .parse_coordinator()
+            .reparse_installed_document(uri.clone(), "rust", Some(incarnation))
+            .await
+            .expect("the refined label must not reject its own regions completion");
+        let document = server.documents.get(&uri).unwrap();
+        assert!(parsed.matches(&document));
+        assert_eq!(document.language_id(), Some("rust"));
+        assert!(
+            document
+                .latest_snapshot_slot()
+                .snapshot
+                .unwrap()
+                .regions
+                .is_some(),
+            "the completion exercised the two-stage regions handoff"
         );
     }
 

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -1486,6 +1486,106 @@ print("hello")
     }
 
     #[tokio::test]
+    async fn current_edit_parse_refines_an_unconfigured_client_label() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+        let uri = Url::parse("file:///test/unresolved-label.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn edited() {}".to_string(),
+            Some("text".to_string()),
+            None,
+        );
+
+        server
+            .parse_coordinator()
+            .reparse_latest(&uri, Some(1))
+            .await;
+
+        let document = server.documents.get(&uri).unwrap();
+        assert!(document.has_current_tree());
+        assert_eq!(document.language_id(), Some("rust"));
+    }
+
+    #[tokio::test]
+    async fn current_edit_parse_preserves_configured_host_alias_routing() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+        let mut settings = (*server.settings_manager.load_settings()).clone();
+        let mut alias = settings.languages["rust"].clone();
+        alias.base = Some("rust".to_string());
+        settings.languages.insert("custom-rust".to_string(), alias);
+        settings
+            .language_servers
+            .get_mut("rust_ls")
+            .unwrap()
+            .languages = Some(vec!["custom-rust".to_string()]);
+        server.settings_manager.apply_settings(settings);
+        server.language.set_base_mapping("custom-rust", "rust");
+        server.bridge.insert_ready_test_connection("rust_ls").await;
+        let uri = Url::parse("file:///test/host-alias.rs").unwrap();
+        let incarnation = server.documents.insert(
+            uri.clone(),
+            "fn edited() {}".to_string(),
+            Some("custom-rust".to_string()),
+            None,
+        );
+        server.bridge.open_host_incarnation(&uri, incarnation).await;
+        server
+            .parse_coordinator()
+            .reparse_latest(&uri, Some(1))
+            .await;
+        let (label, text) = {
+            let document = server.documents.get(&uri).unwrap();
+            assert!(document.has_current_tree());
+            assert_eq!(document.language_id(), Some("custom-rust"));
+            assert_eq!(
+                document
+                    .latest_snapshot_slot()
+                    .snapshot
+                    .unwrap()
+                    .language
+                    .as_deref(),
+                Some("rust"),
+                "the alias routes the host while the snapshot records its actual grammar"
+            );
+            (
+                document.language_id().unwrap().to_string(),
+                document.text().to_string(),
+            )
+        };
+        let settings = server.settings_manager.load_settings();
+        server
+            .bridge
+            .eager_open_host_document_on_servers(&settings, &label, &uri, &text);
+        timeout(Duration::from_secs(1), async {
+            while !server
+                .bridge
+                .pool()
+                .is_host_document_opened(&uri, "rust_ls")
+                .await
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the alias-specific server receives the host open");
+        server
+            .documents
+            .update_document(uri.clone(), "fn next_edit() {}".to_string(), None);
+        server
+            .parse_coordinator()
+            .reparse_latest(&uri, Some(2))
+            .await;
+        assert_eq!(
+            server.documents.get(&uri).unwrap().language_id(),
+            Some("custom-rust")
+        );
+    }
+
+    #[tokio::test]
     async fn diagnostic_snapshot_needs_the_reparsed_tree_not_the_cleared_one() {
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -1456,15 +1456,6 @@ print("hello")
         );
     }
 
-    /// Regression (parse-actor flip): the debounced diagnostic — which drives the
-    /// on-edit host re-sync (#431) that keeps a push host's diagnostics following
-    /// edits — must be scheduled AFTER the off-ingress reparse, not in the
-    /// `did_change` handler. The handler makes the tree stale, and
-    /// `prepare_diagnostic_snapshot` returns `None` without a tree, so scheduling
-    /// the debounce there would capture a `None` snapshot and silently skip the
-    /// re-sync (the diagnostics-don't-follow-edits bug). This pins the mechanism:
-    /// the snapshot is `None` with the tree cleared and valid again once the
-    /// reparse restores it.
     #[rstest::rstest]
     #[case(None)]
     #[case(Some("text"))]
@@ -1722,6 +1713,15 @@ print("hello")
         );
     }
 
+    /// Regression (parse-actor flip): the debounced diagnostic — which drives the
+    /// on-edit host re-sync (#431) that keeps a push host's diagnostics following
+    /// edits — must be scheduled AFTER the off-ingress reparse, not in the
+    /// `did_change` handler. The handler makes the tree stale, and
+    /// `prepare_diagnostic_snapshot` returns `None` without a tree, so scheduling
+    /// the debounce there would capture a `None` snapshot and silently skip the
+    /// re-sync (the diagnostics-don't-follow-edits bug). This pins the mechanism:
+    /// the snapshot is `None` with the tree cleared and valid again once the
+    /// reparse restores it.
     #[tokio::test]
     async fn diagnostic_snapshot_needs_the_reparsed_tree_not_the_cleared_one() {
         let (service, _socket) = LspService::new(Kakehashi::new);

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -74,7 +74,6 @@ impl Kakehashi {
                 .insert(uri.clone(), text.clone(), language_name.clone(), None);
         self.bridge.open_tracker_incarnation(&uri, incarnation);
         self.bridge.open_host_incarnation(&uri, incarnation).await;
-        drop(edit_guard);
 
         // Host-tier hoist (parse-decoupled-document-lifecycle ADR): attach the real
         // host document to any `_self` host-bridge server *before* the parser load,
@@ -94,6 +93,8 @@ impl Kakehashi {
             self.bridge
                 .eager_open_host_document_on_servers(&settings, lang, &uri, &text);
         }
+
+        drop(edit_guard);
 
         // Check if we need to auto-install
         let mut deferred_events = Vec::new();
@@ -1454,6 +1455,339 @@ print("hello")
             server.documents.get(&uri).is_none(),
             "parse_document must not resurrect a document closed before it ran"
         );
+    }
+
+    #[cfg(unix)]
+    async fn recorded_host_messages(
+        path: &std::path::Path,
+        count: usize,
+    ) -> Vec<serde_json::Value> {
+        timeout(Duration::from_secs(3), async {
+            loop {
+                let bytes = tokio::fs::read(path).await.unwrap();
+                let mut reader = crate::lsp::bridge::BridgeReader::new(bytes.as_slice());
+                let mut messages = Vec::new();
+                loop {
+                    match reader.read_message().await {
+                        Ok(message) => messages.push(message),
+                        Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                        Err(error) => panic!("invalid host wire message: {error}"),
+                    }
+                }
+                if messages.len() >= count {
+                    return messages;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("host wire messages must arrive")
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn language_promotion_reasks_a_suppressing_routing_provider() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+        let mut settings = (*server.settings_manager.load_settings()).clone();
+        settings
+            .language_servers
+            .get_mut("rust_ls")
+            .unwrap()
+            .languages = Some(vec!["*".into()]);
+        settings
+            .languages
+            .insert("_".into(), settings.languages["rust"].clone());
+        server.settings_manager.apply_settings(settings);
+        let recording = tempfile::NamedTempFile::new().unwrap();
+        let handle = server
+            .bridge
+            .insert_recording_test_connection("rust_ls", recording.path())
+            .await;
+        crate::lsp::bridge::test_helpers::advertise_routing_for_test(&handle);
+        let uri = Url::parse("file:///test/suppressed-promotion.rs").unwrap();
+        let text = "fn edited() {}";
+        let incarnation =
+            server
+                .documents
+                .insert(uri.clone(), text.into(), Some("text".into()), None);
+        server.bridge.open_host_incarnation(&uri, incarnation).await;
+        server.bridge.eager_open_host_document_on_servers(
+            &server.settings_manager.load_settings(),
+            "text",
+            &uri,
+            text,
+        );
+        let messages = recorded_host_messages(recording.path(), 1).await;
+        assert_eq!(messages[0]["params"]["textDocument"]["languageId"], "text");
+        assert!(messages[0].get("id").is_some(), "routing is a request");
+        assert_eq!(
+            handle.router().route(serde_json::json!({
+                "jsonrpc": "2.0", "id": messages[0]["id"],
+                "result": { "routing": { "rust_ls": { "enabled": false } } }
+            })),
+            crate::lsp::bridge::RouteResult::Delivered
+        );
+        timeout(
+            Duration::from_secs(2),
+            server.bridge.pool().wait_for_host_routing(&uri),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            server.bridge.pool().host_routing_by_server(&uri, "rust_ls"),
+            Some(false)
+        );
+        assert!(
+            !server
+                .bridge
+                .pool()
+                .is_host_document_opened(&uri, "rust_ls")
+                .await
+        );
+
+        server
+            .parse_coordinator()
+            .reparse_latest(&uri, Some(1))
+            .await;
+        let messages = recorded_host_messages(recording.path(), 2).await;
+        assert_eq!(messages[1]["method"], messages[0]["method"]);
+        assert_eq!(messages[1]["params"]["textDocument"]["languageId"], "rust");
+        assert_ne!(messages[1]["id"], messages[0]["id"]);
+        assert_eq!(
+            handle.router().route(serde_json::json!({
+                "jsonrpc": "2.0", "id": messages[1]["id"],
+                "result": { "routing": { "rust_ls": { "enabled": true } } }
+            })),
+            crate::lsp::bridge::RouteResult::Delivered
+        );
+        let messages = recorded_host_messages(recording.path(), 3).await;
+        assert_eq!(messages[2]["method"], "textDocument/didOpen");
+        assert_eq!(messages[2]["params"]["textDocument"]["languageId"], "rust");
+    }
+
+    #[cfg(unix)]
+    #[rstest::rstest]
+    #[case(false, false)]
+    #[case(true, false)]
+    #[case(true, true)]
+    #[tokio::test]
+    async fn winning_edit_reopens_a_provisional_downstream_language(
+        #[case] cancel_after_publication: bool,
+        #[case] reload_before_reconciliation: bool,
+    ) {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+        let mut settings = (*server.settings_manager.load_settings()).clone();
+        settings
+            .language_servers
+            .get_mut("rust_ls")
+            .unwrap()
+            .languages = Some(vec!["*".into()]);
+        settings
+            .languages
+            .insert("_".into(), settings.languages["rust"].clone());
+        server.settings_manager.apply_settings(settings);
+        let recording = tempfile::NamedTempFile::new().unwrap();
+        server
+            .bridge
+            .insert_recording_test_connection("rust_ls", recording.path())
+            .await;
+        let uri = Url::parse("file:///test/provisional-wire.rs").unwrap();
+        let text = "fn edited() {}";
+        let incarnation =
+            server
+                .documents
+                .insert(uri.clone(), text.into(), Some("text".into()), None);
+        server.bridge.open_host_incarnation(&uri, incarnation).await;
+        server.bridge.eager_open_host_document_on_servers(
+            &server.settings_manager.load_settings(),
+            "text",
+            &uri,
+            text,
+        );
+        let messages = recorded_host_messages(recording.path(), 1).await;
+        assert_eq!(messages[0]["method"], "textDocument/didOpen");
+        assert_eq!(messages[0]["params"]["textDocument"]["languageId"], "text");
+
+        if cancel_after_publication {
+            let query = Query::new(
+                &tree_sitter_rust::LANGUAGE.into(),
+                r#"((function_item) @injection.content (#set! injection.language "lua"))"#,
+            )
+            .unwrap();
+            server
+                .language
+                .query_store()
+                .insert_injection_query("rust".into(), std::sync::Arc::new(query));
+            server.bridge.open_tracker_incarnation(&uri, incarnation);
+            let resolution_hold = server.cache.hold_resolution();
+            let lifecycle = server.bridge.pool().host_lifecycle_lock(&uri);
+            let guard = lifecycle.write().await;
+            let parser = server.parse_coordinator();
+            let parse_uri = uri.clone();
+            let parse =
+                tokio::spawn(async move { parser.reparse_latest(&parse_uri, Some(1)).await });
+            timeout(Duration::from_secs(3), async {
+                while server.documents.get(&uri).unwrap().language_id() != Some("rust") {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("first publication must establish the label");
+            timeout(Duration::from_secs(2), async {
+                while server.bridge.has_host_eager_batch_for_test(&uri) {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("reconciliation cancelled the old eager batch");
+            let edit_lock = server.documents.edit_lock(&uri);
+            let edit_guard = timeout(Duration::from_secs(1), edit_lock.lock())
+                .await
+                .expect("waiting for a host response must not block edits");
+            if reload_before_reconciliation {
+                let mut updated = (*server.settings_manager.load_settings()).clone();
+                updated.languages.get_mut("rust").unwrap().base = Some("lua".into());
+                server
+                    .language
+                    .language_registry_for_parallel()
+                    .unregister("rust");
+                server
+                    .language
+                    .language_registry_for_parallel()
+                    .register("lua".into(), tree_sitter_lua::LANGUAGE.into());
+                server.language.set_base_mapping("rust", "lua");
+                server.settings_manager.apply_settings(updated);
+                server
+                    .documents
+                    .update_document(uri.clone(), "print(1)".into(), None);
+            }
+            drop(edit_guard);
+            parse.abort();
+            assert!(parse.await.unwrap_err().is_cancelled());
+            drop(resolution_hold);
+            drop(guard);
+        } else {
+            server
+                .parse_coordinator()
+                .reparse_latest(&uri, Some(1))
+                .await;
+        }
+        assert_eq!(
+            server.documents.get(&uri).unwrap().language_id(),
+            Some("rust")
+        );
+        let messages = recorded_host_messages(recording.path(), 3).await;
+        assert_eq!(messages[1]["method"], "textDocument/didClose");
+        assert_eq!(messages[2]["method"], "textDocument/didOpen");
+        assert_eq!(
+            messages[2]["params"]["textDocument"]["languageId"],
+            if reload_before_reconciliation {
+                "lua"
+            } else {
+                "rust"
+            }
+        );
+        assert_eq!(
+            messages[2]["params"]["textDocument"]["text"],
+            if reload_before_reconciliation {
+                "print(1)"
+            } else {
+                text
+            }
+        );
+        if reload_before_reconciliation {
+            assert_eq!(server.document_language(&uri).as_deref(), Some("lua"));
+            return;
+        }
+
+        // Leave the current incarnation live but its downstream slot vacant,
+        // exactly the gap between a relabel close and replacement eager open.
+        server.bridge.pool().close_host_bridge_document(&uri).await;
+        let settings = server.settings_manager.load_settings();
+        let stale = crate::lsp::bridge::HostDocument {
+            uri: &uri,
+            language_id: "lua",
+            text,
+        };
+        let result = timeout(Duration::from_secs(1), server.bridge.pool().send_host_raw_request(
+            "rust_ls", &settings.language_servers["rust_ls"], &stale,
+            "textDocument/hover", serde_json::json!({ "textDocument": { "uri": uri.as_str() }, "position": { "line": 0, "character": 0 } }), None,
+        )).await.expect("a pre-promotion request must be rejected before reaching the server");
+        assert!(result.is_err());
+        assert!(
+            !server
+                .bridge
+                .pool()
+                .is_host_document_opened(&uri, "rust_ls")
+                .await
+        );
+        server
+            .bridge
+            .pool()
+            .eager_open_host_document(
+                "rust_ls",
+                &settings.language_servers["rust_ls"],
+                &uri,
+                "text",
+                text,
+                None,
+            )
+            .await;
+        assert!(
+            !server
+                .bridge
+                .pool()
+                .is_host_document_opened(&uri, "rust_ls")
+                .await,
+            "a late provisional eager open cannot occupy the replacement slot"
+        );
+
+        // A later configuration can legitimately change an established label's
+        // canonical grammar. The old promotion fence must expire with settings.
+        let mut updated = (*settings).clone();
+        updated.languages.get_mut("rust").unwrap().base = Some("lua".into());
+        server
+            .language
+            .language_registry_for_parallel()
+            .unregister("rust");
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("lua".into(), tree_sitter_lua::LANGUAGE.into());
+        server.language.set_base_mapping("rust", "lua");
+        server.settings_manager.apply_settings(updated);
+        server
+            .documents
+            .update_document(uri.clone(), "print(1)".into(), None);
+        server
+            .parse_coordinator()
+            .reparse_latest(&uri, Some(2))
+            .await;
+        assert_eq!(
+            server.documents.get(&uri).unwrap().language_id(),
+            Some("rust")
+        );
+        let canonical = server.document_language(&uri).unwrap();
+        assert_eq!(canonical, "lua");
+        server
+            .bridge
+            .pool()
+            .eager_open_host_document(
+                "rust_ls",
+                &settings.language_servers["rust_ls"],
+                &uri,
+                &canonical,
+                "print(1)",
+                None,
+            )
+            .await;
+        let messages = recorded_host_messages(recording.path(), 5).await;
+        assert_eq!(messages[4]["method"], "textDocument/didOpen");
+        assert_eq!(messages[4]["params"]["textDocument"]["languageId"], "lua");
     }
 
     #[rstest::rstest]

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -1466,6 +1466,26 @@ print("hello")
     /// the snapshot is `None` with the tree cleared and valid again once the
     /// reparse restores it.
     #[tokio::test]
+    async fn current_edit_parse_establishes_an_unlabelled_documents_language() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+        let uri = Url::parse("file:///test/unlabelled.rs").unwrap();
+        server
+            .documents
+            .insert(uri.clone(), "fn edited() {}".to_string(), None, None);
+
+        server
+            .parse_coordinator()
+            .reparse_latest(&uri, Some(1))
+            .await;
+
+        let document = server.documents.get(&uri).unwrap();
+        assert!(document.has_current_tree());
+        assert_eq!(document.language_id(), Some("rust"));
+    }
+
+    #[tokio::test]
     async fn diagnostic_snapshot_needs_the_reparsed_tree_not_the_cleared_one() {
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();


### PR DESCRIPTION
When an open parse loses to an edit, the winning tree could retain an absent or unresolved stored language label, such as `text` for Rust content. Current edit and installer parses now refine those provisional labels atomically with snapshot publication, checking the captured label and document revision first. Regions completion validates the label that the first current publication established.

Configured language names, eligible bases, available parser names, and explicit bridge-server language declarations retain their routing identity. A wildcard server alone does not establish an unknown label. Stale, reopened, or concurrently relabelled work cannot overwrite the stored language.

When a provisional label was already sent to a wildcard host server, the accepted refinement also closes and reopens that downstream document with the current language and text, invalidating its host-routing decisions and diagnostic baselines. Reconciliation survives cancellation of the parse caller, checks the current lifetime and label, and leaves edits unblocked while outstanding host requests finish. Old host-language requests are refused within the establishing settings generation; reloads can still resolve a preserved label to a new canonical grammar. Newer virtual-routing work is retained.

Validation: deterministic delayed-open/edit interleavings for absent and unresolved labels; direct eager-host server selection and subsequent-edit preservation for aliases and parserless bridge declarations; stale/reopen and concurrent-refinement guards; real two-stage installer completion; wire-level close/reopen, cancellation, reload aliases, stale host requests, and preservation of newer virtual routing. Restoring the prior edit contract or completion expectation makes the corresponding regressions fail. `make check`, all-target/all-feature Clippy, 3,752 library tests, 445 E2E tests, and 79 integration tests passed (2 library and 1 E2E ignored).

Stacked on #1072. Fixes #1065.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic language detection and promotion when documents are edited or reopened.
  - Prevented outdated parsing results from overwriting newer language selections.
  - Improved language-server routing after language changes, configuration reloads, and concurrent edits.
  - Rejected stale requests when a document’s language changes, reducing incorrect or misrouted server actions.
  - Improved reopening and cancellation behavior for documents whose detected language is refined during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->