### PR TITLE
chore(bench): measure full-tree discovery costs

### DIFF
--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -4,10 +4,11 @@ Flamegraph profiling of the `semanticTokens/full` hot path, used to find and
 verify bottlenecks that the A/B benchmark (`benches/semantic_tokens.rs`) then
 quantifies.
 
-> **macOS only.** Offline symbolication relies on `.dSYM` + `dsymutil`/`atos`,
+> **Flamegraph tooling is macOS only.** Offline symbolication relies on `.dSYM` + `dsymutil`/`atos`,
 > and `analyze.py` assumes the macOS `__TEXT` base. `profile.sh` checks for this
 > and fails early elsewhere. (The benchmark in `benches/semantic_tokens.rs` is
-> cross-platform; only this profiling harness is macOS-specific.)
+> cross-platform. The direct driver is also cross-platform; the discovery
+> matrix runner below requires POSIX process groups.)
 
 ## Quick start
 
@@ -38,6 +39,42 @@ python3 benches/profile/drive.py \
   --bin ./target/release/kakehashi \
   --file path/to/input.md --requests 20 --burst 8 --burst-edits
 ```
+
+For reproducible edit-cycle measurements, exclude warmup and remove the default
+10 ms pause after each edit. JSON output preserves individual request samples,
+cycle wall times (starting before the edits), binary/fixture hashes, warnings,
+and resource usage:
+
+```sh
+python3 benches/profile/drive.py \
+  --bin ./target/release/kakehashi --file path/to/input.md \
+  --requests 30 --warmup 5 --edits 1 --edit-delay-ms 0 \
+  --json-output /tmp/semantic-run.json
+```
+
+Use `--documents 4` to open four copies in one server. Each cycle edits all
+copies, then queues one token request per document before reading their responses.
+This exercises the shared compute pool without same-document supersession; each
+JSON request sample includes its URI. When `--documents` is greater than 1,
+it cannot be combined with `--burst` greater than 1, `--captures`, or
+`--concurrent-captures`. In this mode cycle time covers the entire batch, not
+one document.
+
+The matrix adds `--tag-document-uris`, attaching a distinct
+`kakehashi-profile-document` query value to every host URI. Kakehashi preserves
+that query in virtual URIs, allowing the controlled peer's observations to be
+associated with their host without changing the file directory or basename.
+Direct driver invocations keep their existing URIs unless this flag is supplied.
+
+`cycle_seconds` includes all edits, configured edit delays and all responses in
+the cycle; it is edit-to-response latency for the single-request `--edits 1`
+case. Request samples start at the request itself. CPU and peak RSS describe
+reaped child processes over the whole session, including initialization, warmup
+and shutdown; they are not steady-state CPU or a sampled memory timeline.
+Platforms without Python's `resource` module report these fields as `null`.
+Notification counts and server warnings/errors also include initialization and
+warmup, so query-loading failures remain visible. Check them before treating a
+fast run as evidence of successfully executed work.
 
 The driver reports per-method p50/p90/max request-to-response latency both
 overall and split by outcome (`ok`, cancelled, `null`, error), time to the last
@@ -85,6 +122,108 @@ suite (or `make deps/tree-sitter`) once populates it.
 samply samples wall-clock, so blocked syscalls (the synchronous request/response
 IO) show up as `[libsystem_kernel.dylib]` — that's IO wait, not compute. Focus on
 the kakehashi/tree-sitter/regex frames for the actual CPU cost.
+
+## Discovery attribution fixtures
+
+`prepare_discovery.py` creates complete Rust and Markdown fixtures near 2 KiB,
+32 KiB and 1 MiB, plus native, Lua-only and wildcard bridge configurations. Rust
+contains documentation/ordinary comments and macros; Markdown mixes ordinary
+prose, inline markup and Lua fences. Edits toggle a character in the first
+comment/prose line without breaking the code. Sizes are targets; exact bytes and
+hashes are recorded in `inputs.json` together with parser/query and script hashes.
+
+```sh
+python3 benches/profile/prepare_discovery.py \
+  --runtime /path/to/fixed-runtime --output /tmp/discovery-inputs
+python3 benches/profile/drive.py \
+  --bin ./target/release/kakehashi \
+  --server-arg=--config-file --server-arg=/tmp/discovery-inputs/narrow.toml \
+  --file /tmp/discovery-inputs/markdown-common.md \
+  --warmup 5 --requests 30 --edits 1 --edit-delay-ms 0 \
+  --json-output /tmp/discovery-run.json
+```
+
+The runtime must already contain `parser/` and `queries/`, including the Rust,
+Markdown, Markdown-inline, Lua, comment and regex grammars and their real query
+corpus. No assets are installed or modified. Use an immutable runtime snapshot
+and retain its upstream revisions alongside the generated hash manifest. The
+output directory must be new, so old fixtures and peer observations cannot be
+silently reused.
+
+Both bridge configurations use `bridge_fixture.py`, a controlled sync-only LSP
+peer with no analysis or token provider. The narrow configuration accepts Lua
+injections; the wildcard configuration accepts every injection and the host.
+This measures kakehashi's routing/synchronization overhead and does not model
+EmmyLua or another real analyzer's costs. Before acknowledging shutdown, the peer
+records method/language counts and the distinct opened URI/language pairs under
+`peer-summaries/`. The matrix requires an injection open for every expected
+language from every host document, plus the exact host URI in wildcard mode.
+These observations prove coverage during the session, not freshness after each
+edit. Keep the per-run files: successful native tokens alone do not prove bridge
+coverage, and many regions from one document cannot stand in for another host.
+
+### Alternating matrix runs
+
+After building and retaining exact baseline/candidate binaries, run:
+
+```sh
+python3 benches/profile/measure_discovery.py \
+  --baseline /path/to/baseline --candidate /path/to/instrumented-candidate \
+  --inputs /tmp/discovery-inputs --output /tmp/discovery-results
+```
+
+This POSIX runner defaults to both languages, all three sizes/configurations,
+1 and 4 documents, and three alternating A/B pairs per scenario. Each run uses
+5 warmup and 30 measured edit cycles. Override `--sizes`, `--modes`,
+`--documents`, `--requests` and `--repeats` for a smoke test. Logged candidate
+runs follow each scenario separately and never enter the A/B latency sample.
+Run the authoritative matrix on an otherwise idle machine; retain source
+revisions, build commands/toolchain and runtime provenance alongside the output.
+
+`matrix.json` records binary/input/harness hashes, invocation order, peer
+observations and completion/failure status. Its global status becomes `complete`
+only after final input verification; any run or final-verification failure is
+recorded as `failed` with the error. Per-run JSON and stderr are retained,
+and runtime verification checks both the parser/query file inventory and hashes.
+The `.phases.json` files contain phase calls ending between the driver's measurement
+markers. Warmup calls can finish in that window, and final background work can
+finish after it; these are invocation distributions, not per-request accounting.
+Cancelled/incomplete calls are retained with their outcome details. The runner
+fails on missing token work, expected bridge opens, or completed discovery
+attribution in the measurement window, and retains partial evidence on failure.
+A timeout kills its isolated driver/server process group. Query
+warnings remain in each run artifact and must be assessed before drawing a
+conclusion. It never edits runtime queries to make a run appear successful.
+
+## Opt-in phase timings
+
+Set `RUST_LOG=kakehashi::profile=debug,kakehashi::semantic=debug` when running
+the driver to record phase durations on stderr. The `kakehashi::profile`
+timers acquire timestamps only when their Debug target is enabled. Run latency
+comparisons separately with logging disabled: output and timestamp collection
+perturb the profiled execution.
+
+| phase | measured interval |
+| ----- | ----------------- |
+| `parse` | parser work including incremental-seed replay, excluding pool queue and parser checkout; retries have separate `attempt` values |
+| `parse_await` | pool submission through async resumption, including checkout, parse attempts and queue wait |
+| `discovery` | the full-tree injection query traversal |
+| `resolution` | resolving collected regions into languages and virtual content, when bridge regions are required |
+| `snapshot_wait` | semantic-token request waiting for a current snapshot, including cancellation/supersession outcomes |
+
+Durations are wall time in microseconds, not CPU time. `completed=false` marks
+a call that returned no result; it does not distinguish cancellation from parser
+unavailability. Dropping a parse future before it resumes yields no
+`parse_await` record. Missing injection queries skip discovery, and empty regions
+or bridge-less configurations skip resolution; a missing record is not a zero
+cost measurement. The timings exclude region bookkeeping outside those calls.
+
+The existing `kakehashi::semantic` phase log reports host tokenization, injection
+tokenization, finalization and total compute. These intervals overlap: parser
+work is inside `parse_await`, snapshot waits can overlap parsing/discovery, and
+host/injection tokenization may run in parallel. Do not sum their medians into
+an end-to-end latency. Compare them with separately measured edit-to-response
+latency and sampled CPU/resource usage.
 
 ## Files
 

--- a/benches/profile/bridge_fixture.py
+++ b/benches/profile/bridge_fixture.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Controlled sync-only LSP peer for routing-cost measurements.
+
+This performs no language analysis. It isolates kakehashi's routing and document
+synchronization costs; its results do not predict a real downstream analyzer's
+CPU usage or diagnostic latency.
+"""
+import argparse
+from collections import Counter
+import json
+import os
+from pathlib import Path
+import sys
+
+
+def read_message():
+    length = None
+    while True:
+        line = sys.stdin.buffer.readline()
+        if not line:
+            return None
+        if line in (b"\r\n", b"\n"):
+            break
+        name, value = line.decode("ascii").split(":", 1)
+        if name.lower() == "content-length":
+            length = int(value)
+    if length is None:
+        raise ValueError("missing Content-Length")
+    return json.loads(sys.stdin.buffer.read(length))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--summary-dir", type=Path)
+    args = parser.parse_args()
+    methods = Counter()
+    languages = Counter()
+    opened_documents = set()
+    summary_written = False
+
+    def write_summary():
+        nonlocal summary_written
+        if args.summary_dir and not summary_written:
+            args.summary_dir.mkdir(parents=True, exist_ok=True)
+            (args.summary_dir / f"{os.getpid()}.json").write_text(
+                json.dumps({"methods": methods, "opened_languages": languages,
+                            "opened_documents": [{"uri": uri, "language": language}
+                                                 for uri, language in sorted(opened_documents)]},
+                           indent=2) + "\n",
+                encoding="utf-8",
+            )
+            # Never truncate the acknowledged summary during exit: the parent
+            # may send SIGTERM as soon as it receives our shutdown response.
+            summary_written = True
+
+    try:
+        while (message := read_message()) is not None:
+            method = message.get("method")
+            if method is None:
+                continue
+            methods[method] += 1
+            if method == "exit":
+                break
+            if method == "textDocument/didOpen":
+                document = message["params"]["textDocument"]
+                languages[document["languageId"]] += 1
+                opened_documents.add((document["uri"], document["languageId"]))
+            if "id" not in message:
+                continue
+            reply = {"jsonrpc": "2.0", "id": message["id"]}
+            if method == "initialize":
+                reply["result"] = {"capabilities": {"textDocumentSync": 1}}
+            elif method == "shutdown":
+                # The parent can terminate us immediately after this response;
+                # persist observations before acknowledging graceful shutdown.
+                write_summary()
+                reply["result"] = None
+            else:
+                reply["error"] = {"code": -32601, "message": "Method not found"}
+            body = json.dumps(reply).encode("utf-8")
+            sys.stdout.buffer.write(f"Content-Length: {len(body)}\r\n\r\n".encode() + body)
+            sys.stdout.buffer.flush()
+    finally:
+        write_summary()
+
+
+if __name__ == "__main__":
+    main()

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -12,17 +12,53 @@ Usage:
 """
 import argparse
 from collections import Counter, defaultdict
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
+import hashlib
 import json
 import math
 import os
+import platform
 import subprocess
 import sys
 import threading
 import time
+from typing import Optional
+from urllib.parse import parse_qs, urlsplit, urlunsplit
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from gen_session import gen_rust, gen_markdown_injections  # noqa: E402
+
+try:
+    import resource
+except ImportError:  # The LSP driver also runs on Windows.
+    resource = None
+
+
+def children_resources():
+    return resource.getrusage(resource.RUSAGE_CHILDREN) if resource else None
+
+
+def file_sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+PROFILE_DOCUMENT_QUERY = "kakehashi-profile-document"
+
+
+def profile_document_tag(uri):
+    values = parse_qs(urlsplit(uri).query, keep_blank_values=True).get(PROFILE_DOCUMENT_QUERY, [])
+    return values[0] if len(values) == 1 and values[0] else None
+
+
+def tagged_document_uris(uris):
+    # VirtualDocumentUri preserves the host query while replacing its basename.
+    # Tags therefore survive injection routing without changing directory roots.
+    return [urlunsplit(urlsplit(uri)._replace(query=f"{PROFILE_DOCUMENT_QUERY}={index}"))
+            for index, uri in enumerate(uris)]
 
 
 @dataclass(frozen=True)
@@ -31,6 +67,8 @@ class RequestSample:
     wire_bytes: int
     status: str
     completed_at: float = 0.0
+    uri: str = ""
+    token_count: Optional[int] = None
 
 
 @dataclass(frozen=True)
@@ -85,6 +123,12 @@ def response_status(message: dict) -> str:
     if not error:
         return "null" if "result" in message and message["result"] is None else "ok"
     return "canceled" if error.get("code") == -32800 else "error"
+
+
+def semantic_token_count(method: str, response: dict):
+    if method != "textDocument/semanticTokens/full" or response_status(response) != "ok":
+        return None
+    return len((response.get("result") or {}).get("data", [])) // 5
 
 
 def server_request_result(message: dict):
@@ -159,6 +203,15 @@ def main() -> None:
     ap.add_argument("--lang", choices=["rust", "markdown"], default="rust")
     ap.add_argument("--size", type=int, default=150)
     ap.add_argument("--requests", type=int, default=300)
+    ap.add_argument("--documents", type=int, default=1,
+                    help="edit this many copies before requesting tokens concurrently")
+    ap.add_argument("--tag-document-uris", action="store_true",
+                    help="tag host URIs so controlled peers can associate injection opens")
+    ap.add_argument("--warmup", type=int, default=0,
+                    help="unmeasured cycles before collecting request samples")
+    ap.add_argument("--edit-delay-ms", type=float, default=10,
+                    help="delay after each edit; use 0 for edit-to-response latency")
+    ap.add_argument("--json-output", help="write exact samples and run metadata as JSON")
     ap.add_argument(
         "--burst", type=int, default=1,
         help="send this many semantic-token requests back-to-back per cycle; "
@@ -200,6 +253,8 @@ def main() -> None:
     args = ap.parse_args()
     if args.requests <= 0:
         ap.error("--requests must be positive")  # avoids divide-by-zero in the summary
+    if args.warmup < 0 or args.edit_delay_ms < 0:
+        ap.error("--warmup and --edit-delay-ms must be non-negative")
     if args.burst <= 0:
         ap.error("--burst must be positive")
     if args.burst_edits and args.burst <= 1:
@@ -208,6 +263,10 @@ def main() -> None:
         ap.error("--burst-delay-ms must be non-negative")
     if args.burst > 1 and (args.captures or args.concurrent_captures):
         ap.error("--burst cannot be combined with captures modes")
+    if args.documents <= 0:
+        ap.error("--documents must be positive")
+    if args.documents > 1 and (args.burst > 1 or args.captures or args.concurrent_captures):
+        ap.error("--documents cannot be combined with bursts or captures")
     if args.concurrent_captures:
         args.captures = True
 
@@ -226,14 +285,23 @@ def main() -> None:
     else:
         uri, lang, text = "file:///profile/inj.md", "markdown", gen_markdown_injections(args.size)
 
+    uris = [uri] if args.documents == 1 else [
+        uri.rsplit(".", 1)[0] + f"-{index}." + uri.rsplit(".", 1)[1]
+        for index in range(args.documents)
+    ]
+    if args.tag_document_uris:
+        uris = tagged_document_uris(uris)
+        uri = uris[0]
     env = dict(os.environ, KAKEHASHI_DATA_DIR=args.data_dir)
     # Let the server's stderr through (it's silent unless RUST_LOG is set) so a
     # crash or panic is visible instead of being swallowed during profiling.
+    resources_before = children_resources()
     srv = subprocess.Popen([args.bin, *args.server_arg], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                            env=env)
     rid = 0
     request_samples = defaultdict(list)
     notification_counts = Counter()
+    diagnostic_messages = []
     notification_bytes = Counter()
     server_request_counts = Counter()
     server_request_bytes = Counter()
@@ -279,6 +347,10 @@ def main() -> None:
         method = message.get("method", "<unknown>")
         notification_counts[method] += 1
         notification_bytes[method] += wire_bytes
+        if method in ("window/logMessage", "window/showMessage"):
+            params = message.get("params") or {}
+            if params.get("type") in (1, 2):
+                diagnostic_messages.append(params)
 
     def handle_server_method(message, wire_bytes):
         method = message.get("method")
@@ -313,14 +385,18 @@ def main() -> None:
             wire_bytes=wire_bytes,
             status=response_status(response),
             completed_at=completed_at,
+            uri=(params.get("textDocument") or {}).get("uri", ""),
+            token_count=semantic_token_count(method, response),
         ))
         return response
 
     def measured_batch(requests):
         pending = {}
         for method, params in requests:
+            started = time.perf_counter()
             request_id = send_request(method, params)
-            pending[request_id] = (method, time.perf_counter())
+            pending[request_id] = (method, started, params)
+        request_ids = list(pending)
 
         responses = {}
         while pending:
@@ -330,16 +406,18 @@ def main() -> None:
             request_id = message.get("id")
             if request_id not in pending:
                 continue
-            method, started = pending.pop(request_id)
+            method, started, params = pending.pop(request_id)
             completed_at = time.perf_counter()
             request_samples[method].append(RequestSample(
                 seconds=completed_at - started,
                 wire_bytes=wire_bytes,
                 status=response_status(message),
                 completed_at=completed_at,
+                uri=(params.get("textDocument") or {}).get("uri", ""),
+                token_count=semantic_token_count(method, message),
             ))
-            responses[method] = message
-        return responses
+            responses[request_id] = message
+        return [responses[request_id] for request_id in request_ids]
 
     def measured_repeated(method, params, count, before_next=None, delay_seconds=0):
         nonlocal rid
@@ -367,6 +445,8 @@ def main() -> None:
                         wire_bytes=wire_bytes,
                         status=response_status(message),
                         completed_at=completed_at,
+                        uri=(params.get("textDocument") or {}).get("uri", ""),
+                        token_count=semantic_token_count(method, message),
                     ))
                     responses[request_id] = message
             except BaseException as error:
@@ -401,8 +481,9 @@ def main() -> None:
                                                 "tokenTypes": [], "tokenModifiers": [],
                                                 "formats": ["relative"]}}}})
         notify("initialized", {})
-        notify("textDocument/didOpen", {"textDocument": {
-            "uri": uri, "languageId": lang, "version": 1, "text": text}})
+        for document_uri in uris:
+            notify("textDocument/didOpen", {"textDocument": {
+                "uri": document_uri, "languageId": lang, "version": 1, "text": text}})
         if args.settle > 0:
             time.sleep(args.settle)  # let the initial parse settle
 
@@ -428,8 +509,9 @@ def main() -> None:
         # LSP `character` offsets are UTF-16 code units, not Unicode code
         # points — a non-ASCII first line would make the edit range invalid.
         first_line_len = len(text.split("\n", 1)[0].encode("utf-16-le")) // 2
-        t0 = time.time()
+        t0 = time.perf_counter()
         req_times = []
+        edit_response_times = []
         cycle_success_times = []
         line_has_extra = False
 
@@ -439,17 +521,30 @@ def main() -> None:
                 first_line_len, line_has_extra
             )
             version += 1
-            notify("textDocument/didChange", {
-                "textDocument": {"uri": uri, "version": version},
-                "contentChanges": [change],
-            })
+            for document_uri in uris:
+                notify("textDocument/didChange", {
+                    "textDocument": {"uri": document_uri, "version": version},
+                    "contentChanges": [change],
+                })
 
-        for i in range(args.requests):
+        for i in range(args.requests + args.warmup):
+            if i == args.warmup:
+                # Warmup drives the same edits and requests, but no warmup
+                # sample contributes to measured distributions or counters.
+                request_samples.clear()
+                req_times.clear()
+                edit_response_times.clear()
+                cycle_success_times.clear()
+                ok = canceled = superseded = 0
+                sys.stderr.write("[drive] measurement-start\n")
+                sys.stderr.flush()
+                t0 = time.perf_counter()
+            t_cycle = time.perf_counter()
             for j in range(args.edits):
                 # A no-op didChange would be deduped by hashes.
                 send_toggle_edit()
-                # a beat for the off-ingress reparse to run (the profiled work)
-                time.sleep(0.01)
+                if args.edit_delay_ms:
+                    time.sleep(args.edit_delay_ms / 1000)
             t_req = time.perf_counter()
             semantic_sample_start = len(
                 request_samples["textDocument/semanticTokens/full"]
@@ -468,11 +563,16 @@ def main() -> None:
                 # Queue captures first to model an editor whose highlighting work
                 # is already in flight when semantic tokens arrive.
                 responses = measured_batch([*captures_requests, semantic_request])
-                semantic_responses = [responses[semantic_request[0]]]
+                semantic_responses = [responses[-1]]
                 captures_responses = {
-                    method: responses[method]
-                    for method, _ in captures_requests
+                    method: response
+                    for (method, _), response in zip(captures_requests, responses)
                 }
+            elif args.documents > 1:
+                semantic_responses = measured_batch([
+                    (semantic_request[0], {"textDocument": {"uri": document_uri}})
+                    for document_uri in uris
+                ])
             elif args.burst > 1:
                 if args.burst_edits:
                     send_toggle_edit()
@@ -497,6 +597,7 @@ def main() -> None:
                     captures_result_id = next_result_id
                     break
             req_times.append(time.perf_counter() - t_req)
+            edit_response_times.append(time.perf_counter() - t_cycle)
             cycle_semantic_samples = request_samples[
                 "textDocument/semanticTokens/full"
             ][semantic_sample_start:]
@@ -513,7 +614,9 @@ def main() -> None:
             ok += cycle_ok
             canceled += cycle_canceled
             superseded += cycle_superseded
-        elapsed = time.time() - t0
+        elapsed = time.perf_counter() - t0
+        sys.stderr.write("[drive] measurement-end\n")
+        sys.stderr.flush()
 
         request("shutdown", None)
         notify("exit", {})
@@ -525,6 +628,37 @@ def main() -> None:
             srv.kill()
             srv.wait()
 
+    resources_after = children_resources()
+    if args.json_output:
+        binary_sha256 = file_sha256(args.bin)
+        artifact = {
+            "schema_version": 1,
+            "arguments": vars(args),
+            "platform": platform.platform(),
+            "binary_sha256": binary_sha256,
+            "fixture_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "fixture_bytes": len(text.encode("utf-8")),
+            "document_uris": uris,
+            "last_semantic_token_count": tokens,
+            "rust_log": env.get("RUST_LOG", ""),
+            "elapsed_seconds": elapsed,
+            "request_samples": {
+                method: [asdict(sample) for sample in samples]
+                for method, samples in request_samples.items()
+            },
+            "cycle_seconds": edit_response_times,
+            "notification_counts_including_warmup": dict(notification_counts),
+            "server_warnings_and_errors": diagnostic_messages,
+            # The driver launches one server. Child resource usage includes
+            # startup/shutdown and warmup, unlike the measured latency window.
+            "children_user_seconds": (resources_after.ru_utime - resources_before.ru_utime) if resources_after else None,
+            "children_system_seconds": (resources_after.ru_stime - resources_before.ru_stime) if resources_after else None,
+            "children_maxrss_bytes": resources_after.ru_maxrss * (1 if sys.platform == "darwin" else 1024) if resources_after else None,
+            "server_exit_code": srv.returncode,
+        }
+        with open(args.json_output, "w", encoding="utf-8") as output:
+            json.dump(artifact, output, indent=2)
+            output.write("\n")
     n_bytes = len(text.encode("utf-8"))
     n_lines = len(text.splitlines())
     source = (f"file={args.file} ({n_bytes}B/{n_lines}L)"
@@ -533,7 +667,7 @@ def main() -> None:
     measured_responses = sum(len(samples) for samples in request_samples.values())
     sys.stderr.write(f"[drive] first-cycle ms: {firsts}\n")
     sys.stderr.write(
-        f"[drive] lang={lang} {source} cycles={args.requests} burst={args.burst} "
+        f"[drive] lang={lang} {source} documents={args.documents} cycles={args.requests} burst={args.burst} "
         f"responses={measured_responses} "
         f"ok={ok} canceled={canceled} superseded={superseded} tokens/req={tokens} "
         f"wall={elapsed*1000:.0f}ms "

--- a/benches/profile/measure_discovery.py
+++ b/benches/profile/measure_discovery.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Alternate exact binaries across discovery scenarios, retaining raw evidence."""
+import argparse
+import itertools
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import signal
+import subprocess
+import sys
+from urllib.parse import urlsplit
+
+from drive import file_sha256, profile_document_tag
+from prepare_discovery import runtime_asset_paths
+
+
+def phase_samples(log):
+    """Only aggregate calls ending inside the driver's measurement window.
+
+    These are invocation samples, not a sum or attribution per request: work
+    may overlap, and work started during warmup can finish inside the window.
+    """
+    active = False
+    samples = []
+    for line in log.splitlines():
+        if line == "[drive] measurement-start":
+            active = True
+        elif line == "[drive] measurement-end":
+            active = False
+        elif active:
+            match = re.search(r"phase=(\w+) elapsed_us=(\d+)\s+(.*)", line)
+            if match:
+                samples.append({"phase": match[1], "elapsed_us": int(match[2]),
+                                "details": match[3]})
+            match = re.search(
+                r"compute phases: compute=(\d+)us host=(\d+)us injections=(\d+)us finalize=(\d+)us (.*)",
+                line,
+            )
+            if match:
+                for index, phase in enumerate(("compute", "host_tokens", "injection_tokens", "finalize"), 1):
+                    samples.append({"phase": phase, "elapsed_us": int(match[index]),
+                                    "details": match[5]})
+    return samples
+
+
+def verify_inputs(directory, expected_manifest=None):
+    manifest = json.loads((directory / "inputs.json").read_text())
+    # Regenerating inputs.json must not redefine the provenance captured before
+    # measurement, even when the replacement files match its new hashes.
+    if expected_manifest is not None and manifest != expected_manifest:
+        raise ValueError("input manifest changed during measurement")
+    for item in manifest["fixtures"] + manifest["configs"]:
+        if file_sha256(directory / item["path"]) != item["sha256"]:
+            raise ValueError(f"input changed: {item['path']}")
+    runtime = Path(manifest["runtime"])
+    expected_assets = {item["path"] for item in manifest["assets"]}
+    actual_assets = {str(path.relative_to(runtime)) for path in runtime_asset_paths(runtime)}
+    if actual_assets != expected_assets:
+        raise ValueError(f"runtime inventory changed: added={sorted(actual_assets - expected_assets)}, "
+                         f"removed={sorted(expected_assets - actual_assets)}")
+    for item in manifest["assets"]:
+        if file_sha256(runtime / item["path"]) != item["sha256"]:
+            raise ValueError(f"runtime changed: {item['path']}")
+    for name, digest in manifest["scripts"].items():
+        if file_sha256(Path(__file__).with_name(name)) != digest:
+            raise ValueError(f"input generator/peer changed: {name}; regenerate inputs")
+    return manifest
+
+
+def run_driver(command, env, log, timeout):
+    # The driver owns a server and possibly bridge children. A timeout must
+    # reap the entire isolated process group, not just kill the Python parent.
+    process = subprocess.Popen(command, env=env, stdout=log, stderr=log,
+                               start_new_session=True)
+    try:
+        code = process.wait(timeout=timeout)
+        if code:
+            raise subprocess.CalledProcessError(code, command)
+    except BaseException:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.wait()
+        raise
+
+
+def require_bridge_documents(peers, host_uris, language, mode):
+    expected = set()
+    if mode == "wildcard":
+        expected = {"comment"} if language == "rust" else {"markdown_inline", "lua"}
+    elif mode == "narrow" and language == "markdown":
+        expected = {"lua"}
+    if not expected:
+        return
+    tags = [profile_document_tag(uri) for uri in host_uris]
+    if None in tags or len(set(tags)) != len(host_uris):
+        raise ValueError("bridge evidence requires distinct host document tags")
+    opened = {(document["uri"], document["language"])
+              for peer in peers for document in peer.get("opened_documents", [])}
+    for host_uri, tag in zip(host_uris, tags):
+        if mode == "wildcard" and (host_uri, language) not in opened:
+            raise ValueError(f"intended bridge host open missing for {host_uri}")
+        injected = {opened_language for uri, opened_language in opened
+                    if uri != host_uri and profile_document_tag(uri) == tag
+                    and urlsplit(uri).path.rsplit("/", 1)[-1].startswith("kakehashi-virtual-uri-")}
+        missing = expected - injected
+        if missing:
+            raise ValueError(f"intended bridge injections missing for {host_uri}: {sorted(missing)}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", type=Path, required=True)
+    parser.add_argument("--candidate", type=Path, required=True)
+    parser.add_argument("--inputs", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--requests", type=int, default=30)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--documents", type=int, nargs="+", default=[1, 4])
+    parser.add_argument("--sizes", nargs="+", choices=["small", "common", "large"],
+                        default=["small", "common", "large"])
+    parser.add_argument("--modes", nargs="+", choices=["native", "narrow", "wildcard"],
+                        default=["native", "narrow", "wildcard"])
+    parser.add_argument("--timeout", type=float, default=180)
+    args = parser.parse_args()
+    if os.name != "posix":
+        parser.error("the matrix runner requires POSIX process-group cleanup")
+    if args.requests < 1 or args.warmup < 0 or args.repeats < 1 or min(args.documents) < 1 or args.timeout <= 0:
+        parser.error("positive counts/timeout and nonnegative warmup required")
+    for name in ("documents", "sizes", "modes"):
+        values = getattr(args, name)
+        if len(values) != len(set(values)):
+            parser.error(f"--{name} cannot contain duplicate values")
+    inputs = args.inputs.resolve()
+    manifest = verify_inputs(inputs)
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    binaries = {"baseline": args.baseline.resolve(), "candidate": args.candidate.resolve()}
+    hashes = {name: file_sha256(path) for name, path in binaries.items()}
+    runs = []
+    record = {"status": "running", "platform": platform.platform(), "cpu_count": os.cpu_count(),
+              "arguments": {k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()},
+              "binaries": {k: {"path": str(v), "sha256": hashes[k]} for k, v in binaries.items()},
+              "harness_sha256": {name: file_sha256(Path(__file__).with_name(name))
+                                  for name in ("drive.py", "measure_discovery.py")},
+              "inputs": manifest, "runs": runs}
+
+    def save():
+        (output / "matrix.json").write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+
+    def run(language, size, mode, documents, variant, repetition, profile=False):
+        stem = f"{language}-{size}-{mode}-d{documents}-{variant}-{repetition}" + ("-profile" if profile else "")
+        run_record = {"name": stem, "language": language, "size": size, "mode": mode,
+                      "documents": documents, "variant": variant, "repetition": repetition,
+                      "profile": profile, "status": "running"}
+        runs.append(run_record)
+        save()
+        print(stem, flush=True)
+        peer_dir = inputs / "peer-summaries"
+        before = set(peer_dir.glob("*.json"))
+        ext = "rs" if language == "rust" else "md"
+        command = [sys.executable, str(Path(__file__).with_name("drive.py")),
+                   "--bin", str(binaries[variant]), "--server-arg=--config-file",
+                   "--server-arg=" + str(inputs / f"{mode}.toml"),
+                   "--file", str(inputs / f"{language}-{size}.{ext}"),
+                   "--data-dir", manifest["runtime"], "--requests", str(args.requests),
+                   "--warmup", str(args.warmup), "--edits", "1", "--edit-delay-ms", "0",
+                   "--tag-document-uris",
+                   "--documents", str(documents), "--json-output", str(output / f"{stem}.json")]
+        run_record["command"] = command
+        env = dict(os.environ, RUST_LOG="kakehashi::profile=debug,kakehashi::semantic=debug" if profile else "")
+        try:
+            with (output / f"{stem}.log").open("w") as log:
+                run_driver(command, env, log, args.timeout)
+            result = json.loads((output / f"{stem}.json").read_text())
+            samples = result["request_samples"]["textDocument/semanticTokens/full"]
+            if result["binary_sha256"] != hashes[variant]:
+                raise ValueError("binary changed during measurement")
+            if len(samples) != args.requests * documents or result["last_semantic_token_count"] == 0:
+                raise ValueError("missing responses or empty token computation")
+            if result["server_exit_code"] != 0:
+                raise ValueError("server exited unsuccessfully")
+            completed_uris = {
+                sample["uri"] for sample in samples
+                if sample["status"] == "ok" and (sample.get("token_count") or 0) > 0
+            }
+            if completed_uris != set(result["document_uris"]):
+                raise ValueError("at least one document completed no measured token work")
+            peers = [json.loads(path.read_text()) for path in sorted(set(peer_dir.glob("*.json")) - before)]
+            run_record["peers"] = peers
+            require_bridge_documents(peers, result["document_uris"], language, mode)
+            if profile:
+                phases = phase_samples((output / f"{stem}.log").read_text())
+                if not any(sample["phase"] == "discovery" and
+                           re.search(r"(?:^|\s)completed=true(?:\s|$)", sample["details"])
+                           for sample in phases):
+                    raise ValueError("candidate emitted no completed discovery phase samples")
+                (output / f"{stem}.phases.json").write_text(json.dumps(phases, indent=2) + "\n")
+            run_record["status"] = "complete"
+        except BaseException as error:
+            run_record["status"] = "failed"
+            run_record["error"] = str(error)
+            raise
+        finally:
+            save()
+
+    try:
+        scenarios = itertools.product(("rust", "markdown"), args.sizes, args.modes, args.documents)
+        for index, (language, size, mode, documents) in enumerate(scenarios):
+            for repetition in range(args.repeats):
+                order = ("baseline", "candidate") if (index + repetition) % 2 == 0 else ("candidate", "baseline")
+                for variant in order:
+                    run(language, size, mode, documents, variant, repetition)
+            # Logged attribution is a separate run, never part of the A/B latency samples.
+            run(language, size, mode, documents, "candidate", 0, profile=True)
+        verify_inputs(inputs, manifest)
+        for name, digest in record["harness_sha256"].items():
+            if file_sha256(Path(__file__).with_name(name)) != digest:
+                raise ValueError(f"measurement harness changed: {name}")
+    except BaseException as error:
+        record["status"] = "failed"
+        record["error"] = str(error)
+        raise
+    else:
+        record["status"] = "complete"
+    finally:
+        save()
+
+
+if __name__ == "__main__":
+    main()

--- a/benches/profile/prepare_discovery.py
+++ b/benches/profile/prepare_discovery.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Prepare fixed fixtures/configs and hash an existing parser/query runtime."""
+import argparse
+import json
+from pathlib import Path
+import sys
+
+from drive import file_sha256
+from gen_session import gen_rust
+
+
+def runtime_asset_paths(runtime):
+    return [path for directory in (runtime / "parser", runtime / "queries")
+            for path in sorted(directory.rglob("*")) if path.is_file()]
+
+
+def rust_fixture(target_bytes):
+    prefix = "// An ordinary comment edited by the measurement driver.\n"
+    count = max(1, target_bytes // len(gen_rust(1).encode()))
+    while True:
+        text = prefix + gen_rust(count)
+        if len(text.encode()) >= target_bytes:
+            return text
+        count += 1
+
+
+def markdown_fixture(target_bytes):
+    chunks = ["An ordinary prose line edited by the measurement driver.\n\n"]
+    size = len(chunks[0].encode())
+    index = 0
+    while size < target_bytes:
+        chunk = (
+            f"## Section {index}\n\n"
+            "This paragraph describes a small Lua example. Ordinary prose, "
+            "emphasis on *readability*, and a `value` reference surround each "
+            "code block. The examples keep their local state in functions.\n\n"
+            f"```lua\n-- An ordinary comment for example {index}.\n"
+            f"local function example_{index}(value)\n"
+            "  local doubled = value * 2\n"
+            "  print(doubled)\n"
+            "  return doubled\nend\n```\n\n"
+        )
+        chunks.append(chunk)
+        size += len(chunk.encode())
+        index += 1
+    return "".join(chunks)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runtime", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    runtime = args.runtime.resolve()
+    output = args.output.resolve()
+    if not (runtime / "parser").is_dir() or not (runtime / "queries").is_dir():
+        parser.error("--runtime must contain parser/ and queries/")
+    # Refuse existing output so a rerun cannot mix fixtures or peer summaries.
+    output.mkdir(parents=True, exist_ok=False)
+    fixtures = []
+    for name, target in (("small", 2048), ("common", 32768), ("large", 1048576)):
+        for language, ext, generate in (("rust", "rs", rust_fixture),
+                                        ("markdown", "md", markdown_fixture)):
+            path = output / f"{language}-{name}.{ext}"
+            path.write_text(generate(target), encoding="utf-8")
+            fixtures.append({"path": path.name, "language": language,
+                             "target_bytes": target, "bytes": path.stat().st_size,
+                             "sha256": file_sha256(path)})
+    command = [sys.executable, str(Path(__file__).with_name("bridge_fixture.py").resolve()),
+               "--summary-dir", str(output / "peer-summaries")]
+    common = f"searchPaths = [{json.dumps(str(runtime), ensure_ascii=False)}]\n[languages._]\nautoInstall = false\n"
+    configs = []
+    for mode in ("native", "narrow", "wildcard"):
+        config = common
+        if mode != "native":
+            config += "[languages._.bridge._self]\nenabled = true\n"
+            config += f"[languages._.bridge._]\nenabled = {str(mode == 'wildcard').lower()}\n"
+            if mode == "narrow":
+                config += "[languages._.bridge.lua]\nenabled = true\n"
+            config += f"[languageServers.profile]\ncmd = {json.dumps(command, ensure_ascii=False)}\n"
+            config += f"languages = {json.dumps(['lua'] if mode == 'narrow' else ['*'])}\n"
+        for language in ("rust", "markdown", "markdown_inline", "lua", "comment", "regex"):
+            config += f"[languages.{language}]\n"
+        path = output / f"{mode}.toml"
+        path.write_text(config, encoding="utf-8")
+        configs.append({"mode": mode, "path": path.name, "sha256": file_sha256(path)})
+    assets = [{"path": str(path.relative_to(runtime)), "sha256": file_sha256(path)}
+              for path in runtime_asset_paths(runtime)]
+    scripts = {path.name: file_sha256(path) for path in (
+        Path(__file__), Path(__file__).with_name("bridge_fixture.py"),
+        Path(__file__).with_name("gen_session.py"))}
+    (output / "inputs.json").write_text(json.dumps({
+        "runtime": str(runtime), "assets": assets, "fixtures": fixtures,
+        "configs": configs, "scripts": scripts,
+        "peer": "sync-only fixture; no downstream analysis",
+    }, indent=2) + "\n", encoding="utf-8")
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/benches/profile/test_bridge_fixture.py
+++ b/benches/profile/test_bridge_fixture.py
@@ -1,0 +1,43 @@
+"""Check the controlled peer's actual wire observations and shutdown artifact."""
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+class BridgeFixtureTest(unittest.TestCase):
+    def test_records_opened_uri_and_language_before_shutdown(self):
+        opened = [
+            {"uri": "file:///profile/input-0.md?kakehashi-profile-document=0", "language": "markdown"},
+            {"uri": "file:///profile/kakehashi-virtual-uri-R0.lua?kakehashi-profile-document=0", "language": "lua"},
+            {"uri": "file:///profile/kakehashi-virtual-uri-R1.lua?kakehashi-profile-document=1", "language": "lua"},
+        ]
+        messages = [{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}]
+        messages.extend({"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": {
+            "textDocument": {"uri": document["uri"], "languageId": document["language"],
+                             "version": 1, "text": ""}}} for document in opened)
+        messages.extend([{"jsonrpc": "2.0", "id": 2, "method": "shutdown", "params": None},
+                         {"jsonrpc": "2.0", "method": "exit"}])
+        wire = b""
+        for message in messages:
+            body = json.dumps(message).encode("utf-8")
+            wire += f"Content-Length: {len(body)}\r\n\r\n".encode() + body
+        with tempfile.TemporaryDirectory() as directory:
+            result = subprocess.run([
+                sys.executable, str(Path(__file__).with_name("bridge_fixture.py")),
+                "--summary-dir", directory,
+            ], input=wire, capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr.decode())
+            summaries = list(Path(directory).glob("*.json"))
+            self.assertEqual(len(summaries), 1)
+            summary = json.loads(summaries[0].read_text())
+            self.assertEqual(summary.get("opened_documents"), sorted(opened, key=lambda item: (item["uri"], item["language"])))
+            self.assertEqual(summary["opened_languages"], {"markdown": 1, "lua": 2})
+            self.assertEqual(summary["methods"]["shutdown"], 1)
+            self.assertNotIn("exit", summary["methods"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benches/profile/test_discovery_inputs.py
+++ b/benches/profile/test_discovery_inputs.py
@@ -1,0 +1,61 @@
+"""Runtime provenance checks against fixtures prepared by the real generator."""
+import contextlib
+import io
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent))
+import measure_discovery
+import prepare_discovery
+
+
+class DiscoveryInputsTest(unittest.TestCase):
+    def prepare_inputs(self, root):
+        runtime = root / "runtime"
+        (runtime / "parser").mkdir(parents=True)
+        (runtime / "queries" / "rust").mkdir(parents=True)
+        (runtime / "parser" / "rust.so").write_bytes(b"fixed parser bytes")
+        (runtime / "queries" / "rust" / "highlights.scm").write_text(
+            "(identifier) @variable\n", encoding="utf-8")
+        output = root / "inputs"
+        arguments = ["prepare_discovery.py", "--runtime", str(runtime),
+                     "--output", str(output)]
+        with patch.object(sys, "argv", arguments), contextlib.redirect_stdout(io.StringIO()), \
+                patch.object(prepare_discovery, "rust_fixture", return_value="// comment\n"), \
+                patch.object(prepare_discovery, "markdown_fixture", return_value="prose\n"):
+            prepare_discovery.main()
+        measure_discovery.verify_inputs(output)
+        return runtime, output
+
+    def test_rejects_added_runtime_query(self):
+        with tempfile.TemporaryDirectory() as directory:
+            runtime, inputs = self.prepare_inputs(Path(directory))
+            (runtime / "queries" / "rust" / "injections.scm").write_text(
+                "(line_comment) @injection.content\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "runtime inventory changed"):
+                measure_discovery.verify_inputs(inputs)
+
+    def test_rejects_added_parser_or_removed_query(self):
+        for change in ("add parser", "remove query"):
+            with self.subTest(change=change), tempfile.TemporaryDirectory() as directory:
+                runtime, inputs = self.prepare_inputs(Path(directory))
+                if change == "add parser":
+                    (runtime / "parser" / "lua.so").write_bytes(b"another parser")
+                else:
+                    (runtime / "queries" / "rust" / "highlights.scm").unlink()
+                with self.assertRaisesRegex(ValueError, "runtime inventory changed"):
+                    measure_discovery.verify_inputs(inputs)
+
+    def test_still_rejects_changed_bytes_with_the_same_inventory(self):
+        with tempfile.TemporaryDirectory() as directory:
+            runtime, inputs = self.prepare_inputs(Path(directory))
+            (runtime / "parser" / "rust.so").write_bytes(b"different parser bytes")
+            with self.assertRaisesRegex(ValueError, "runtime changed"):
+                measure_discovery.verify_inputs(inputs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -8,14 +8,25 @@ from drive import (
     RequestSample,
     count_semantic_outcomes,
     next_toggle_change,
+    profile_document_tag,
     response_result_id,
     server_request_result,
     summarize_samples,
     summarize_samples_by_status,
+    tagged_document_uris,
 )
 
 
 class RequestSummaryTest(unittest.TestCase):
+    def test_tags_preserve_file_paths_and_identify_each_document(self):
+        uris = ["file:///profile/input-0.md", "file:///profile/input-1.md"]
+        tagged = tagged_document_uris(uris)
+        self.assertEqual(tagged, [uri + f"?kakehashi-profile-document={index}"
+                                  for index, uri in enumerate(uris)])
+        self.assertEqual([profile_document_tag(uri) for uri in tagged], ["0", "1"])
+        self.assertIsNone(profile_document_tag(uris[0]))
+        self.assertIsNone(profile_document_tag(tagged[0] + "&kakehashi-profile-document=1"))
+
     def test_summarizes_latency_status_and_wire_bytes(self):
         samples = [
             RequestSample(seconds=0.010, wire_bytes=100, status="ok"),

--- a/benches/profile/test_measure_discovery.py
+++ b/benches/profile/test_measure_discovery.py
@@ -1,0 +1,273 @@
+"""Matrix admission regressions with fabricated driver artifacts, no processes."""
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+from urllib.parse import urlsplit, urlunsplit
+
+sys.path.insert(0, str(Path(__file__).parent))
+import measure_discovery
+
+
+@unittest.skipUnless(os.name == "posix", "matrix runner requires POSIX process groups")
+class MatrixTokenWorkTest(unittest.TestCase):
+    def run_matrix(self, cycles, mode="native", peer_languages=None, phase_log=None,
+                   final_verification_error=None, changed_harness=None, peer_documents=None,
+                   rewrite_inputs=False):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            original_verify_inputs = measure_discovery.verify_inputs
+            original_file_sha256 = measure_discovery.file_sha256
+            if rewrite_inputs:
+                inputs = root / "inputs"
+                inputs.mkdir()
+                fixture = inputs / "fixture.txt"
+                fixture.write_text("original fixture")
+                manifest = {"runtime": str(root), "fixtures": [
+                    {"path": fixture.name, "sha256": original_file_sha256(fixture)}],
+                    "configs": [], "assets": [], "scripts": {}}
+                (inputs / "inputs.json").write_text(json.dumps(manifest))
+            uris = [f"file:///profile/input-{index}.md?kakehashi-profile-document={index}"
+                    for index in range(4)]
+            samples = [
+                {"uri": uri, "status": status, "token_count": count}
+                for cycle in cycles
+                for uri, (status, count) in zip(uris, cycle)
+            ]
+
+            def fake_driver(command, env, log, timeout):
+                # Exercise the actual matrix main, its validators, and its
+                # artifact status handling; only the external process is fake.
+                if rewrite_inputs:
+                    # Simulate regenerating an input and its self-consistent
+                    # manifest after the initial provenance snapshot was recorded.
+                    fixture.write_text("replacement fixture")
+                    manifest["fixtures"][0]["sha256"] = original_file_sha256(fixture)
+                    (inputs / "inputs.json").write_text(json.dumps(manifest))
+                output = Path(command[command.index("--json-output") + 1])
+                running_matrix = json.loads((output.parent / "matrix.json").read_text())
+                self.assertEqual(running_matrix.get("status"), "running")
+                if peer_languages is not None:
+                    peer_dir = root / "inputs" / "peer-summaries"
+                    peer_dir.mkdir(parents=True, exist_ok=True)
+                    language = output.name.split("-", 1)[0]
+                    languages = peer_languages(language)
+                    opened_documents = (peer_documents(language, uris) if peer_documents else
+                                        self.bridge_documents(language, uris, languages))
+                    (peer_dir / output.name).write_text(json.dumps({
+                        "opened_languages": languages,
+                        "opened_documents": opened_documents,
+                    }), encoding="utf-8")
+                output.write_text(json.dumps({
+                    "binary_sha256": "fixed-binary-hash",
+                    "request_samples": {"textDocument/semanticTokens/full": samples},
+                    "last_semantic_token_count": 3,
+                    "document_uris": uris,
+                    "server_exit_code": 0,
+                }), encoding="utf-8")
+                log.write("[drive] measurement-start\n")
+                log.write(phase_log if phase_log is not None else
+                          "phase=discovery elapsed_us=1 completed=true regions=1\n")
+                log.write("[drive] measurement-end\n")
+
+            arguments = [
+                "measure_discovery.py", "--baseline", str(root / "baseline"),
+                "--candidate", str(root / "candidate"),
+                "--inputs", str(root / "inputs"), "--output", str(root / "results"),
+                "--requests", str(len(cycles)), "--warmup", "0", "--repeats", "1",
+                "--documents", "4", "--sizes", "small", "--modes", mode,
+            ]
+            verification_calls = 0
+
+            def fake_verify_inputs(directory, *args):
+                nonlocal verification_calls
+                verification_calls += 1
+                if verification_calls > 1 and final_verification_error is not None:
+                    raise ValueError(final_verification_error)
+                if rewrite_inputs:
+                    return original_verify_inputs(directory, *args)
+                return {"runtime": str(root)}
+
+            def fake_file_sha256(path):
+                if rewrite_inputs and Path(path).resolve() == fixture.resolve():
+                    return original_file_sha256(path)
+                if verification_calls > 1 and Path(path).name == changed_harness:
+                    return "changed-harness-hash"
+                return "fixed-binary-hash"
+
+            with patch.object(sys, "argv", arguments), \
+                    patch.object(measure_discovery, "verify_inputs", side_effect=fake_verify_inputs), \
+                    patch.object(measure_discovery, "file_sha256", side_effect=fake_file_sha256), \
+                    patch.object(measure_discovery, "run_driver", side_effect=fake_driver), \
+                    patch("builtins.print"):
+                try:
+                    measure_discovery.main()
+                finally:
+                    self.last_matrix_record = json.loads(
+                        (root / "results" / "matrix.json").read_text())
+            record = json.loads((root / "results" / "matrix.json").read_text())
+            self.assertEqual(len(record["runs"]), 6)
+            self.assertEqual(record.get("status"), "complete")
+            self.assertTrue(all(run["status"] == "complete" for run in record["runs"]))
+
+    @staticmethod
+    def bridge_documents(host_language, uris, languages):
+        opened = []
+        for index, uri in enumerate(uris):
+            for language in languages:
+                parts = urlsplit(uri)
+                path = f"/profile/kakehashi-virtual-uri-region-{index}-{language}.{language}"
+                opened_uri = uri if language == host_language else urlunsplit(parts._replace(path=path))
+                opened.append({"uri": opened_uri, "language": language})
+        return opened
+
+    def test_one_documents_many_regions_cannot_cover_other_documents(self):
+        for mode in ("narrow", "wildcard"):
+            with self.subTest(mode=mode):
+                def languages(language):
+                    if mode == "narrow":
+                        return {"lua": 4} if language == "markdown" else {}
+                    return ({"rust": 4, "comment": 4} if language == "rust" else
+                            {"markdown": 4, "markdown_inline": 4, "lua": 4})
+
+                def opened(language, uris):
+                    values = self.bridge_documents(language, uris, languages(language))
+                    if language == "markdown":
+                        for index, item in enumerate(values):
+                            if item["language"] == "lua":
+                                parts = urlsplit(item["uri"])
+                                item["uri"] = urlunsplit(parts._replace(
+                                    query="kakehashi-profile-document=0",
+                                    path=f"/profile/kakehashi-virtual-uri-extra-{index}.lua"))
+                    return values
+
+                with self.assertRaisesRegex(ValueError, "bridge"):
+                    self.run_matrix([[("ok", 3)] * 4], mode=mode,
+                                    peer_languages=languages, peer_documents=opened)
+
+    def test_virtual_rust_opens_cannot_substitute_for_wildcard_host_opens(self):
+        def languages(language):
+            return ({"rust": 4, "comment": 4} if language == "rust" else
+                    {"markdown": 4, "markdown_inline": 4, "lua": 4})
+
+        def opened(language, uris):
+            values = self.bridge_documents(language, uris, languages(language))
+            for index, item in enumerate(values):
+                if item["language"] == language:
+                    parts = urlsplit(item["uri"])
+                    item["uri"] = urlunsplit(parts._replace(
+                        path=f"/profile/kakehashi-virtual-uri-host-substitute-{index}.{language}"))
+            return values
+
+        with self.assertRaisesRegex(ValueError, "bridge host open"):
+            self.run_matrix([[("ok", 3)] * 4], mode="wildcard",
+                            peer_languages=languages, peer_documents=opened)
+
+    def test_replaced_input_and_manifest_cannot_redefine_final_verification(self):
+        with self.assertRaisesRegex(ValueError, "input manifest changed"):
+            self.run_matrix([[("ok", 3)] * 4], rewrite_inputs=True)
+        self.assertEqual(len(self.last_matrix_record["runs"]), 6)
+        self.assertTrue(all(run["status"] == "complete" for run in self.last_matrix_record["runs"]))
+        self.assertEqual(self.last_matrix_record["status"], "failed")
+        self.assertIn("input manifest changed", self.last_matrix_record["error"])
+
+    def test_records_final_verification_failure_after_successful_runs(self):
+        with self.assertRaisesRegex(ValueError, "runtime changed during measurement"):
+            self.run_matrix([[("ok", 3)] * 4],
+                            final_verification_error="runtime changed during measurement")
+        self.assertTrue(all(run["status"] == "complete" for run in self.last_matrix_record["runs"]))
+        self.assertEqual(self.last_matrix_record.get("status"), "failed")
+        self.assertEqual(self.last_matrix_record.get("error"), "runtime changed during measurement")
+
+    def test_records_changed_measurement_harness_after_successful_runs(self):
+        for name in ("drive.py", "measure_discovery.py"):
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(ValueError, "measurement harness changed"):
+                    self.run_matrix([[("ok", 3)] * 4], changed_harness=name)
+                self.assertTrue(all(run["status"] == "complete" for run in self.last_matrix_record["runs"]))
+                self.assertEqual(self.last_matrix_record.get("status"), "failed")
+                self.assertIn(name, self.last_matrix_record.get("error", ""))
+
+    def test_rejects_documents_with_only_empty_successful_responses(self):
+        # The old validator accepts this: all URIs have status=ok, and
+        # the last document supplies a nonzero global final token count.
+        cycle = [("ok", 0), ("ok", 0), ("ok", 0), ("ok", 3)]
+        with self.assertRaisesRegex(ValueError, "token work"):
+            self.run_matrix([cycle, cycle])
+
+    def test_rejects_legacy_token_timings_without_discovery_attribution(self):
+        with self.assertRaisesRegex(ValueError, "discovery"):
+            self.run_matrix(
+                [[("ok", 3)] * 4],
+                phase_log="compute phases: compute=8us host=3us injections=4us finalize=1us uri=file:///profile/input.md\n",
+            )
+        self.assertEqual(self.last_matrix_record.get("status"), "failed")
+        self.assertIn("discovery", self.last_matrix_record.get("error", ""))
+        self.assertEqual(self.last_matrix_record["runs"][-1]["status"], "failed")
+
+    def test_rejects_incomplete_or_outside_window_discovery(self):
+        for phase_log in (
+            "phase=discovery elapsed_us=1 completed=false regions=0\n",
+            "phase=parse elapsed_us=1 completed=true\n",
+            "[drive] measurement-end\nphase=discovery elapsed_us=1 completed=true regions=1\n",
+        ):
+            with self.subTest(phase_log=phase_log), self.assertRaisesRegex(ValueError, "discovery"):
+                self.run_matrix([[("ok", 3)] * 4], phase_log=phase_log)
+
+    def test_accepts_cancellation_when_each_document_eventually_has_tokens(self):
+        self.run_matrix([
+            [("canceled", None), ("null", None), ("ok", 0), ("ok", 3)],
+            [("ok", 3), ("ok", 3), ("ok", 3), ("ok", 3)],
+        ])
+
+    def test_rejects_wildcard_host_opens_without_injections(self):
+        cycle = [("ok", 3)] * 4
+        with self.assertRaisesRegex(ValueError, "bridge"):
+            self.run_matrix([cycle], mode="wildcard",
+                            peer_languages=lambda language: {language: 4})
+
+    def test_rejects_markdown_wildcard_opens_without_lua(self):
+        cycle = [("ok", 3)] * 4
+        with self.assertRaisesRegex(ValueError, "bridge"):
+            self.run_matrix(
+                [cycle], mode="wildcard",
+                peer_languages=lambda language: (
+                    {"rust": 4, "comment": 4} if language == "rust" else
+                    {"markdown": 4, "markdown_inline": 4}
+                ),
+            )
+
+    def test_accepts_wildcard_host_and_injection_opens(self):
+        self.run_matrix(
+            [[("ok", 3)] * 4], mode="wildcard",
+            peer_languages=lambda language: (
+                {"rust": 4, "comment": 4} if language == "rust" else
+                {"markdown": 4, "markdown_inline": 4, "lua": 4}
+            ),
+        )
+
+    def test_rejects_duplicate_sizes_before_inputs_or_output(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "results"
+            arguments = [
+                "measure_discovery.py", "--baseline", "unused-baseline",
+                "--candidate", "unused-candidate", "--inputs", "unused-inputs",
+                "--output", str(output), "--sizes", "small", "small",
+            ]
+            # The sentinel proves parser validation happens before filesystem
+            # inspection. Old code exits with 88 at verify_inputs, not 2.
+            with patch.object(sys, "argv", arguments), \
+                    patch.object(measure_discovery, "verify_inputs", side_effect=SystemExit(88)) as verify, \
+                    patch("sys.stderr"):
+                with self.assertRaises(SystemExit) as caught:
+                    measure_discovery.main()
+            self.assertEqual(caught.exception.code, 2)
+            verify.assert_not_called()
+            self.assertFalse(output.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benches/profile/test_prepare_discovery.py
+++ b/benches/profile/test_prepare_discovery.py
@@ -1,0 +1,41 @@
+import contextlib
+import io
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+try:
+    import tomllib
+except ImportError:
+    tomllib = None
+
+import prepare_discovery
+
+
+@unittest.skipIf(tomllib is None, "TOML parser requires Python 3.11")
+class PrepareUnicodeTest(unittest.TestCase):
+    def test_non_bmp_paths_remain_valid_toml(self):
+        with tempfile.TemporaryDirectory(prefix="discovery-🚀-") as temporary:
+            directory = Path(temporary)
+            runtime = directory / "runtime"
+            (runtime / "parser").mkdir(parents=True)
+            (runtime / "queries").mkdir()
+            output = directory / "inputs"
+            arguments = ["prepare_discovery.py", "--runtime", str(runtime),
+                         "--output", str(output)]
+            with patch.object(sys, "argv", arguments), contextlib.redirect_stdout(io.StringIO()), \
+                    patch.object(prepare_discovery, "rust_fixture", return_value="// comment\n"), \
+                    patch.object(prepare_discovery, "markdown_fixture", return_value="prose\n"):
+                prepare_discovery.main()
+            for mode in ("native", "narrow", "wildcard"):
+                config = tomllib.loads((output / f"{mode}.toml").read_text(encoding="utf-8"))
+                self.assertEqual(config["searchPaths"], [str(runtime.resolve())])
+                if mode != "native":
+                    self.assertEqual(config["languageServers"]["profile"]["cmd"][-1],
+                                     str(output.resolve() / "peer-summaries"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benches/results/.gitignore
+++ b/benches/results/.gitignore
@@ -1,0 +1,4 @@
+# Keep raw measurement archives outside the repository.
+*.tar.gz
+*.tar.xz
+*.zip

--- a/benches/results/discovery-2026-09-08/README.md
+++ b/benches/results/discovery-2026-09-08/README.md
@@ -1,0 +1,135 @@
+# Discovery attribution after the correctness stack
+
+Full-tree discovery remains a material cost for large documents, but these measurements do not justify treating it as the universal first optimization. In the single-document native cases, Rust near 1 MiB spent a median 31.8 ms in discovery and 96.3 ms in host tokenization; Markdown spent 21.1 ms and 25.7 ms respectively. These are separate logged invocation distributions, not additive shares of a request or predicted optimization wins.
+
+For the common ~32 KiB fixtures, native discovery was 0.94 ms for Rust and 0.56 ms for Markdown. Baseline edit-to-response medians were 5.46 ms and 3.49 ms. Large-file work is therefore the useful target for a bounded discovery experiment; small/common-file controls must remain in its gate.
+
+Recommended next work: profile the host-token query cost under [#895](https://github.com/atusy/kakehashi/issues/895), and retain [#1068](https://github.com/atusy/kakehashi/issues/1068) for a separately scoped discovery experiment against a full-query oracle. Require a defined invalidation contract, unknown-query fallback, and zero mismatches before activation. This PR adds measurement only. It introduces no incremental cache, scheduler policy, or language-precedence change. Cold range requests (#935) and immutable query metadata (#936) remain separate hypotheses; this run does not measure either.
+
+## Method and provenance
+
+- Baseline: `73df422f9c2e16f93a411f5ae5b7c1213a19f2b7`, including the unmerged #1072/#1073 correctness fixes above integrated main. Candidate: `5fbaf20b79a272996c500fa9cf9264102c3f2f3e`, the same implementation with opt-in phase timers. This is an instrumentation comparison, not a before/after optimization experiment.
+- Measurement harness: `e80b668ff49a42dd07473d014b3be2d8bd8eca19`. Every host URI carries a distinct `?kakehashi-profile-document=N` query tag, preserved by virtual injection URIs, so the controlled peer can identify the originating host without changing directory roots. Both variants use the same tagged workload.
+- Both binaries: `cargo build --release --bin kakehashi`, rustc 1.97.1, Apple M4 (10 CPUs), 32 GiB RAM. Exact binary hashes, build commands, hardware and runtime provenance are in [provenance.json](provenance.json) and the archived matrix.
+- Real parser/query assets were copied from the existing Neovim runtime. The clean query repository revision was `nvim-treesitter/nvim-treesitter@8b98b4470eb326f1c7b50dae79f8c963568e5720`; every copied asset is hashed. Parser libraries and query source are not committed.
+- Rust sizes: 2,152 / 33,001 / 1,048,613 bytes. Markdown: 2,170 / 33,043 / 1,048,682 bytes. Rust includes ordinary/doc comments and macros; Markdown includes ordinary prose, inline markup and Lua fences. A character is toggled in the first ordinary comment/prose line, with no artificial edit delay.
+- Both languages × 3 sizes × native/Lua-only/wildcard configuration × 1/4 documents = 36 scenarios. Each uses 3 alternating A/B pairs, 5 warmup cycles and 30 measured cycles per run. A separate logged candidate run follows each scenario: 252 runs total. All copies are edited before their concurrent token requests; a four-document cycle ends after all four responses.
+- A/B logs are disabled. Phase timing runs are separate and excluded from A/B latency/resource comparisons. The matrix ran without our builds/tests, but ordinary desktop applications remained active. Three pairs on a workstation are descriptive evidence, not confidence intervals or a proof of zero instrumentation overhead.
+- Bridge peers are controlled sync-only servers. Narrow accepts Lua injections; wildcard accepts the host and all injections. These results measure kakehashi routing/synchronization, not real analyzer CPU or diagnostic latency.
+
+## Validation and limits
+
+All 18,900 measured token responses were `ok`, with an explicit minimum of 120 tokens per response: no cancellation, null, error or empty responses. Both consumers verify the declared cycle/response counts and exact per-document coverage in every run, including the logged attribution runs. This proves nonempty responses, not correspondence to the latest edit or byte-for-byte token correctness.
+
+Expected injected languages were observed for every tagged host URI in every applicable bridge run. Wildcard runs separately require the exact host URI and host language to open downstream. This is session-level coverage, including warmup; it does not establish fresh downstream work on every measured cycle. See [validation.json](validation.json).
+
+The runner retains mixed outcomes as completed observations when each document eventually produces nonempty work. That is separate from report eligibility: both report consumers require explicit positive token counts and successful responses throughout, plus per-host bridge evidence. There are no legacy byte-size or manifest exceptions in these consumers.
+
+Three existing query warnings occurred in every run: unsupported capture-valued `#set!` patterns in `markdown_inline/highlights.scm`, lines 48–50, 52–54 and 99–101. They concern links/images/autolinks; these fixtures contain none. The unmodified warnings and full stderr are retained, rather than deleting query patterns to obtain a silent run. No error-level server messages occurred.
+
+This attribution does not satisfy the broader behavioral optimization gate in #895: it does not validate every token against a unique-edit oracle, exercise cancellation/bursts/reloads, or cover sparse/Unicode/mixed-priority workloads. Parser/query revisions and dense repeated fixtures limit generalization. Cross-configuration timing differences are observations, not evidence that adding a bridge speeds up parsing.
+
+## Edit-to-response latency
+
+Milliseconds; medians/p90 pool 90 cycles per variant. Paired deltas compare each repetition's candidate cycle median to its baseline median, then report the median and full range of those three deltas. Negative means candidate faster. Four-document values are batch latency, not per-document latency. Raw per-request distributions and status counts remain in [summary.json](summary.json).
+
+| Language | Size | Mode | Docs | Baseline median / p90 | Candidate median / p90 | Paired delta median [min, max] |
+| --- | --- | --- | ---: | ---: | ---: | ---: |
+| rust | small | native | 1 | 1.07 / 1.49 | 1.02 / 1.47 | +0.6% [-26.6, +5.2] |
+| rust | small | native | 4 | 1.44 / 2.19 | 1.45 / 2.23 | +0.6% [+0.5, +1.8] |
+| rust | small | narrow | 1 | 1.02 / 1.43 | 1.11 / 1.48 | +8.0% [-3.5, +37.2] |
+| rust | small | narrow | 4 | 1.47 / 2.20 | 1.44 / 2.23 | -3.2% [-4.9, -0.9] |
+| rust | small | wildcard | 1 | 1.12 / 1.49 | 1.12 / 1.53 | +0.7% [-0.9, +3.8] |
+| rust | small | wildcard | 4 | 1.43 / 2.21 | 1.49 / 2.38 | +4.0% [+0.1, +7.1] |
+| rust | common | native | 1 | 5.46 / 5.87 | 5.51 / 6.15 | +1.4% [+0.9, +4.0] |
+| rust | common | native | 4 | 12.01 / 13.05 | 12.15 / 12.94 | +0.6% [-0.5, +2.4] |
+| rust | common | narrow | 1 | 5.52 / 5.92 | 5.53 / 5.99 | -0.9% [-1.6, +1.1] |
+| rust | common | narrow | 4 | 11.01 / 11.65 | 11.10 / 11.83 | +1.0% [+0.2, +1.4] |
+| rust | common | wildcard | 1 | 5.58 / 6.00 | 5.59 / 5.92 | +0.6% [-0.5, +0.9] |
+| rust | common | wildcard | 4 | 10.90 / 11.70 | 10.79 / 11.58 | -1.2% [-2.8, +0.8] |
+| rust | large | native | 1 | 189.17 / 191.46 | 189.59 / 191.93 | +0.3% [-0.1, +0.5] |
+| rust | large | native | 4 | 418.57 / 432.85 | 416.22 / 434.09 | -1.1% [-2.9, +2.6] |
+| rust | large | narrow | 1 | 188.52 / 191.32 | 187.32 / 189.47 | -0.7% [-1.0, -0.2] |
+| rust | large | narrow | 4 | 383.56 / 393.95 | 382.13 / 392.11 | -0.5% [-0.9, +0.4] |
+| rust | large | wildcard | 1 | 191.90 / 196.52 | 188.31 / 192.98 | -2.1% [-2.8, -1.0] |
+| rust | large | wildcard | 4 | 392.67 / 432.17 | 396.86 / 418.30 | -1.2% [-3.7, +0.7] |
+| markdown | small | native | 1 | 0.80 / 0.98 | 0.80 / 1.01 | +0.2% [-5.3, +0.6] |
+| markdown | small | native | 4 | 1.05 / 1.34 | 1.08 / 1.44 | +2.6% [-3.1, +9.4] |
+| markdown | small | narrow | 1 | 0.72 / 0.88 | 0.71 / 0.89 | -5.2% [-7.9, +9.4] |
+| markdown | small | narrow | 4 | 1.10 / 1.47 | 1.03 / 1.31 | -1.6% [-25.6, +8.2] |
+| markdown | small | wildcard | 1 | 0.74 / 0.95 | 0.72 / 0.92 | -2.1% [-4.6, -0.4] |
+| markdown | small | wildcard | 4 | 1.31 / 1.69 | 1.23 / 1.72 | -3.9% [-8.3, -1.1] |
+| markdown | common | native | 1 | 3.49 / 4.35 | 3.50 / 4.39 | -0.2% [-0.2, +0.4] |
+| markdown | common | native | 4 | 5.77 / 6.39 | 5.68 / 6.22 | -3.4% [-4.5, +4.0] |
+| markdown | common | narrow | 1 | 2.69 / 3.68 | 2.72 / 3.62 | +0.7% [-0.7, +3.5] |
+| markdown | common | narrow | 4 | 6.11 / 6.60 | 6.20 / 6.62 | +1.2% [-1.3, +3.4] |
+| markdown | common | wildcard | 1 | 2.75 / 3.80 | 2.74 / 3.86 | -0.1% [-1.2, +1.9] |
+| markdown | common | wildcard | 4 | 7.24 / 8.00 | 7.18 / 8.02 | -0.9% [-1.6, +1.4] |
+| markdown | large | native | 1 | 125.39 / 133.74 | 127.84 / 136.42 | +2.0% [+1.3, +3.7] |
+| markdown | large | native | 4 | 233.24 / 253.91 | 228.52 / 249.98 | -2.0% [-2.3, -0.9] |
+| markdown | large | narrow | 1 | 95.35 / 103.16 | 96.16 / 103.77 | +0.6% [+0.4, +1.1] |
+| markdown | large | narrow | 4 | 232.11 / 245.82 | 228.73 / 239.45 | -1.5% [-1.7, -0.5] |
+| markdown | large | wildcard | 1 | 98.08 / 109.07 | 97.98 / 106.54 | -1.1% [-1.2, +2.9] |
+| markdown | large | wildcard | 4 | 282.95 / 679.18 | 263.71 / 593.78 | -2.1% [-3.6, +6.8] |
+
+Small absolute differences can have large percentage changes. The candidate is faster in some pairs/scenarios and slower in others; no general speedup or exact-zero-overhead claim follows from this comparison. The full paired range remains visible for each scenario rather than being averaged across workloads.
+
+## Phase attribution
+
+Candidate logged invocation medians in milliseconds. Representative native cases plus large wildcard cases are shown; all 36 phase distributions, counts and incomplete outcomes are in `summary.json` and raw `.phases.json` files. A dash means the phase was not observed, not zero cost.
+
+| Language | Size | Mode | Docs | Parse | Discovery | Resolution | Snapshot wait | Host tokens | Injection tokens | Finalize |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| rust | small | native | 1 | 0.01 | 0.16 | — | 0.24 | 0.45 | 0.19 | 0.09 |
+| rust | common | native | 1 | 0.04 | 0.94 | — | 1.06 | 2.76 | 0.92 | 0.60 |
+| rust | large | native | 1 | 2.25 | 31.84 | — | 35.90 | 96.27 | 22.24 | 24.64 |
+| rust | large | native | 4 | 3.36 | 37.63 | — | 43.87 | 185.41 | 150.56 | 33.64 |
+| rust | large | wildcard | 1 | 2.24 | 31.84 | 0.80 | 36.20 | 94.16 | 22.24 | 24.52 |
+| rust | large | wildcard | 4 | 3.67 | 40.75 | 1.55 | 48.63 | 189.74 | 140.93 | 41.00 |
+| markdown | small | native | 1 | 0.02 | 0.10 | — | 0.23 | 0.13 | 0.07 | 0.05 |
+| markdown | common | native | 1 | 0.21 | 0.56 | — | 1.43 | 0.72 | 0.18 | 0.29 |
+| markdown | large | native | 1 | 9.05 | 21.06 | — | 56.67 | 25.74 | 4.83 | 12.18 |
+| markdown | large | native | 4 | 16.76 | 29.84 | — | 62.93 | 46.94 | 22.69 | 18.97 |
+| markdown | large | wildcard | 1 | 7.86 | 21.97 | 7.03 | 41.34 | 25.49 | 4.76 | 11.67 |
+| markdown | large | wildcard | 4 | 19.60 | 39.30 | 16.36 | 83.78 | 52.96 | 19.85 | 22.72 |
+
+`parse` includes incremental-seed replay inside the parser closure; `parse_await` additionally includes pool/checkout/resumption. Discovery covers the root injection query traversal, and resolution covers the measured resolver call when bridge regions are built. Snapshot waits overlap parse/population; host and injection tokenization can overlap. Region bookkeeping outside the timed calls, serialization, queues and protocol work also cost time. Never sum these medians to reconstruct end-to-end latency or subtract them to invent an unmeasured phase.
+
+The four-document runs demonstrate larger batch latency and phase durations under contention. They do not isolate fairness or identify a particular lock/queue as the cause; that needs a dedicated workload and queue instrumentation.
+
+## CPU and memory
+
+Baseline large-file runs below: median child user+system CPU seconds per complete session, and maximum OS-reported child `ru_maxrss` across the three runs, converted to MiB. These include initialization, warmup, measured work and shutdown; CPU is not the phase wall time above. RSS is an OS child-resource statistic, not allocations per edit or the sum of simultaneously live processes. Candidate and small/common results are retained in `summary.json`.
+
+| Language | Mode | Docs | Session CPU seconds | Maximum child RSS MiB |
+| --- | --- | ---: | ---: | ---: |
+| rust | native | 1 | 14.59 | 1161.0 |
+| rust | native | 4 | 79.63 | 1052.8 |
+| rust | narrow | 1 | 12.09 | 1161.2 |
+| rust | narrow | 4 | 62.28 | 1349.2 |
+| rust | wildcard | 1 | 12.99 | 1182.7 |
+| rust | wildcard | 4 | 69.95 | 1326.3 |
+| markdown | native | 1 | 7.47 | 256.2 |
+| markdown | native | 4 | 48.89 | 1133.7 |
+| markdown | narrow | 1 | 6.48 | 561.9 |
+| markdown | narrow | 4 | 36.10 | 1286.7 |
+| markdown | wildcard | 1 | 7.18 | 567.2 |
+| markdown | wildcard | 4 | 43.88 | 1083.2 |
+
+## External evidence and reproduction
+
+The raw measurement archive is retained outside the repository and is not distributed with this checkout. `provenance.json` records its filename, SHA-256, size and member count. It contains all per-run JSON/stderr/phase samples, `matrix.json`, generated fixtures/configs and the exact measured harness. The invocation exited successfully and persisted overall completion after final input and harness verification; both consumers require that status and the complete unique scenario inventory.
+
+This authoritative rerun supersedes the initial measurement identified in `provenance.json`. That initial run retained aggregate bridge-language counts, which could not prove coverage for every host. The new run uses the same exact binaries and parser/query assets, with explicit token counts and tagged peer URI evidence. Its measurements replace all tables here; differences between the two runs are not an optimization comparison.
+
+The summary, validation audit and provenance remain in the repository. Regenerating them requires a separately supplied raw archive matching the SHA-256 in `provenance.json`; there is no public download URL recorded here. Once that archive is available:
+
+```sh
+discovery_archive=/path/to/raw-results.tar.gz
+mkdir /tmp/discovery-retained
+tar -xzf "$discovery_archive" -C /tmp/discovery-retained
+python3 benches/results/discovery-2026-09-08/summarize.py /tmp/discovery-retained/results /tmp/summary.json
+python3 benches/results/discovery-2026-09-08/validate_retained.py /tmp/discovery-retained/results /tmp/validation.json
+```
+
+Regression tests use small self-contained fixtures and do not require the external archive. To collect a new matrix, follow [the harness instructions](../../profile/README.md#discovery-attribution-fixtures) with rebuilt exact binaries and a runtime whose asset hashes match the manifest. Regenerate configuration paths and retain the resulting new hashes. Keep raw outputs outside the repository. A new run is new evidence; it does not reproduce the historical timings exactly.

--- a/benches/results/discovery-2026-09-08/matrix_contract.py
+++ b/benches/results/discovery-2026-09-08/matrix_contract.py
@@ -1,0 +1,129 @@
+"""Validate the complete scenario inventory before consuming retained records."""
+import itertools
+import json
+from pathlib import PurePosixPath
+from collections import Counter
+from urllib.parse import parse_qs, urlsplit
+
+
+def require_identity(matrix, run, result):
+    """Bind portable result records to their declared fixture and invocation."""
+    arguments = matrix["arguments"]
+    command = run["command"]
+    # The runner resolves paths for the invocation, while matrix CLI arguments
+    # may remain relative. Do not resolve archived paths against today's cwd.
+    fixture_path = PurePosixPath(command[command.index("--file") + 1])
+    output_path = PurePosixPath(command[command.index("--json-output") + 1])
+    inputs = fixture_path.parent
+    extension = "rs" if run["language"] == "rust" else "md"
+    fixture = f"{run['language']}-{run['size']}.{extension}"
+    fixture_hashes = {item["path"]: item["sha256"] for item in matrix["inputs"]["fixtures"]}
+    binary = matrix["binaries"][run["variant"]]
+    expected = {
+        "bin": binary["path"], "file": str(inputs / fixture),
+        "server_arg": ["--config-file", str(inputs / (run["mode"] + ".toml"))],
+        "data_dir": matrix["inputs"]["runtime"],
+        "requests": arguments["requests"], "warmup": arguments["warmup"],
+        "documents": run["documents"], "edits": 1, "edit_delay_ms": 0,
+        "tag_document_uris": True,
+        "json_output": str(output_path),
+    }
+    if (fixture_path.name != fixture or output_path.name != run["name"] + ".json"
+            or result.get("binary_sha256") != binary["sha256"]
+            or result.get("fixture_sha256") != fixture_hashes[fixture]
+            or any(result.get("arguments", {}).get(key) != value for key, value in expected.items())):
+        raise ValueError(f"Result identity does not match declared measurement: {run['name']}")
+
+
+def require_comparable(run_name, result):
+    samples = result["request_samples"]["textDocument/semanticTokens/full"]
+    if not samples or any(sample["status"] != "ok" or (sample.get("token_count") or 0) <= 0
+                          for sample in samples):
+        raise ValueError(f"Cannot compare {run_name}: every response must be successful and nonempty")
+
+
+def bridge_coverage(run, result):
+    """Check session-level opens, including warmup, independently for each host."""
+    language, mode = run["language"], run["mode"]
+    expected = set()
+    if mode == "wildcard":
+        expected = {"comment"} if language == "rust" else {"markdown_inline", "lua"}
+    elif mode == "narrow" and language == "markdown":
+        expected = {"lua"}
+    if not expected:
+        return {}
+
+    def document_tag(uri):
+        values = parse_qs(urlsplit(uri).query, keep_blank_values=True).get("kakehashi-profile-document", [])
+        return values[0] if len(values) == 1 and values[0] else None
+
+    host_uris = result["document_uris"]
+    tags = [document_tag(uri) for uri in host_uris]
+    if None in tags or len(set(tags)) != len(host_uris):
+        raise ValueError("bridge evidence requires distinct host document tags")
+    opened = {(document["uri"], document["language"])
+              for peer in run["peers"] for document in peer.get("opened_documents", [])}
+    coverage = {}
+    for host_uri, tag in zip(host_uris, tags):
+        host_open = (host_uri, language) in opened
+        if mode == "wildcard" and not host_open:
+            raise ValueError(f"intended bridge host open missing for {host_uri}")
+        injected = {opened_language for uri, opened_language in opened
+                    if uri != host_uri and document_tag(uri) == tag
+                    and urlsplit(uri).path.rsplit("/", 1)[-1].startswith("kakehashi-virtual-uri-")}
+        if expected - injected:
+            raise ValueError(f"intended bridge injections missing for {host_uri}: {sorted(expected - injected)}")
+        coverage[host_uri] = {"host_open": host_open, "expected_injected_languages": sorted(expected),
+                              "injected_languages": sorted(injected)}
+    return coverage
+
+
+def require_workload(run, result, requests):
+    documents = run["documents"]
+    prefix = f"Incomplete workload for {run['name']}: "
+    if requests < 1 or documents < 1:
+        raise ValueError(prefix + "invalid declared workload")
+    if len(result["cycle_seconds"]) != requests:
+        raise ValueError(prefix + "cycle count does not match declared requests")
+    samples = result["request_samples"]["textDocument/semanticTokens/full"]
+    if len(samples) != requests * documents:
+        raise ValueError(prefix + "response count does not match requests times documents")
+    uris = result["document_uris"]
+    if len(uris) != documents or len(set(uris)) != documents:
+        raise ValueError(prefix + "document inventory has duplicate or missing URIs")
+    if Counter(sample["uri"] for sample in samples) != Counter({uri: requests for uri in uris}):
+        raise ValueError(prefix + "per-document response count does not match declared requests")
+
+
+def load_matrix(path):
+    matrix = json.loads(path.read_text())
+    if matrix.get("status") != "complete":
+        raise ValueError("Matrix has no successful final verification")
+    arguments = matrix["arguments"]
+    for name in ("sizes", "modes", "documents"):
+        values = arguments[name]
+        if not values or len(values) != len(set(values)):
+            raise ValueError(f"Invalid scenario dimension: {name}")
+    if arguments["repeats"] < 1:
+        raise ValueError("Invalid scenario repetition count")
+    expected = set()
+    for dimensions in itertools.product(("rust", "markdown"), arguments["sizes"],
+                                        arguments["modes"], arguments["documents"]):
+        for repetition in range(arguments["repeats"]):
+            for variant in ("baseline", "candidate"):
+                expected.add((*dimensions, variant, repetition, False))
+        expected.add((*dimensions, "candidate", 0, True))
+    fields = ("language", "size", "mode", "documents", "variant", "repetition", "profile")
+    keys = [tuple(run[field] for field in fields) for run in matrix["runs"]]
+    if len(keys) != len(expected) or len(set(keys)) != len(keys) or set(keys) != expected:
+        raise ValueError("Duplicate, missing, or unexpected scenario records")
+    for run, key in zip(matrix["runs"], keys):
+        language, size, mode, documents, variant, repetition, profile = key
+        name = f"{language}-{size}-{mode}-d{documents}-{variant}-{repetition}"
+        if profile:
+            name += "-profile"
+        if run["name"] != name:
+            raise ValueError("Scenario artifact name does not match its identity")
+        if run["status"] != "complete":
+            raise ValueError("Refusing to consume an incomplete scenario")
+    return matrix

--- a/benches/results/discovery-2026-09-08/provenance.json
+++ b/benches/results/discovery-2026-09-08/provenance.json
@@ -1,0 +1,50 @@
+{
+  "builds": {
+    "baseline": {
+      "source": "73df422f9c2e16f93a411f5ae5b7c1213a19f2b7",
+      "binary": "/tmp/kakehashi-1068-final-baseline-73df422f9",
+      "sha256": "41dbac8e16b5eac9ae442f9f3ce507b1cc43b4d6f3c676ebe26f0689bae74d02",
+      "build": "cargo build --release --bin kakehashi"
+    },
+    "candidate": {
+      "source": "5fbaf20b79a272996c500fa9cf9264102c3f2f3e",
+      "binary": "/tmp/kakehashi-1068-final-candidate-5fbaf20b7",
+      "sha256": "b5249af6fdd383bbad06e7ea7719c0fd057a178f127c64ba12e15696227f5e23",
+      "build": "cargo build --release --bin kakehashi"
+    },
+    "rustc": "rustc 1.97.1 (8bab26f4f 2026-07-14) (built from a source tarball)"
+  },
+  "hardware": {
+    "hw.model": "Mac16,12",
+    "hw.memsize": "34359738368",
+    "hw.ncpu": "10",
+    "machdep.cpu.brand_string": "Apple M4"
+  },
+  "platform": "macOS-26.5.1-arm64-arm-64bit",
+  "query_repository": "https://github.com/nvim-treesitter/nvim-treesitter",
+  "query_commit": "8b98b4470eb326f1c7b50dae79f8c963568e5720",
+  "measurement_harness_commit": "e80b668ff49a42dd07473d014b3be2d8bd8eca19",
+  "notes": [
+    "Exact optimized binaries copied before later source changes.",
+    "Parser and real query assets copied from existing Neovim runtime; only hashes are retained, no parser libraries or query source files committed.",
+    "No own Cargo builds or tests overlapped the authoritative matrix. Ordinary desktop processes remained running; alternating pairs describe workstation noise, not isolated-machine confidence intervals.",
+    "A/B logging disabled; candidate phase logs collected separately."
+  ],
+  "archive": {
+    "filename": "raw-results.tar.gz",
+    "storage": "External local retention; not distributed with this repository and no public download URL is recorded.",
+    "sha256": "5b23b353692ad358e9a71aabb3d4cdf30bea49e00d8fc4b39d97db99ba433e5e",
+    "bytes": 7706200,
+    "files": 556
+  },
+  "matrix_execution": {
+    "exit_code": 0,
+    "manifest_sha256": "5f92ec149aabc10d07a6e83b22e72ad30c728e1c366c91d3db67dc74beac6186",
+    "status": "complete"
+  },
+  "supersedes": {
+    "report_commit": "0f56eb7c977625a437f2bfddacd847eb8635fa7c",
+    "archive_sha256": "e7d84e2dd5a76d3dabde3ed62dc3de35dccf26ffbdda9d53ed2d7e7c1c4bf18d",
+    "reason": "Rerun with explicit token counts and per-host bridge URI evidence; initial results remain at the immutable report commit."
+  }
+}

--- a/benches/results/discovery-2026-09-08/summarize.py
+++ b/benches/results/discovery-2026-09-08/summarize.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Summarize the retained matrix without adding overlapping phase durations."""
+import argparse
+from collections import Counter, defaultdict
+import json
+import math
+from pathlib import Path
+import statistics
+
+from matrix_contract import bridge_coverage, load_matrix, require_identity, require_comparable, require_workload
+
+
+def distribution(values):
+    values = sorted(values)
+    if not values:
+        return None
+    return {
+        "n": len(values),
+        "median": statistics.median(values),
+        "p90": values[max(0, math.ceil(0.9 * len(values)) - 1)],
+        "max": values[-1],
+    }
+
+
+def summarize(root):
+    matrix = load_matrix(root / "matrix.json")
+    groups = defaultdict(list)
+    results = {}
+    dimensions = ("language", "size", "mode", "documents")
+    for run in matrix["runs"]:
+        result = json.loads((root / (run["name"] + ".json")).read_text())
+        require_identity(matrix, run, result)
+        require_workload(run, result, matrix["arguments"]["requests"])
+        require_comparable(run["name"], result)
+        bridge_coverage(run, result)
+        results[run["name"]] = result
+        groups[tuple(run[key] for key in dimensions)].append(run)
+    summary = []
+    for key, runs in groups.items():
+        row = dict(zip(dimensions, key))
+        pairs = defaultdict(dict)
+        for variant in ("baseline", "candidate"):
+            selected = [run for run in runs if run["variant"] == variant and not run["profile"]]
+            data = [results[run["name"]] for run in selected]
+            cycles = [seconds * 1000 for result in data for seconds in result["cycle_seconds"]]
+            responses = [sample for result in data
+                         for sample in result["request_samples"]["textDocument/semanticTokens/full"]]
+            row[variant] = {
+                "cycles_ms": distribution(cycles),
+                "requests_ms": distribution([sample["seconds"] * 1000 for sample in responses]),
+                "statuses": dict(Counter(sample["status"] for sample in responses)),
+                "session_cpu_seconds": distribution([
+                    result["children_user_seconds"] + result["children_system_seconds"] for result in data
+                ]),
+                "maxrss_mib": distribution([result["children_maxrss_bytes"] / 1024**2 for result in data]),
+            }
+            for run, result in zip(selected, data):
+                pairs[run["repetition"]][variant] = statistics.median(result["cycle_seconds"]) * 1000
+        row["pairs"] = [
+            {"repetition": repetition, **pair,
+             "delta_percent": (pair["candidate"] / pair["baseline"] - 1) * 100}
+            for repetition, pair in pairs.items() if len(pair) == 2
+        ]
+        row["phases_us"] = {}
+        for run in runs:
+            if run["profile"]:
+                phases = json.loads((root / (run["name"] + ".phases.json")).read_text())
+                phase_groups = defaultdict(list)
+                for sample in phases:
+                    phase_groups[sample["phase"]].append(sample)
+                row["phases_us"] = {
+                    phase: {
+                        **distribution([sample["elapsed_us"] for sample in samples]),
+                        "incomplete": sum("completed=false" in sample["details"] for sample in samples),
+                    }
+                    for phase, samples in phase_groups.items()
+                }
+        summary.append(row)
+    return summary
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("results", type=Path)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+    args.output.write_text(json.dumps(summarize(args.results), indent=2) + "\n", encoding="utf-8")

--- a/benches/results/discovery-2026-09-08/summary.json
+++ b/benches/results/discovery-2026-09-08/summary.json
@@ -1,0 +1,5282 @@
+[
+  {
+    "language": "rust",
+    "size": "small",
+    "mode": "native",
+    "documents": 1,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 1.0716664983192459,
+        "p90": 1.4921659894753247,
+        "max": 1.726541988318786
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 1.0447704989928752,
+        "p90": 1.433375000488013,
+        "max": 1.676165993558243
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.18201299999999998,
+        "p90": 0.18580599999999997,
+        "max": 0.18580599999999997
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 27.546875,
+        "p90": 27.65625,
+        "max": 27.65625
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 1.0234375222353265,
+        "p90": 1.4714589924551547,
+        "max": 1.9475840090308338
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 0.9981250041164458,
+        "p90": 1.415292004821822,
+        "max": 1.8717919883783907
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.18578699999999998,
+        "p90": 0.185997,
+        "max": 0.185997
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 27.53125,
+        "p90": 27.703125,
+        "max": 27.703125
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 1.0736664989963174,
+        "candidate": 1.1299170146230608,
+        "delta_percent": 5.239105036743474
+      },
+      {
+        "repetition": 1,
+        "baseline": 1.0684165026759729,
+        "candidate": 0.7840830076020211,
+        "delta_percent": -26.612607944729948
+      },
+      {
+        "repetition": 2,
+        "baseline": 1.0844169883057475,
+        "candidate": 1.0912709985859692,
+        "delta_percent": 0.6320456387288953
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 30,
+        "median": 11.0,
+        "p90": 19,
+        "max": 37,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 30,
+        "median": 42.5,
+        "p90": 72,
+        "max": 89,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 30,
+        "median": 158.0,
+        "p90": 215,
+        "max": 247,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 30,
+        "median": 243.0,
+        "p90": 337,
+        "max": 387,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 30,
+        "median": 549.0,
+        "p90": 732,
+        "max": 841,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 30,
+        "median": 448.5,
+        "p90": 598,
+        "max": 702,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 30,
+        "median": 192.0,
+        "p90": 222,
+        "max": 298,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 30,
+        "median": 90.0,
+        "p90": 123,
+        "max": 156,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "rust",
+    "size": "small",
+    "mode": "native",
+    "documents": 4,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 1.4415420009754598,
+        "p90": 2.1913749806117266,
+        "max": 2.702041994780302
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 1.2626040115719661,
+        "p90": 1.9244170107413083,
+        "max": 2.599500003270805
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.400794,
+        "p90": 0.40790099999999996,
+        "max": 0.40790099999999996
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 30.484375,
+        "p90": 30.90625,
+        "max": 30.90625
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 1.4521249977406114,
+        "p90": 2.2299159900285304,
+        "max": 3.3143750042654574
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 1.3000205071875826,
+        "p90": 1.906499994220212,
+        "max": 3.2174999942071736
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.4123629999999999,
+        "p90": 0.417525,
+        "max": 0.417525
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 30.9375,
+        "p90": 31.28125,
+        "max": 31.28125
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 1.4464795094681904,
+        "candidate": 1.454749988624826,
+        "delta_percent": 0.5717660777425415
+      },
+      {
+        "repetition": 1,
+        "baseline": 1.4063959970371798,
+        "candidate": 1.413812511600554,
+        "delta_percent": 0.5273418424823761
+      },
+      {
+        "repetition": 2,
+        "baseline": 1.4456459903158247,
+        "candidate": 1.4711459953105077,
+        "delta_percent": 1.7639176648712063
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 120,
+        "median": 9.0,
+        "p90": 18,
+        "max": 41,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 120,
+        "median": 70.0,
+        "p90": 134,
+        "max": 301,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 120,
+        "median": 139.0,
+        "p90": 202,
+        "max": 305,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 120,
+        "median": 236.0,
+        "p90": 394,
+        "max": 4710,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 120,
+        "median": 695.5,
+        "p90": 1079,
+        "max": 4861,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 120,
+        "median": 484.0,
+        "p90": 640,
+        "max": 1008,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 120,
+        "median": 456.5,
+        "p90": 906,
+        "max": 4697,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 120,
+        "median": 80.0,
+        "p90": 123,
+        "max": 197,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "rust",
+    "size": "small",
+    "mode": "narrow",
+    "documents": 1,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 1.018958500935696,
+        "p90": 1.4252919936552644,
+        "max": 1.7530000186525285
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 0.9928334911819547,
+        "p90": 1.3870839902665466,
+        "max": 1.6945830138865858
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.16541199999999998,
+        "p90": 0.16650399999999999,
+        "max": 0.16650399999999999
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 27.609375,
+        "p90": 27.65625,
+        "max": 27.65625
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 1.1129585036542267,
+        "p90": 1.47683298564516,
+        "max": 1.7994590161833912
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 1.0879999899771065,
+        "p90": 1.4356249885167927,
+        "max": 1.7429999716114253
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.168533,
+        "p90": 0.169763,
+        "max": 0.169763
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 27.625,
+        "p90": 27.65625,
+        "max": 27.65625
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 0.8036040089791641,
+        "candidate": 1.1022499966202304,
+        "delta_percent": 37.16332724875813
+      },
+      {
+        "repetition": 1,
+        "baseline": 1.0573125036899,
+        "candidate": 1.1422289971960708,
+        "delta_percent": 8.031352434575577
+      },
+      {
+        "repetition": 2,
+        "baseline": 1.1092915083281696,
+        "candidate": 1.0704170126700774,
+        "delta_percent": -3.5044436350802455
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 30,
+        "median": 9.0,
+        "p90": 26,
+        "max": 35,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 30,
+        "median": 36.0,
+        "p90": 83,
+        "max": 192,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 30,
+        "median": 137.5,
+        "p90": 243,
+        "max": 358,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 30,
+        "median": 4.5,
+        "p90": 11,
+        "max": 13,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 30,
+        "median": 219.5,
+        "p90": 401,
+        "max": 556,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 30,
+        "median": 445.0,
+        "p90": 809,
+        "max": 1016,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 30,
+        "median": 373.0,
+        "p90": 669,
+        "max": 823,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 30,
+        "median": 194.5,
+        "p90": 252,
+        "max": 360,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 30,
+        "median": 65.5,
+        "p90": 127,
+        "max": 181,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "rust",
+    "size": "small",
+    "mode": "narrow",
+    "documents": 4,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 1.4667505020042881,
+        "p90": 2.201499999500811,
+        "max": 2.924707980128005
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 1.260041506611742,
+        "p90": 1.9073750008828938,
+        "max": 2.8320419951342046
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.367581,
+        "p90": 0.367788,
+        "max": 0.367788
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 30.359375,
+        "p90": 30.390625,
+        "max": 30.390625
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 1.4439579972531646,
+        "p90": 2.2345000179484487,
+        "max": 2.913499978603795
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 1.2485414918046445,
+        "p90": 1.9401249883230776,
+        "max": 2.796375018078834
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.359393,
+        "p90": 0.368365,
+        "max": 0.368365
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 30.390625,
+        "p90": 30.8125,
+        "max": 30.8125
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 1.4666250062873587,
+        "candidate": 1.4533119974657893,
+        "delta_percent": -0.9077309308444304
+      },
+      {
+        "repetition": 1,
+        "baseline": 1.4476670185104012,
+        "candidate": 1.3764374889433384,
+        "delta_percent": -4.920297876258561
+      },
+      {
+        "repetition": 2,
+        "baseline": 1.5189580008154735,
+        "candidate": 1.470437491661869,
+        "delta_percent": -3.194328554677328
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 120,
+        "median": 8.0,
+        "p90": 22,
+        "max": 54,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 120,
+        "median": 68.5,
+        "p90": 144,
+        "max": 300,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 120,
+        "median": 129.5,
+        "p90": 242,
+        "max": 328,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 120,
+        "median": 5.0,
+        "p90": 11,
+        "max": 27,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 120,
+        "median": 236.5,
+        "p90": 398,
+        "max": 714,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 120,
+        "median": 662.0,
+        "p90": 1059,
+        "max": 1732,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 120,
+        "median": 442.5,
+        "p90": 634,
+        "max": 986,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 120,
+        "median": 452.5,
+        "p90": 960,
+        "max": 1602,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 120,
+        "median": 69.5,
+        "p90": 114,
+        "max": 175,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "rust",
+    "size": "small",
+    "mode": "wildcard",
+    "documents": 1,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 1.1167500051669776,
+        "p90": 1.4890420134179294,
+        "max": 1.7027499852702022
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 1.0812084947247058,
+        "p90": 1.45220902049914,
+        "max": 1.6534999886061996
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.19829,
+        "p90": 0.19833199999999998,
+        "max": 0.19833199999999998
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 29.59375,
+        "p90": 29.734375,
+        "max": 29.734375
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 1.1195205006515607,
+        "p90": 1.52824999531731,
+        "max": 1.821458019549027
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 1.0844374919543043,
+        "p90": 1.4848329883534461,
+        "max": 1.778334000846371
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.19718999999999998,
+        "p90": 0.19852,
+        "max": 0.19852
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 29.625,
+        "p90": 29.796875,
+        "max": 29.796875
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 1.0906664974754676,
+        "candidate": 1.0984164982801303,
+        "delta_percent": 0.7105747561331865
+      },
+      {
+        "repetition": 1,
+        "baseline": 1.0877710010390729,
+        "candidate": 1.1288959940429777,
+        "delta_percent": 3.7806664237804544
+      },
+      {
+        "repetition": 2,
+        "baseline": 1.1465829884400591,
+        "candidate": 1.135770493419841,
+        "delta_percent": -0.9430189641073228
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 30,
+        "median": 13.5,
+        "p90": 18,
+        "max": 49,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 30,
+        "median": 48.0,
+        "p90": 78,
+        "max": 111,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 30,
+        "median": 159.5,
+        "p90": 223,
+        "max": 257,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 30,
+        "median": 6.0,
+        "p90": 9,
+        "max": 12,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 30,
+        "median": 273.5,
+        "p90": 369,
+        "max": 393,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 30,
+        "median": 565.5,
+        "p90": 765,
+        "max": 871,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 30,
+        "median": 452.5,
+        "p90": 608,
+        "max": 699,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 30,
+        "median": 189.5,
+        "p90": 216,
+        "max": 264,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 30,
+        "median": 93.0,
+        "p90": 129,
+        "max": 158,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "rust",
+    "size": "small",
+    "mode": "wildcard",
+    "documents": 4,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 1.43470850889571,
+        "p90": 2.207666024332866,
+        "max": 2.7952090022154152
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 1.2646874965867028,
+        "p90": 1.9453330023679882,
+        "max": 2.686332998564467
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.413856,
+        "p90": 0.417744,
+        "max": 0.417744
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 33.140625,
+        "p90": 33.203125,
+        "max": 33.203125
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 1.4881454990245402,
+        "p90": 2.381291997153312,
+        "max": 2.769415994407609
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 1.3015000004088506,
+        "p90": 2.028334012720734,
+        "max": 2.6812080177478492
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.41132,
+        "p90": 0.43422399999999994,
+        "max": 0.43422399999999994
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 33.40625,
+        "p90": 33.5,
+        "max": 33.5
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 1.4164379972498864,
+        "candidate": 1.5175829903455451,
+        "delta_percent": 7.140799194319758
+      },
+      {
+        "repetition": 1,
+        "baseline": 1.4321459893835708,
+        "candidate": 1.4891875034663826,
+        "delta_percent": 3.982939903170335
+      },
+      {
+        "repetition": 2,
+        "baseline": 1.4608749916078523,
+        "candidate": 1.4620829897467047,
+        "delta_percent": 0.08269004163887761
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 120,
+        "median": 9.0,
+        "p90": 19,
+        "max": 74,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 120,
+        "median": 57.0,
+        "p90": 121,
+        "max": 282,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 120,
+        "median": 139.0,
+        "p90": 212,
+        "max": 286,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 120,
+        "median": 225.0,
+        "p90": 406,
+        "max": 714,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 120,
+        "median": 5.0,
+        "p90": 11,
+        "max": 22,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 120,
+        "median": 683.0,
+        "p90": 1032,
+        "max": 1520,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 120,
+        "median": 462.0,
+        "p90": 621,
+        "max": 871,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 120,
+        "median": 508.0,
+        "p90": 901,
+        "max": 1400,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 120,
+        "median": 74.5,
+        "p90": 116,
+        "max": 224,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "rust",
+    "size": "common",
+    "mode": "native",
+    "documents": 1,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 5.462417000671849,
+        "p90": 5.867542000487447,
+        "max": 7.542041013948619
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 5.4428334988188,
+        "p90": 5.843624996487051,
+        "max": 7.51137497718446
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.6121219999999999,
+        "p90": 0.624573,
+        "max": 0.624573
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 33.265625,
+        "p90": 33.296875,
+        "max": 33.296875
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 5.5145834921859205,
+        "p90": 6.154250004328787,
+        "max": 7.2608749906066805
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 5.494437005836517,
+        "p90": 6.124125007772818,
+        "max": 7.22408399451524
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.6168699999999999,
+        "p90": 0.63239,
+        "max": 0.63239
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 33.453125,
+        "p90": 33.484375,
+        "max": 33.484375
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 5.413229504483752,
+        "candidate": 5.461478998768143,
+        "delta_percent": 0.8913254877596977
+      },
+      {
+        "repetition": 1,
+        "baseline": 5.5169374973047525,
+        "candidate": 5.739291489589959,
+        "delta_percent": 4.030388098357762
+      },
+      {
+        "repetition": 2,
+        "baseline": 5.425937502877787,
+        "candidate": 5.500104001839645,
+        "delta_percent": 1.3668881907047847
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 30,
+        "median": 42.0,
+        "p90": 54,
+        "max": 63,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 30,
+        "median": 58.0,
+        "p90": 71,
+        "max": 83,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 30,
+        "median": 936.5,
+        "p90": 1023,
+        "max": 1370,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 30,
+        "median": 1064.0,
+        "p90": 1268,
+        "max": 5289,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 30,
+        "median": 3391.0,
+        "p90": 3686,
+        "max": 4439,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 30,
+        "median": 2759.0,
+        "p90": 2998,
+        "max": 3594,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 30,
+        "median": 923.5,
+        "p90": 981,
+        "max": 994,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 30,
+        "median": 603.5,
+        "p90": 642,
+        "max": 810,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "rust",
+    "size": "common",
+    "mode": "native",
+    "documents": 4,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 12.011957995127887,
+        "p90": 13.047166023170575,
+        "max": 13.528917013900355
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 10.892542006331496,
+        "p90": 12.329709017649293,
+        "max": 13.443125004414469
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 2.605617,
+        "p90": 2.638414,
+        "max": 2.638414
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 51.8125,
+        "p90": 53.296875,
+        "max": 53.296875
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 12.146750013926066,
+        "p90": 12.937749997945502,
+        "max": 13.601624988950789
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 10.913437508861534,
+        "p90": 12.308333010878414,
+        "max": 13.495749997673556
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 2.640492,
+        "p90": 2.661038,
+        "max": 2.661038
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 51.96875,
+        "p90": 52.125,
+        "max": 52.125
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 12.000479488051496,
+        "candidate": 11.944270983804017,
+        "delta_percent": -0.4683854866253001
+      },
+      {
+        "repetition": 1,
+        "baseline": 11.993291511316784,
+        "candidate": 12.277750007342547,
+        "delta_percent": 2.3718134071647468
+      },
+      {
+        "repetition": 2,
+        "baseline": 12.067417002981529,
+        "candidate": 12.143853993620723,
+        "delta_percent": 0.6334163360751432
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 120,
+        "median": 58.0,
+        "p90": 89,
+        "max": 177,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 120,
+        "median": 98.5,
+        "p90": 170,
+        "max": 3365,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 120,
+        "median": 1086.0,
+        "p90": 1393,
+        "max": 1855,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 120,
+        "median": 1275.5,
+        "p90": 2092,
+        "max": 6307,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 120,
+        "median": 7133.5,
+        "p90": 9052,
+        "max": 9954,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 120,
+        "median": 4305.5,
+        "p90": 6514,
+        "max": 7707,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 120,
+        "median": 5709.5,
+        "p90": 8305,
+        "max": 9239,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 120,
+        "median": 653.0,
+        "p90": 714,
+        "max": 1167,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "rust",
+    "size": "common",
+    "mode": "narrow",
+    "documents": 1,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 5.522124993149191,
+        "p90": 5.921042000409216,
+        "max": 7.305875013116747
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 5.503312015207484,
+        "p90": 5.895292008062825,
+        "max": 7.266416010679677
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.5342779999999999,
+        "p90": 0.536283,
+        "max": 0.536283
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 33.390625,
+        "p90": 33.40625,
+        "max": 33.40625
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 5.525874992599711,
+        "p90": 5.992874997900799,
+        "max": 8.367750007892027
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 5.50281249161344,
+        "p90": 5.973500024992973,
+        "max": 8.319375017890707
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.530262,
+        "p90": 0.537419,
+        "max": 0.537419
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 33.375,
+        "p90": 33.5,
+        "max": 33.5
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 5.546728993067518,
+        "candidate": 5.455958496895619,
+        "delta_percent": -1.636468922230505
+      },
+      {
+        "repetition": 1,
+        "baseline": 5.512333489605226,
+        "candidate": 5.572290989221074,
+        "delta_percent": 1.0876972470717172
+      },
+      {
+        "repetition": 2,
+        "baseline": 5.524374995729886,
+        "candidate": 5.47627049672883,
+        "delta_percent": -0.8707681690370173
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 30,
+        "median": 40.5,
+        "p90": 49,
+        "max": 55,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 30,
+        "median": 59.5,
+        "p90": 70,
+        "max": 187,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 30,
+        "median": 935.0,
+        "p90": 1008,
+        "max": 1214,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 30,
+        "median": 1083.0,
+        "p90": 1224,
+        "max": 5355,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 30,
+        "median": 32.0,
+        "p90": 38,
+        "max": 47,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 30,
+        "median": 3397.0,
+        "p90": 3573,
+        "max": 4263,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 30,
+        "median": 2740.5,
+        "p90": 2908,
+        "max": 3456,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 30,
+        "median": 901.0,
+        "p90": 1004,
+        "max": 1101,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 30,
+        "median": 624.0,
+        "p90": 658,
+        "max": 770,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "rust",
+    "size": "common",
+    "mode": "narrow",
+    "documents": 4,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 11.012062488589436,
+        "p90": 11.648208979750052,
+        "max": 12.14829200762324
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 9.82208299683407,
+        "p90": 11.092875007307157,
+        "max": 12.06212499528192
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 2.086405,
+        "p90": 2.093147,
+        "max": 2.093147
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 51.171875,
+        "p90": 51.828125,
+        "max": 51.828125
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 11.097791502834298,
+        "p90": 11.825666995719075,
+        "max": 12.55579199641943
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 10.015708496212028,
+        "p90": 11.208665993763134,
+        "max": 12.466707994462922
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 2.110608,
+        "p90": 2.111006,
+        "max": 2.111006
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 51.421875,
+        "p90": 51.765625,
+        "max": 51.765625
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 10.894395512877963,
+        "candidate": 11.051999506889842,
+        "delta_percent": 1.4466520315475906
+      },
+      {
+        "repetition": 1,
+        "baseline": 10.97502101038117,
+        "candidate": 11.088374987593852,
+        "delta_percent": 1.0328360839169326
+      },
+      {
+        "repetition": 2,
+        "baseline": 11.227583512663841,
+        "candidate": 11.251437492319383,
+        "delta_percent": 0.21245871499095959
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 120,
+        "median": 57.0,
+        "p90": 97,
+        "max": 160,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 120,
+        "median": 96.0,
+        "p90": 149,
+        "max": 4384,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 120,
+        "median": 1096.0,
+        "p90": 1370,
+        "max": 1727,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 120,
+        "median": 38.0,
+        "p90": 69,
+        "max": 154,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 120,
+        "median": 1370.5,
+        "p90": 3272,
+        "max": 6871,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 120,
+        "median": 6126.5,
+        "p90": 8124,
+        "max": 9102,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 120,
+        "median": 4074.0,
+        "p90": 5802,
+        "max": 6233,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 120,
+        "median": 3623.0,
+        "p90": 7276,
+        "max": 8314,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 120,
+        "median": 662.5,
+        "p90": 719,
+        "max": 943,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "rust",
+    "size": "common",
+    "mode": "wildcard",
+    "documents": 1,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 5.583791513345204,
+        "p90": 5.996499996399507,
+        "max": 7.261124992510304
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 5.562103993725032,
+        "p90": 5.972167011350393,
+        "max": 7.225083012599498
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.587375,
+        "p90": 0.589583,
+        "max": 0.589583
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 37.40625,
+        "p90": 37.765625,
+        "max": 37.765625
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 5.592146015260369,
+        "p90": 5.924625002080575,
+        "max": 7.071250001899898
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 5.571354486164637,
+        "p90": 5.888665997190401,
+        "max": 7.029000000329688
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.5876779999999999,
+        "p90": 0.5877749999999999,
+        "max": 0.5877749999999999
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 37.0,
+        "p90": 37.828125,
+        "max": 37.828125
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 5.590541521087289,
+        "candidate": 5.642875505145639,
+        "delta_percent": 0.9361165436469587
+      },
+      {
+        "repetition": 1,
+        "baseline": 5.586625004070811,
+        "candidate": 5.559312005061656,
+        "delta_percent": -0.4888998096212349
+      },
+      {
+        "repetition": 2,
+        "baseline": 5.5522500042570755,
+        "candidate": 5.5843125155661255,
+        "delta_percent": 0.5774687970546477
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 30,
+        "median": 40.0,
+        "p90": 51,
+        "max": 66,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 30,
+        "median": 63.0,
+        "p90": 87,
+        "max": 102,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 30,
+        "median": 949.5,
+        "p90": 1007,
+        "max": 1298,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 30,
+        "median": 1117.5,
+        "p90": 1164,
+        "max": 1495,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 30,
+        "median": 31.5,
+        "p90": 37,
+        "max": 42,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 30,
+        "median": 3428.0,
+        "p90": 3750,
+        "max": 4281,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 30,
+        "median": 2781.0,
+        "p90": 3088,
+        "max": 3456,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 30,
+        "median": 900.5,
+        "p90": 935,
+        "max": 952,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 30,
+        "median": 610.5,
+        "p90": 651,
+        "max": 790,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "rust",
+    "size": "common",
+    "mode": "wildcard",
+    "documents": 4,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 10.899416491156444,
+        "p90": 11.696500005200505,
+        "max": 12.524874997325242
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 9.789562507648952,
+        "p90": 10.99875001818873,
+        "max": 12.44775002123788
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 2.2775819999999998,
+        "p90": 2.289867,
+        "max": 2.289867
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 63.5625,
+        "p90": 64.203125,
+        "max": 64.203125
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 10.786375481984578,
+        "p90": 11.576208984479308,
+        "max": 12.69612499163486
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 9.747853997396305,
+        "p90": 10.959459003061056,
+        "max": 12.620333000086248
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 2.267643,
+        "p90": 2.286785,
+        "max": 2.286785
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 63.546875,
+        "p90": 64.15625,
+        "max": 64.15625
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 10.870458499994129,
+        "candidate": 10.566895507508889,
+        "delta_percent": -2.792550033518859
+      },
+      {
+        "repetition": 1,
+        "baseline": 10.96077098918613,
+        "candidate": 10.827895486727357,
+        "delta_percent": -1.2122824442721059
+      },
+      {
+        "repetition": 2,
+        "baseline": 10.915000006207265,
+        "candidate": 11.00118798785843,
+        "delta_percent": 0.7896287824292303
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 120,
+        "median": 72.5,
+        "p90": 118,
+        "max": 175,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 120,
+        "median": 107.5,
+        "p90": 158,
+        "max": 249,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 120,
+        "median": 1074.0,
+        "p90": 1340,
+        "max": 1768,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 120,
+        "median": 43.5,
+        "p90": 65,
+        "max": 89,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 120,
+        "median": 1337.5,
+        "p90": 1548,
+        "max": 3250,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 120,
+        "median": 5656.5,
+        "p90": 8036,
+        "max": 10857,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 120,
+        "median": 3799.0,
+        "p90": 5731,
+        "max": 6517,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 120,
+        "median": 3894.0,
+        "p90": 7247,
+        "max": 10114,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 120,
+        "median": 655.0,
+        "p90": 708,
+        "max": 758,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "rust",
+    "size": "large",
+    "mode": "native",
+    "documents": 1,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 189.1743125161156,
+        "p90": 191.46250002086163,
+        "max": 194.86250000772998
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 188.70887497905642,
+        "p90": 190.82266700570472,
+        "max": 194.30591698619537
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 14.592504,
+        "p90": 14.634746,
+        "max": 14.634746
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 1160.859375,
+        "p90": 1161.015625,
+        "max": 1161.015625
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 189.58725049742498,
+        "p90": 191.93016600911506,
+        "max": 224.3442079925444
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 189.1864585049916,
+        "p90": 191.45183300133795,
+        "max": 223.72770801302977
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 14.572408,
+        "p90": 14.691668,
+        "max": 14.691668
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 1161.328125,
+        "p90": 1161.828125,
+        "max": 1161.828125
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 189.73479149281047,
+        "candidate": 189.58395850495435,
+        "delta_percent": -0.07949674736477119
+      },
+      {
+        "repetition": 1,
+        "baseline": 189.36212500557303,
+        "candidate": 189.97739598853514,
+        "delta_percent": 0.3249176586627378
+      },
+      {
+        "repetition": 2,
+        "baseline": 188.36824949539732,
+        "candidate": 189.33639550232328,
+        "delta_percent": 0.5139645399473869
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 30,
+        "median": 2246.5,
+        "p90": 2458,
+        "max": 2759,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 30,
+        "median": 2275.5,
+        "p90": 2487,
+        "max": 2790,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 30,
+        "median": 31838.5,
+        "p90": 32045,
+        "max": 32894,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 30,
+        "median": 35901.0,
+        "p90": 36901,
+        "max": 38752,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 30,
+        "median": 121601.5,
+        "p90": 124072,
+        "max": 124920,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 30,
+        "median": 96272.0,
+        "p90": 97488,
+        "max": 99795,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 30,
+        "median": 22242.5,
+        "p90": 22970,
+        "max": 25363,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 30,
+        "median": 24640.0,
+        "p90": 25287,
+        "max": 26771,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "rust",
+    "size": "large",
+    "mode": "native",
+    "documents": 4,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 418.57489601534326,
+        "p90": 432.84645801759325,
+        "max": 445.4399590031244
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 378.67529201321304,
+        "p90": 419.7434170055203,
+        "max": 443.24833300197497
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 79.63445,
+        "p90": 81.361892,
+        "max": 81.361892
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 1049.671875,
+        "p90": 1052.75,
+        "max": 1052.75
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 416.21560450585093,
+        "p90": 434.09437499940395,
+        "max": 445.41654200293124
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 377.62668750656303,
+        "p90": 419.29637498105876,
+        "max": 442.1419999853242
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 79.902176,
+        "p90": 81.248818,
+        "max": 81.248818
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 872.6875,
+        "p90": 1003.6875,
+        "max": 1003.6875
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 416.0232294962043,
+        "candidate": 403.8415620016167,
+        "delta_percent": -2.9281219487044874
+      },
+      {
+        "repetition": 1,
+        "baseline": 416.4489164977567,
+        "candidate": 427.17154149431735,
+        "delta_percent": 2.574775577935351
+      },
+      {
+        "repetition": 2,
+        "baseline": 426.3436245091725,
+        "candidate": 421.7651455110172,
+        "delta_percent": -1.073894092687866
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 120,
+        "median": 3356.5,
+        "p90": 3777,
+        "max": 4141,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 120,
+        "median": 3409.5,
+        "p90": 3824,
+        "max": 4195,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 120,
+        "median": 37629.0,
+        "p90": 39034,
+        "max": 40876,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 120,
+        "median": 43869.0,
+        "p90": 46981,
+        "max": 53187,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 120,
+        "median": 227314.5,
+        "p90": 315939,
+        "max": 322581,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 120,
+        "median": 185409.5,
+        "p90": 211510,
+        "max": 236927,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 120,
+        "median": 150558.5,
+        "p90": 277143,
+        "max": 287836,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 120,
+        "median": 33639.5,
+        "p90": 36318,
+        "max": 44317,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "rust",
+    "size": "large",
+    "mode": "narrow",
+    "documents": 1,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 188.52195850922726,
+        "p90": 191.31716698757373,
+        "max": 195.89412497589365
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 188.10920800024178,
+        "p90": 190.8570000086911,
+        "max": 195.46895800158381
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 12.090266,
+        "p90": 12.098137,
+        "max": 12.098137
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 1161.109375,
+        "p90": 1161.171875,
+        "max": 1161.171875
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 187.32339599227998,
+        "p90": 189.46962500922382,
+        "max": 191.5859580039978
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 186.77208299050108,
+        "p90": 189.01479101623408,
+        "max": 191.12920900806785
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 12.00963,
+        "p90": 12.029474,
+        "max": 12.029474
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 1161.21875,
+        "p90": 1162.90625,
+        "max": 1162.90625
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 189.32079151272774,
+        "candidate": 187.98352050362155,
+        "delta_percent": -0.7063519006132446
+      },
+      {
+        "repetition": 1,
+        "baseline": 188.55816700670402,
+        "candidate": 186.63375050527975,
+        "delta_percent": -1.0205956771715208
+      },
+      {
+        "repetition": 2,
+        "baseline": 187.77068750932813,
+        "candidate": 187.37902099383064,
+        "delta_percent": -0.20858767717832905
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 30,
+        "median": 2207.0,
+        "p90": 2630,
+        "max": 2757,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 30,
+        "median": 2287.5,
+        "p90": 2785,
+        "max": 6100,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 30,
+        "median": 31510.5,
+        "p90": 31775,
+        "max": 32136,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 30,
+        "median": 35964.5,
+        "p90": 36785,
+        "max": 40925,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 30,
+        "median": 795.0,
+        "p90": 829,
+        "max": 869,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 30,
+        "median": 118912.5,
+        "p90": 121685,
+        "max": 125543,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 30,
+        "median": 93012.5,
+        "p90": 96649,
+        "max": 100150,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 30,
+        "median": 21980.5,
+        "p90": 22889,
+        "max": 27877,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 30,
+        "median": 24580.5,
+        "p90": 25039,
+        "max": 25640,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "rust",
+    "size": "large",
+    "mode": "narrow",
+    "documents": 4,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 383.55979199695867,
+        "p90": 393.947875010781,
+        "max": 420.21758400369436
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 342.2087500075577,
+        "p90": 383.0469590029679,
+        "max": 417.458792013349
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 62.276314,
+        "p90": 63.101466,
+        "max": 63.101466
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 1026.046875,
+        "p90": 1349.1875,
+        "max": 1349.1875
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 382.1275834925473,
+        "p90": 392.10633299080655,
+        "max": 408.43391700764187
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 340.4878334986279,
+        "p90": 381.74820799031295,
+        "max": 405.7277090032585
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 62.829169,
+        "p90": 62.909269,
+        "max": 62.909269
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 1095.15625,
+        "p90": 1375.78125,
+        "max": 1375.78125
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 376.4775000017835,
+        "candidate": 373.22966651117895,
+        "delta_percent": -0.8626899324897686
+      },
+      {
+        "repetition": 1,
+        "baseline": 384.2609375133179,
+        "candidate": 385.9787710098317,
+        "delta_percent": 0.44704869238867406
+      },
+      {
+        "repetition": 2,
+        "baseline": 386.6577290027635,
+        "candidate": 384.89564548945054,
+        "delta_percent": -0.4557217872917185
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 120,
+        "median": 3316.0,
+        "p90": 3753,
+        "max": 4183,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 120,
+        "median": 3351.5,
+        "p90": 3794,
+        "max": 4216,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 120,
+        "median": 38061.0,
+        "p90": 39791,
+        "max": 42810,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 120,
+        "median": 1417.0,
+        "p90": 2018,
+        "max": 10828,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 120,
+        "median": 46218.5,
+        "p90": 50448,
+        "max": 58791,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 120,
+        "median": 198584.5,
+        "p90": 273357,
+        "max": 282803,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 120,
+        "median": 160291.5,
+        "p90": 175684,
+        "max": 187931,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 120,
+        "median": 116856.0,
+        "p90": 236240,
+        "max": 248074,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 120,
+        "median": 35496.5,
+        "p90": 37833,
+        "max": 38757,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "rust",
+    "size": "large",
+    "mode": "wildcard",
+    "documents": 1,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 191.89993750478607,
+        "p90": 196.51979199261405,
+        "max": 205.3436250134837
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 191.39887500205077,
+        "p90": 196.1025000200607,
+        "max": 204.793291981332
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 12.991671,
+        "p90": 13.18336,
+        "max": 13.18336
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 761.8125,
+        "p90": 1182.734375,
+        "max": 1182.734375
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 188.30610398435965,
+        "p90": 192.97620799625292,
+        "max": 196.5148750168737
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 187.81239551026374,
+        "p90": 192.41587500437163,
+        "max": 195.894665986998
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 12.950747,
+        "p90": 13.016164000000002,
+        "max": 13.016164000000002
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 1182.796875,
+        "p90": 1182.921875,
+        "max": 1182.921875
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 193.77325050299987,
+        "candidate": 188.378979000845,
+        "delta_percent": -2.783806066189398
+      },
+      {
+        "repetition": 1,
+        "baseline": 190.82077099301387,
+        "candidate": 188.96452100307215,
+        "delta_percent": -0.972771454743615
+      },
+      {
+        "repetition": 2,
+        "baseline": 191.9436664902605,
+        "candidate": 187.91089550359175,
+        "delta_percent": -2.101018002004973
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 30,
+        "median": 2244.0,
+        "p90": 2679,
+        "max": 2853,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 30,
+        "median": 2287.0,
+        "p90": 2826,
+        "max": 4915,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 30,
+        "median": 31837.0,
+        "p90": 31990,
+        "max": 33029,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 30,
+        "median": 36202.0,
+        "p90": 36894,
+        "max": 40933,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 30,
+        "median": 800.0,
+        "p90": 831,
+        "max": 856,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 30,
+        "median": 119469.5,
+        "p90": 121623,
+        "max": 122878,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 30,
+        "median": 94162.5,
+        "p90": 95492,
+        "max": 97688,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 30,
+        "median": 22236.0,
+        "p90": 22692,
+        "max": 23258,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 30,
+        "median": 24524.5,
+        "p90": 25492,
+        "max": 26309,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "rust",
+    "size": "large",
+    "mode": "wildcard",
+    "documents": 4,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 392.6698744908208,
+        "p90": 432.1675840183161,
+        "max": 472.19916598987766
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 360.8658960001776,
+        "p90": 403.3129579911474,
+        "max": 469.34008301468566
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 69.945928,
+        "p90": 74.151583,
+        "max": 74.151583
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 894.921875,
+        "p90": 1326.265625,
+        "max": 1326.265625
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 396.86445851111785,
+        "p90": 418.300333985826,
+        "max": 430.0252499815542
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 355.6436669896357,
+        "p90": 399.33024998754263,
+        "max": 427.46320797596127
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 70.156325,
+        "p90": 72.87226199999999,
+        "max": 72.87226199999999
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 779.5,
+        "p90": 1173.21875,
+        "max": 1173.21875
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 388.1145619961899,
+        "candidate": 383.39704199461266,
+        "delta_percent": -1.2154967794337779
+      },
+      {
+        "repetition": 1,
+        "baseline": 392.0341665216256,
+        "candidate": 394.93535399378743,
+        "delta_percent": 0.7400343439203372
+      },
+      {
+        "repetition": 2,
+        "baseline": 428.53616701904684,
+        "candidate": 412.84820799774025,
+        "delta_percent": -3.660824973171828
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 120,
+        "median": 3675.0,
+        "p90": 4211,
+        "max": 5105,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 120,
+        "median": 3720.0,
+        "p90": 4296,
+        "max": 5166,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 120,
+        "median": 40751.5,
+        "p90": 41775,
+        "max": 45204,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 120,
+        "median": 48630.5,
+        "p90": 52716,
+        "max": 59085,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 120,
+        "median": 1550.0,
+        "p90": 2393,
+        "max": 3991,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 120,
+        "median": 234580.5,
+        "p90": 300892,
+        "max": 317614,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 120,
+        "median": 189740.0,
+        "p90": 198471,
+        "max": 205742,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 120,
+        "median": 140932.0,
+        "p90": 263523,
+        "max": 278138,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 120,
+        "median": 40999.0,
+        "p90": 43445,
+        "max": 54884,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "markdown",
+    "size": "small",
+    "mode": "native",
+    "documents": 1,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 0.8027709991438314,
+        "p90": 0.981958000920713,
+        "max": 1.1494590144138783
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 0.7707085023866966,
+        "p90": 0.9457090054638684,
+        "max": 1.1017080105375499
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.166688,
+        "p90": 0.16724699999999998,
+        "max": 0.16724699999999998
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 27.671875,
+        "p90": 27.734375,
+        "max": 27.734375
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 0.7950415019877255,
+        "p90": 1.0081669897772372,
+        "max": 1.3538329803850502
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 0.7670420018257573,
+        "p90": 0.9618339827284217,
+        "max": 1.2855839740950614
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.168199,
+        "p90": 0.17383099999999999,
+        "max": 0.17383099999999999
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 27.953125,
+        "p90": 28.125,
+        "max": 28.125
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 0.806249983725138,
+        "candidate": 0.807917007477954,
+        "delta_percent": 0.20676264018186785
+      },
+      {
+        "repetition": 1,
+        "baseline": 0.7796249992679805,
+        "candidate": 0.7843539933674037,
+        "delta_percent": 0.6065729169618006
+      },
+      {
+        "repetition": 2,
+        "baseline": 0.8056665101321414,
+        "candidate": 0.7629164756508544,
+        "delta_percent": -5.306169977733754
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 30,
+        "median": 20.0,
+        "p90": 31,
+        "max": 64,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 30,
+        "median": 59.5,
+        "p90": 74,
+        "max": 110,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 30,
+        "median": 97.5,
+        "p90": 118,
+        "max": 158,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 30,
+        "median": 231.0,
+        "p90": 322,
+        "max": 5372,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 30,
+        "median": 189.5,
+        "p90": 235,
+        "max": 278,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 30,
+        "median": 127.0,
+        "p90": 162,
+        "max": 187,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 30,
+        "median": 65.5,
+        "p90": 92,
+        "max": 104,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 30,
+        "median": 51.0,
+        "p90": 65,
+        "max": 77,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "markdown",
+    "size": "small",
+    "mode": "native",
+    "documents": 4,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 1.0509999992791563,
+        "p90": 1.3386670034378767,
+        "max": 1.8374169885646552
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 0.9113750129472464,
+        "p90": 1.1727090168278664,
+        "max": 1.7397500050719827
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.32898499999999997,
+        "p90": 0.335437,
+        "max": 0.335437
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 31.125,
+        "p90": 31.453125,
+        "max": 31.453125
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 1.0823545017046854,
+        "p90": 1.4382920053321868,
+        "max": 2.041833009570837
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 0.9355209913337603,
+        "p90": 1.2489169894251972,
+        "max": 1.9038750033359975
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.33151,
+        "p90": 0.338105,
+        "max": 0.338105
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 31.578125,
+        "p90": 31.65625,
+        "max": 31.65625
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 1.0976874909829348,
+        "candidate": 1.0632494959281757,
+        "delta_percent": -3.137322356103489
+      },
+      {
+        "repetition": 1,
+        "baseline": 0.9885829786071554,
+        "candidate": 1.0810624953592196,
+        "delta_percent": 9.354755114473189
+      },
+      {
+        "repetition": 2,
+        "baseline": 1.1108750040875748,
+        "candidate": 1.1401255178498104,
+        "delta_percent": 2.6331057638893096
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 120,
+        "median": 12.0,
+        "p90": 25,
+        "max": 79,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 120,
+        "median": 55.5,
+        "p90": 94,
+        "max": 161,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 120,
+        "median": 59.5,
+        "p90": 108,
+        "max": 149,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 120,
+        "median": 155.0,
+        "p90": 227,
+        "max": 316,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 120,
+        "median": 184.0,
+        "p90": 320,
+        "max": 398,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 120,
+        "median": 119.0,
+        "p90": 137,
+        "max": 184,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 120,
+        "median": 47.0,
+        "p90": 254,
+        "max": 347,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 120,
+        "median": 48.0,
+        "p90": 61,
+        "max": 74,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "markdown",
+    "size": "small",
+    "mode": "narrow",
+    "documents": 1,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 0.7157704967539757,
+        "p90": 0.8800830109976232,
+        "max": 1.435082987882197
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 0.6851459911558777,
+        "p90": 0.8365829999092966,
+        "max": 1.3460409827530384
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.18314899999999998,
+        "p90": 0.188627,
+        "max": 0.188627
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 28.96875,
+        "p90": 29.046875,
+        "max": 29.046875
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 0.7063125085551292,
+        "p90": 0.886791996890679,
+        "max": 1.2738329824060202
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 0.6760210089851171,
+        "p90": 0.8442920225206763,
+        "max": 1.2099580198992044
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.185615,
+        "p90": 0.190529,
+        "max": 0.190529
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 29.109375,
+        "p90": 29.109375,
+        "max": 29.109375
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 0.7300205033970997,
+        "candidate": 0.6918750004842877,
+        "delta_percent": -5.225264596720846
+      },
+      {
+        "repetition": 1,
+        "baseline": 0.7616874936502427,
+        "candidate": 0.7018544856691733,
+        "delta_percent": -7.855322357247996
+      },
+      {
+        "repetition": 2,
+        "baseline": 0.6549375102622434,
+        "candidate": 0.7162500114645809,
+        "delta_percent": 9.361580340357566
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 30,
+        "median": 12.0,
+        "p90": 17,
+        "max": 53,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 30,
+        "median": 40.0,
+        "p90": 55,
+        "max": 83,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 30,
+        "median": 59.0,
+        "p90": 69,
+        "max": 75,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 30,
+        "median": 160.0,
+        "p90": 201,
+        "max": 229,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 30,
+        "median": 18.0,
+        "p90": 19,
+        "max": 22,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 30,
+        "median": 116.5,
+        "p90": 140,
+        "max": 153,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 30,
+        "median": 76.0,
+        "p90": 86,
+        "max": 101,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 30,
+        "median": 53.0,
+        "p90": 80,
+        "max": 98,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 30,
+        "median": 32.0,
+        "p90": 40,
+        "max": 57,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "markdown",
+    "size": "small",
+    "mode": "narrow",
+    "documents": 4,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 1.098229011404328,
+        "p90": 1.473833981435746,
+        "max": 1.9092919828835875
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 0.9096880094148219,
+        "p90": 1.2660420034080744,
+        "max": 1.764959015417844
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.327582,
+        "p90": 0.336374,
+        "max": 0.336374
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 32.515625,
+        "p90": 32.5625,
+        "max": 32.5625
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 1.0292914957972243,
+        "p90": 1.3095000176690519,
+        "max": 2.026332978857681
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 0.8762085053604096,
+        "p90": 1.1332500143907964,
+        "max": 1.9546669791452587
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.334175,
+        "p90": 0.33549399999999996,
+        "max": 0.33549399999999996
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 32.546875,
+        "p90": 32.96875,
+        "max": 32.96875
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 1.142854496720247,
+        "candidate": 0.8506875019520521,
+        "delta_percent": -25.56467123388436
+      },
+      {
+        "repetition": 1,
+        "baseline": 1.0527915001148358,
+        "candidate": 1.138853986049071,
+        "delta_percent": 8.174694222440792
+      },
+      {
+        "repetition": 2,
+        "baseline": 1.095458515919745,
+        "candidate": 1.0775005066534504,
+        "delta_percent": -1.6393144062801013
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 120,
+        "median": 20.0,
+        "p90": 36,
+        "max": 73,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 120,
+        "median": 78.5,
+        "p90": 137,
+        "max": 263,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 120,
+        "median": 102.5,
+        "p90": 145,
+        "max": 215,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 120,
+        "median": 240.5,
+        "p90": 349,
+        "max": 521,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 120,
+        "median": 30.0,
+        "p90": 42,
+        "max": 55,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 120,
+        "median": 211.0,
+        "p90": 420,
+        "max": 854,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 120,
+        "median": 130.5,
+        "p90": 165,
+        "max": 217,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 120,
+        "median": 68.0,
+        "p90": 301,
+        "max": 536,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 120,
+        "median": 53.0,
+        "p90": 71,
+        "max": 100,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "markdown",
+    "size": "small",
+    "mode": "wildcard",
+    "documents": 1,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 0.7444160000886768,
+        "p90": 0.9487500065006316,
+        "max": 1.4179170248098671
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 0.7132914906833321,
+        "p90": 0.9004160237964243,
+        "max": 1.346125005511567
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.194603,
+        "p90": 0.200063,
+        "max": 0.200063
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 29.8125,
+        "p90": 29.984375,
+        "max": 29.984375
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 0.7216665107989684,
+        "p90": 0.9238339844159782,
+        "max": 1.2593750143423676
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 0.6947079964447767,
+        "p90": 0.8718330063857138,
+        "max": 1.1929999745916575
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.19214699999999998,
+        "p90": 0.192629,
+        "max": 0.192629
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 30.078125,
+        "p90": 30.109375,
+        "max": 30.109375
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 0.7586660067318007,
+        "candidate": 0.755979010136798,
+        "delta_percent": -0.35417384872400426
+      },
+      {
+        "repetition": 1,
+        "baseline": 0.7560835074400529,
+        "candidate": 0.7216665107989684,
+        "delta_percent": -4.552009970117399
+      },
+      {
+        "repetition": 2,
+        "baseline": 0.7233954966068268,
+        "candidate": 0.7083119999151677,
+        "delta_percent": -2.0850968470788156
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 30,
+        "median": 24.0,
+        "p90": 33,
+        "max": 101,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 30,
+        "median": 59.0,
+        "p90": 75,
+        "max": 152,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 30,
+        "median": 119.5,
+        "p90": 152,
+        "max": 194,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 30,
+        "median": 268.0,
+        "p90": 333,
+        "max": 472,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 30,
+        "median": 33.0,
+        "p90": 43,
+        "max": 48,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 30,
+        "median": 207.0,
+        "p90": 260,
+        "max": 286,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 30,
+        "median": 139.5,
+        "p90": 180,
+        "max": 195,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 30,
+        "median": 70.0,
+        "p90": 99,
+        "max": 109,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 30,
+        "median": 56.5,
+        "p90": 70,
+        "max": 78,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "markdown",
+    "size": "small",
+    "mode": "wildcard",
+    "documents": 4,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 1.3066249957773834,
+        "p90": 1.6864159842953086,
+        "max": 2.2482080094050616
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 1.0233540087938309,
+        "p90": 1.4593329979106784,
+        "max": 2.1345840068534017
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.367834,
+        "p90": 0.37593899999999997,
+        "max": 0.37593899999999997
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 34.109375,
+        "p90": 34.234375,
+        "max": 34.234375
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 1.228041495778598,
+        "p90": 1.7236660060007125,
+        "max": 2.366625005379319
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 1.0195210052188486,
+        "p90": 1.4988329785410315,
+        "max": 2.2528329864144325
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.37124999999999997,
+        "p90": 0.371811,
+        "max": 0.371811
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 34.171875,
+        "p90": 34.46875,
+        "max": 34.46875
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 1.227978995302692,
+        "candidate": 1.1797085026046261,
+        "delta_percent": -3.9308891180314887
+      },
+      {
+        "repetition": 1,
+        "baseline": 1.278749987250194,
+        "candidate": 1.2647294934140518,
+        "delta_percent": -1.0964218162998085
+      },
+      {
+        "repetition": 2,
+        "baseline": 1.3324585015652701,
+        "candidate": 1.221645507030189,
+        "delta_percent": -8.316431198788287
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 120,
+        "median": 21.5,
+        "p90": 37,
+        "max": 89,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 120,
+        "median": 72.0,
+        "p90": 137,
+        "max": 265,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 120,
+        "median": 100.0,
+        "p90": 143,
+        "max": 220,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 120,
+        "median": 29.0,
+        "p90": 39,
+        "max": 65,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 120,
+        "median": 231.0,
+        "p90": 388,
+        "max": 847,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 120,
+        "median": 196.0,
+        "p90": 437,
+        "max": 1487,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 120,
+        "median": 129.5,
+        "p90": 159,
+        "max": 255,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 120,
+        "median": 60.0,
+        "p90": 338,
+        "max": 1375,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 120,
+        "median": 51.0,
+        "p90": 66,
+        "max": 88,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "markdown",
+    "size": "common",
+    "mode": "native",
+    "documents": 1,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 3.493063006317243,
+        "p90": 4.347916983533651,
+        "max": 5.345041980035603
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 3.4778960107360035,
+        "p90": 4.327582981204614,
+        "max": 5.312875000527129
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.351701,
+        "p90": 0.354567,
+        "max": 0.354567
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 34.078125,
+        "p90": 34.21875,
+        "max": 34.21875
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 3.497833517030813,
+        "p90": 4.386125016026199,
+        "max": 5.348791019059718
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 3.483895998215303,
+        "p90": 4.362542007584125,
+        "max": 5.317750008543953
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.355425,
+        "p90": 0.356497,
+        "max": 0.356497
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 34.171875,
+        "p90": 34.328125,
+        "max": 34.328125
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 3.4867920039687306,
+        "candidate": 3.4815415128832683,
+        "delta_percent": -0.15058228536390939
+      },
+      {
+        "repetition": 1,
+        "baseline": 3.532645510858856,
+        "candidate": 3.524312502122484,
+        "delta_percent": -0.2358857890144228
+      },
+      {
+        "repetition": 2,
+        "baseline": 3.481771011138335,
+        "candidate": 3.494416523608379,
+        "delta_percent": 0.36319196264174014
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 30,
+        "median": 206.0,
+        "p90": 438,
+        "max": 756,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 30,
+        "median": 249.0,
+        "p90": 455,
+        "max": 776,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 30,
+        "median": 562.5,
+        "p90": 702,
+        "max": 865,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 30,
+        "median": 1426.0,
+        "p90": 1997,
+        "max": 5220,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 30,
+        "median": 1040.0,
+        "p90": 1295,
+        "max": 1619,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 30,
+        "median": 716.5,
+        "p90": 902,
+        "max": 1118,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 30,
+        "median": 185.0,
+        "p90": 238,
+        "max": 310,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 30,
+        "median": 286.0,
+        "p90": 349,
+        "max": 456,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "markdown",
+    "size": "common",
+    "mode": "native",
+    "documents": 4,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 5.768770977738313,
+        "p90": 6.38558401260525,
+        "max": 7.453750004060566
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 5.112375016324222,
+        "p90": 6.007833988405764,
+        "max": 7.406416989397258
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 1.475947,
+        "p90": 1.48767,
+        "max": 1.48767
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 54.859375,
+        "p90": 55.9375,
+        "max": 55.9375
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 5.680417001713067,
+        "p90": 6.2230829789768904,
+        "max": 6.7921669979114085
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 5.05168798554223,
+        "p90": 5.82666601985693,
+        "max": 6.733292015269399
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 1.462556,
+        "p90": 1.4762979999999999,
+        "max": 1.4762979999999999
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 55.328125,
+        "p90": 55.40625,
+        "max": 55.40625
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 5.8939584996551275,
+        "candidate": 5.628229002468288,
+        "delta_percent": -4.508506417247227
+      },
+      {
+        "repetition": 1,
+        "baseline": 5.577749994699843,
+        "candidate": 5.800895989523269,
+        "delta_percent": 4.0006453325349245
+      },
+      {
+        "repetition": 2,
+        "baseline": 5.821854007081129,
+        "candidate": 5.626334008411504,
+        "delta_percent": -3.3583803103240495
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 120,
+        "median": 255.5,
+        "p90": 448,
+        "max": 714,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 120,
+        "median": 282.5,
+        "p90": 686,
+        "max": 3496,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 120,
+        "median": 622.5,
+        "p90": 713,
+        "max": 1167,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 120,
+        "median": 1254.5,
+        "p90": 1689,
+        "max": 5803,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 120,
+        "median": 2305.5,
+        "p90": 3661,
+        "max": 7216,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 120,
+        "median": 1043.0,
+        "p90": 2070,
+        "max": 2744,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 120,
+        "median": 569.5,
+        "p90": 3057,
+        "max": 6846,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 120,
+        "median": 310.0,
+        "p90": 638,
+        "max": 725,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "markdown",
+    "size": "common",
+    "mode": "narrow",
+    "documents": 1,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 2.6891459856415167,
+        "p90": 3.683959017507732,
+        "max": 4.374792013550177
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 2.6736044965218753,
+        "p90": 3.659834008431062,
+        "max": 4.336167010478675
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.34784899999999996,
+        "p90": 0.352317,
+        "max": 0.352317
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 36.890625,
+        "p90": 36.953125,
+        "max": 36.953125
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 2.720604490605183,
+        "p90": 3.6151249951217324,
+        "max": 4.4303339964244515
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 2.705770995817147,
+        "p90": 3.5909999860450625,
+        "max": 4.394082992803305
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.350414,
+        "p90": 0.350951,
+        "max": 0.350951
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 36.5,
+        "p90": 36.828125,
+        "max": 36.828125
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 2.641437517013401,
+        "candidate": 2.734645997406915,
+        "delta_percent": 3.5287028291663747
+      },
+      {
+        "repetition": 1,
+        "baseline": 2.721749508054927,
+        "candidate": 2.7035624952986836,
+        "delta_percent": -0.6682103809487083
+      },
+      {
+        "repetition": 2,
+        "baseline": 2.700020995689556,
+        "candidate": 2.718062503845431,
+        "delta_percent": 0.668198809738052
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 30,
+        "median": 213.0,
+        "p90": 461,
+        "max": 865,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 30,
+        "median": 229.5,
+        "p90": 476,
+        "max": 889,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 30,
+        "median": 575.0,
+        "p90": 763,
+        "max": 869,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 30,
+        "median": 1102.5,
+        "p90": 1506,
+        "max": 2056,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 30,
+        "median": 183.0,
+        "p90": 224,
+        "max": 253,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 30,
+        "median": 1047.5,
+        "p90": 1332,
+        "max": 1605,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 30,
+        "median": 718.0,
+        "p90": 916,
+        "max": 1100,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 30,
+        "median": 202.0,
+        "p90": 243,
+        "max": 279,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 30,
+        "median": 291.0,
+        "p90": 373,
+        "max": 450,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "markdown",
+    "size": "common",
+    "mode": "narrow",
+    "documents": 4,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 6.114458010415547,
+        "p90": 6.598416977794841,
+        "max": 7.31679200544022
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 5.561458005104214,
+        "p90": 6.266874988796189,
+        "max": 7.252291979966685
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 1.226161,
+        "p90": 1.232183,
+        "max": 1.232183
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 60.734375,
+        "p90": 61.125,
+        "max": 61.125
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 6.201937503647059,
+        "p90": 6.620625004870817,
+        "max": 7.416584005113691
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 5.628374507068656,
+        "p90": 6.29641700652428,
+        "max": 7.3347500001545995
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 1.23059,
+        "p90": 1.236965,
+        "max": 1.236965
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 61.53125,
+        "p90": 61.640625,
+        "max": 61.640625
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 6.166438004584052,
+        "candidate": 6.241854498512112,
+        "delta_percent": 1.2230155216349514
+      },
+      {
+        "repetition": 1,
+        "baseline": 6.17143748968374,
+        "candidate": 6.090707989642397,
+        "delta_percent": -1.3081150084772286
+      },
+      {
+        "repetition": 2,
+        "baseline": 6.022958506946452,
+        "candidate": 6.227061981917359,
+        "delta_percent": 3.388757779677687
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 120,
+        "median": 245.5,
+        "p90": 518,
+        "max": 829,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 120,
+        "median": 311.0,
+        "p90": 629,
+        "max": 3921,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 120,
+        "median": 622.0,
+        "p90": 694,
+        "max": 944,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 120,
+        "median": 1470.0,
+        "p90": 1900,
+        "max": 2223,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 120,
+        "median": 197.0,
+        "p90": 232,
+        "max": 534,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 120,
+        "median": 1631.0,
+        "p90": 2185,
+        "max": 3013,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 120,
+        "median": 810.5,
+        "p90": 1191,
+        "max": 1686,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 120,
+        "median": 503.5,
+        "p90": 1809,
+        "max": 2659,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 120,
+        "median": 297.5,
+        "p90": 326,
+        "max": 439,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "markdown",
+    "size": "common",
+    "mode": "wildcard",
+    "documents": 1,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 2.7481250144774094,
+        "p90": 3.7987079995218664,
+        "max": 4.715415998362005
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 2.7346249989932403,
+        "p90": 3.7721249973401427,
+        "max": 4.679625009885058
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.390394,
+        "p90": 0.394163,
+        "max": 0.394163
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 40.453125,
+        "p90": 40.78125,
+        "max": 40.78125
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 2.7435624942881986,
+        "p90": 3.856875002384186,
+        "max": 4.65487502515316
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 2.7292289887554944,
+        "p90": 3.832290996797383,
+        "max": 4.611457989085466
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 0.39069,
+        "p90": 0.39316,
+        "max": 0.39316
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 40.65625,
+        "p90": 40.65625,
+        "max": 40.65625
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 2.705000006244518,
+        "candidate": 2.7552494866540655,
+        "delta_percent": 1.8576517668593917
+      },
+      {
+        "repetition": 1,
+        "baseline": 2.771125000435859,
+        "candidate": 2.7370624884497374,
+        "delta_percent": -1.2291943517800163
+      },
+      {
+        "repetition": 2,
+        "baseline": 2.7325624832883477,
+        "candidate": 2.730958498432301,
+        "delta_percent": -0.05869892695432588
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 30,
+        "median": 217.0,
+        "p90": 475,
+        "max": 875,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 30,
+        "median": 234.0,
+        "p90": 499,
+        "max": 894,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 30,
+        "median": 572.5,
+        "p90": 767,
+        "max": 953,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 30,
+        "median": 1115.5,
+        "p90": 1566,
+        "max": 2083,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 30,
+        "median": 175.0,
+        "p90": 227,
+        "max": 287,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 30,
+        "median": 1051.5,
+        "p90": 1435,
+        "max": 1744,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 30,
+        "median": 730.5,
+        "p90": 987,
+        "max": 1207,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 30,
+        "median": 192.5,
+        "p90": 227,
+        "max": 258,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 30,
+        "median": 286.5,
+        "p90": 401,
+        "max": 480,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "markdown",
+    "size": "common",
+    "mode": "wildcard",
+    "documents": 4,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 7.241125000291504,
+        "p90": 7.998542016139254,
+        "max": 9.529583010589704
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 6.556832988280803,
+        "p90": 7.435667008394375,
+        "max": 9.456416999455541
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 1.447306,
+        "p90": 1.454351,
+        "max": 1.454351
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 72.59375,
+        "p90": 74.046875,
+        "max": 74.046875
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 7.183603986050002,
+        "p90": 8.022458001505584,
+        "max": 9.625166014302522
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 6.50285450683441,
+        "p90": 7.435790990712121,
+        "max": 9.565874992404133
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 1.451089,
+        "p90": 1.469081,
+        "max": 1.469081
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 73.375,
+        "p90": 74.359375,
+        "max": 74.359375
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 7.242291496368125,
+        "candidate": 7.177271007094532,
+        "delta_percent": -0.897788901567953
+      },
+      {
+        "repetition": 1,
+        "baseline": 7.2242919995915145,
+        "candidate": 7.1081244823290035,
+        "delta_percent": -1.608012484394039
+      },
+      {
+        "repetition": 2,
+        "baseline": 7.257312507135794,
+        "candidate": 7.356541507760994,
+        "delta_percent": 1.367296785519878
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 120,
+        "median": 350.0,
+        "p90": 693,
+        "max": 1230,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 120,
+        "median": 412.0,
+        "p90": 821,
+        "max": 4402,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 120,
+        "median": 628.0,
+        "p90": 697,
+        "max": 1174,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 120,
+        "median": 1526.5,
+        "p90": 2114,
+        "max": 6171,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 120,
+        "median": 192.0,
+        "p90": 206,
+        "max": 573,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 120,
+        "median": 1495.5,
+        "p90": 2232,
+        "max": 2768,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 120,
+        "median": 870.5,
+        "p90": 1206,
+        "max": 1646,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 120,
+        "median": 473.0,
+        "p90": 1831,
+        "max": 2399,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 120,
+        "median": 300.0,
+        "p90": 337,
+        "max": 432,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "markdown",
+    "size": "large",
+    "mode": "native",
+    "documents": 1,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 125.38612498610746,
+        "p90": 133.74175000353716,
+        "max": 141.44658300210722
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 125.21450000349432,
+        "p90": 133.5757500200998,
+        "max": 141.28299997537397
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 7.47151,
+        "p90": 7.516194,
+        "max": 7.516194
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 253.765625,
+        "p90": 256.1875,
+        "max": 256.1875
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 127.83504149410874,
+        "p90": 136.41791700501926,
+        "max": 145.93204198172316
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 127.66870800987817,
+        "p90": 136.22199997189455,
+        "max": 145.75949998106807
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 7.619965,
+        "p90": 7.630938,
+        "max": 7.630938
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 253.84375,
+        "p90": 255.9375,
+        "max": 255.9375
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 125.80464599886909,
+        "candidate": 128.3546660124557,
+        "delta_percent": 2.026968076846347
+      },
+      {
+        "repetition": 1,
+        "baseline": 124.81883299187757,
+        "candidate": 126.42433350265492,
+        "delta_percent": 1.2862646383513532
+      },
+      {
+        "repetition": 2,
+        "baseline": 124.2691039951751,
+        "candidate": 128.8347289955709,
+        "delta_percent": 3.67398239273784
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 30,
+        "median": 9049.0,
+        "p90": 13347,
+        "max": 23622,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 30,
+        "median": 9875.0,
+        "p90": 14691,
+        "max": 23677,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 30,
+        "median": 21060.5,
+        "p90": 21385,
+        "max": 21638,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 30,
+        "median": 56665.5,
+        "p90": 70032,
+        "max": 82544,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 30,
+        "median": 39356.5,
+        "p90": 40973,
+        "max": 41825,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 30,
+        "median": 25735.5,
+        "p90": 27906,
+        "max": 28433,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 30,
+        "median": 4832.0,
+        "p90": 4998,
+        "max": 5028,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 30,
+        "median": 12176.0,
+        "p90": 12514,
+        "max": 13105,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "markdown",
+    "size": "large",
+    "mode": "native",
+    "documents": 4,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 233.23629150399938,
+        "p90": 253.9071660139598,
+        "max": 277.8814999910537
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 212.46256250014994,
+        "p90": 239.71537500619888,
+        "max": 277.1544159913901
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 48.886232,
+        "p90": 50.856853,
+        "max": 50.856853
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 1103.71875,
+        "p90": 1133.703125,
+        "max": 1133.703125
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 228.51877100765705,
+        "p90": 249.97991701820865,
+        "max": 267.4495420069434
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 210.56983350717928,
+        "p90": 236.4154169918038,
+        "max": 266.76254099584185
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 49.367919,
+        "p90": 49.581379,
+        "max": 49.581379
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 1078.5625,
+        "p90": 1128.21875,
+        "max": 1128.21875
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 228.11310399265494,
+        "candidate": 222.79681199870538,
+        "delta_percent": -2.330550898172312
+      },
+      {
+        "repetition": 1,
+        "baseline": 232.2522089962149,
+        "candidate": 230.09166649717372,
+        "delta_percent": -0.9302570289337453
+      },
+      {
+        "repetition": 2,
+        "baseline": 240.4334784951061,
+        "candidate": 235.54504198546056,
+        "delta_percent": -2.033176303168216
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 120,
+        "median": 16764.0,
+        "p90": 29481,
+        "max": 41791,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 120,
+        "median": 17439.5,
+        "p90": 29541,
+        "max": 41847,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 120,
+        "median": 29835.0,
+        "p90": 31283,
+        "max": 33791,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 120,
+        "median": 62931.5,
+        "p90": 80096,
+        "max": 100391,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 120,
+        "median": 79119.5,
+        "p90": 111216,
+        "max": 143581,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 120,
+        "median": 46935.0,
+        "p90": 53559,
+        "max": 59061,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 120,
+        "median": 22686.5,
+        "p90": 87624,
+        "max": 120607,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 120,
+        "median": 18966.5,
+        "p90": 21827,
+        "max": 25633,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "markdown",
+    "size": "large",
+    "mode": "narrow",
+    "documents": 1,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 95.34925001207739,
+        "p90": 103.15524999168701,
+        "max": 111.40516700106673
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 95.17104200494941,
+        "p90": 102.98337499261834,
+        "max": 111.23945799772628
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 6.483122,
+        "p90": 6.540344,
+        "max": 6.540344
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 556.90625,
+        "p90": 561.875,
+        "max": 561.875
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 96.16339550120756,
+        "p90": 103.76883301069029,
+        "max": 111.09229200519621
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 96.00456249609124,
+        "p90": 103.5882500000298,
+        "max": 110.91687501175329
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 6.500907,
+        "p90": 6.557666,
+        "max": 6.557666
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 558.65625,
+        "p90": 560.328125,
+        "max": 560.328125
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 95.62522900523618,
+        "candidate": 96.71652049291879,
+        "delta_percent": 1.1412171233836865
+      },
+      {
+        "repetition": 1,
+        "baseline": 95.2125624899054,
+        "candidate": 95.73687499505468,
+        "delta_percent": 0.5506757631954962
+      },
+      {
+        "repetition": 2,
+        "baseline": 94.73420849826653,
+        "candidate": 95.15362499223556,
+        "delta_percent": 0.4427297178259737
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 30,
+        "median": 7811.5,
+        "p90": 13679,
+        "max": 23849,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 30,
+        "median": 8601.0,
+        "p90": 13719,
+        "max": 23909,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 30,
+        "median": 21672.5,
+        "p90": 21976,
+        "max": 22183,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 30,
+        "median": 40865.0,
+        "p90": 45277,
+        "max": 56658,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 30,
+        "median": 7065.0,
+        "p90": 7254,
+        "max": 7343,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 30,
+        "median": 38298.5,
+        "p90": 38992,
+        "max": 40301,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 30,
+        "median": 25554.0,
+        "p90": 25962,
+        "max": 26939,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 30,
+        "median": 4778.0,
+        "p90": 4873,
+        "max": 4894,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 30,
+        "median": 11756.0,
+        "p90": 12020,
+        "max": 12413,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "markdown",
+    "size": "large",
+    "mode": "narrow",
+    "documents": 4,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 232.11306300072465,
+        "p90": 245.82366598770022,
+        "max": 254.7642919817008
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 212.38933299900964,
+        "p90": 236.1883329867851,
+        "max": 254.11312500364147
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 36.103458,
+        "p90": 36.586343,
+        "max": 36.586343
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 1056.359375,
+        "p90": 1286.6875,
+        "max": 1286.6875
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 228.7329380051233,
+        "p90": 239.44666699389927,
+        "max": 257.75191700086
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 208.54472900100518,
+        "p90": 231.49783301050775,
+        "max": 256.98887498583645
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 35.662255,
+        "p90": 35.710667,
+        "max": 35.710667
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 1438.03125,
+        "p90": 1454.4375,
+        "max": 1454.4375
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 229.81047950452194,
+        "candidate": 225.98714550258592,
+        "delta_percent": -1.6636900154332501
+      },
+      {
+        "repetition": 1,
+        "baseline": 231.14202049328014,
+        "candidate": 229.99491699738428,
+        "delta_percent": -0.49627648553379755
+      },
+      {
+        "repetition": 2,
+        "baseline": 233.3918959920993,
+        "candidate": 229.8783129954245,
+        "delta_percent": -1.5054434438433795
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 120,
+        "median": 9692.0,
+        "p90": 17248,
+        "max": 29968,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 120,
+        "median": 9747.0,
+        "p90": 18347,
+        "max": 34534,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 120,
+        "median": 27941.5,
+        "p90": 28496,
+        "max": 29691,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 120,
+        "median": 59073.0,
+        "p90": 77467,
+        "max": 97863,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 120,
+        "median": 11420.0,
+        "p90": 16121,
+        "max": 18775,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 120,
+        "median": 57745.5,
+        "p90": 85207,
+        "max": 107274,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 120,
+        "median": 36812.0,
+        "p90": 42410,
+        "max": 46637,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 120,
+        "median": 18055.5,
+        "p90": 67654,
+        "max": 91820,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 120,
+        "median": 15539.5,
+        "p90": 17464,
+        "max": 22741,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "markdown",
+    "size": "large",
+    "mode": "wildcard",
+    "documents": 1,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 98.07610399730038,
+        "p90": 109.07395899994299,
+        "max": 116.64512500283308
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 97.90977100783493,
+        "p90": 108.89979201601818,
+        "max": 116.4739579835441
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 7.179227,
+        "p90": 7.357273999999999,
+        "max": 7.357273999999999
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 330.625,
+        "p90": 567.234375,
+        "max": 567.234375
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 97.98039599263575,
+        "p90": 106.53929199906997,
+        "max": 119.49933299911208
+      },
+      "requests_ms": {
+        "n": 90,
+        "median": 97.81806249520741,
+        "p90": 106.3650420110207,
+        "max": 119.31583299883641
+      },
+      "statuses": {
+        "ok": 90
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 7.20039,
+        "p90": 7.246608,
+        "max": 7.246608
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 551.40625,
+        "p90": 552.265625,
+        "max": 552.265625
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 99.95591649203561,
+        "candidate": 98.83002100104932,
+        "delta_percent": -1.1263920441127673
+      },
+      {
+        "repetition": 1,
+        "baseline": 95.94249949441291,
+        "candidate": 98.75008300878108,
+        "delta_percent": 2.92631891931443
+      },
+      {
+        "repetition": 2,
+        "baseline": 98.07610399730038,
+        "candidate": 96.92987499875017,
+        "delta_percent": -1.1687138373499883
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 30,
+        "median": 7856.5,
+        "p90": 13537,
+        "max": 24051,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 30,
+        "median": 10102.5,
+        "p90": 13578,
+        "max": 24094,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 30,
+        "median": 21967.5,
+        "p90": 22593,
+        "max": 24180,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 30,
+        "median": 41345.0,
+        "p90": 46540,
+        "max": 56724,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 30,
+        "median": 7026.5,
+        "p90": 7338,
+        "max": 7530,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 30,
+        "median": 38176.0,
+        "p90": 40272,
+        "max": 40778,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 30,
+        "median": 25488.0,
+        "p90": 26857,
+        "max": 27322,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 30,
+        "median": 4759.0,
+        "p90": 4877,
+        "max": 4967,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 30,
+        "median": 11668.0,
+        "p90": 12551,
+        "max": 13166,
+        "incomplete": 0
+      }
+    }
+  },
+  {
+    "language": "markdown",
+    "size": "large",
+    "mode": "wildcard",
+    "documents": 4,
+    "baseline": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 282.9461455112323,
+        "p90": 679.1776659956668,
+        "max": 1059.9485420098063
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 234.73156249383464,
+        "p90": 431.1771249922458,
+        "max": 1059.2317910050042
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 43.876674,
+        "p90": 56.957757,
+        "max": 56.957757
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 1064.765625,
+        "p90": 1083.15625,
+        "max": 1083.15625
+      }
+    },
+    "candidate": {
+      "cycles_ms": {
+        "n": 90,
+        "median": 263.71441698574927,
+        "p90": 593.7824999855366,
+        "max": 1147.3719580098987
+      },
+      "requests_ms": {
+        "n": 360,
+        "median": 220.88075001374818,
+        "p90": 375.62283300212584,
+        "max": 1146.788165991893
+      },
+      "statuses": {
+        "ok": 360
+      },
+      "session_cpu_seconds": {
+        "n": 3,
+        "median": 44.388858,
+        "p90": 47.500829,
+        "max": 47.500829
+      },
+      "maxrss_mib": {
+        "n": 3,
+        "median": 1057.96875,
+        "p90": 1080.84375,
+        "max": 1080.84375
+      }
+    },
+    "pairs": [
+      {
+        "repetition": 0,
+        "baseline": 243.26306249713525,
+        "candidate": 259.69118748616893,
+        "delta_percent": 6.753234469876479
+      },
+      {
+        "repetition": 1,
+        "baseline": 260.8299374842318,
+        "candidate": 255.47529198229313,
+        "delta_percent": -2.0529259614849082
+      },
+      {
+        "repetition": 2,
+        "baseline": 357.30602049443405,
+        "candidate": 344.26660450117197,
+        "delta_percent": -3.649369236829081
+      }
+    ],
+    "phases_us": {
+      "parse": {
+        "n": 120,
+        "median": 19595.5,
+        "p90": 39870,
+        "max": 62694,
+        "incomplete": 0
+      },
+      "parse_await": {
+        "n": 120,
+        "median": 20146.5,
+        "p90": 39950,
+        "max": 62747,
+        "incomplete": 0
+      },
+      "discovery": {
+        "n": 120,
+        "median": 39302.0,
+        "p90": 44357,
+        "max": 51124,
+        "incomplete": 0
+      },
+      "snapshot_wait": {
+        "n": 120,
+        "median": 83783.5,
+        "p90": 108966,
+        "max": 146430,
+        "incomplete": 0
+      },
+      "resolution": {
+        "n": 120,
+        "median": 16365.0,
+        "p90": 19880,
+        "max": 23765,
+        "incomplete": 0
+      },
+      "compute": {
+        "n": 120,
+        "median": 83507.5,
+        "p90": 143186,
+        "max": 193416,
+        "incomplete": 0
+      },
+      "host_tokens": {
+        "n": 120,
+        "median": 52956.0,
+        "p90": 58960,
+        "max": 64266,
+        "incomplete": 0
+      },
+      "injection_tokens": {
+        "n": 120,
+        "median": 19846.0,
+        "p90": 120817,
+        "max": 169230,
+        "incomplete": 0
+      },
+      "finalize": {
+        "n": 120,
+        "median": 22720.5,
+        "p90": 25964,
+        "max": 28927,
+        "incomplete": 0
+      }
+    }
+  }
+]

--- a/benches/results/discovery-2026-09-08/test_summarize.py
+++ b/benches/results/discovery-2026-09-08/test_summarize.py
@@ -1,0 +1,344 @@
+"""Check report contracts with small synthetic workloads, independent of raw archives."""
+import json
+from pathlib import Path
+import sys
+import subprocess
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).parent))
+from summarize import distribution, summarize
+from validate_retained import validate
+
+
+class DistributionTest(unittest.TestCase):
+    def test_p90_excludes_a_lone_outlier(self):
+        self.assertEqual(distribution([100, 1, 10, 3, 9, 2, 8, 4, 7, 5, 6]),
+                         {"n": 11, "median": 6, "p90": 10, "max": 100})
+
+
+class ComparisonEligibilityTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.write_workload(documents=1)
+
+    def write_workload(self, documents, mode="native"):
+        # Three cycles make medians explicit. Logged runs are deliberately much
+        # slower, so including them in A/B statistics changes the expected result.
+        matrix = {"status": "complete", "arguments": {
+            "sizes": ["small"], "modes": [mode], "documents": [documents],
+            "repeats": 1, "requests": 3, "warmup": 0,
+            "inputs": "/profile", "output": "/results"},
+            "binaries": {variant: {"path": "/bin/" + variant, "sha256": "synthetic-" + variant}
+                         for variant in ("baseline", "candidate")},
+            "inputs": {"runtime": "/runtime", "fixtures": [
+                {"path": "rust-small.rs", "sha256": "rust-fixture"},
+                {"path": "markdown-small.md", "sha256": "markdown-fixture"}]}, "runs": []}
+        injections = {("rust", "wildcard"): ("comment",),
+                      ("markdown", "narrow"): ("lua",),
+                      ("markdown", "wildcard"): ("markdown_inline", "lua")}
+        for language, extension in (("rust", "rs"), ("markdown", "md")):
+            uris = [f"file:///profile/input-{index}.{extension}?kakehashi-profile-document={index}"
+                    for index in range(documents)]
+            opened = []
+            for index, uri in enumerate(uris):
+                if mode == "wildcard":
+                    opened.append({"uri": uri, "language": language})
+                for injected in injections.get((language, mode), ()):
+                    opened.append({"uri": f"file:///profile/kakehashi-virtual-uri-region-{index}-{injected}.{injected}"
+                                          f"?kakehashi-profile-document={index}",
+                                   "language": injected})
+            for variant, profile, seconds in (("baseline", False, [0.01, 0.02, 0.03]),
+                                               ("candidate", False, [0.02, 0.04, 0.06]),
+                                               ("candidate", True, [0.1, 0.2, 0.3])):
+                name = f"{language}-small-{mode}-d{documents}-{variant}-0"
+                if profile:
+                    name += "-profile"
+                matrix["runs"].append({"name": name, "language": language, "size": "small",
+                                       "mode": mode, "documents": documents, "variant": variant,
+                                       "repetition": 0, "profile": profile, "status": "complete",
+                                       "command": ["python3", "drive.py", "--file",
+                                           f"/profile/{language}-small.{extension}",
+                                           "--json-output", f"/results/{name}.json"],
+                                       "peers": [{"opened_documents": opened}] if opened else []})
+                result = {"binary_sha256": "synthetic-" + variant,
+                          "fixture_sha256": language + "-fixture",
+                          "arguments": {"bin": "/bin/" + variant,
+                              "file": f"/profile/{language}-small.{extension}",
+                              "server_arg": ["--config-file", f"/profile/{mode}.toml"],
+                              "data_dir": "/runtime", "requests": 3, "documents": documents,
+                              "warmup": 0, "edits": 1, "edit_delay_ms": 0,
+                              "tag_document_uris": True, "json_output": f"/results/{name}.json"},
+                          "document_uris": uris, "cycle_seconds": seconds,
+                          "request_samples": {"textDocument/semanticTokens/full": [
+                              {"uri": uri, "status": "ok", "token_count": 7 + cycle,
+                               "seconds": duration / 2, "wire_bytes": 1024}
+                              for cycle, duration in enumerate(seconds) for uri in uris]},
+                          "children_user_seconds": 1, "children_system_seconds": 2,
+                          "children_maxrss_bytes": 8 * 1024**2, "server_warnings_and_errors": []}
+                (self.root / (name + ".json")).write_text(json.dumps(result))
+                if profile:
+                    phases = [{"phase": "discovery", "elapsed_us": 100, "details": "completed=true"},
+                              {"phase": "discovery", "elapsed_us": 300, "details": "completed=true"},
+                              {"phase": "host_tokens", "elapsed_us": 500, "details": ""}]
+                    (self.root / (name + ".phases.json")).write_text(json.dumps(phases))
+        (self.root / "matrix.json").write_text(json.dumps(matrix))
+        self.sample_file = self.root / f"rust-small-{mode}-d{documents}-baseline-0.json"
+
+    def change_result(self, change):
+        result = json.loads(self.sample_file.read_text())
+        change(result)
+        self.sample_file.write_text(json.dumps(result))
+
+    def test_failed_final_verification_cannot_produce_a_comparison(self):
+        path = self.root / "matrix.json"
+        for status in ("running", "failed"):
+            with self.subTest(status=status):
+                matrix = json.loads(path.read_text())
+                matrix["status"] = status
+                path.write_text(json.dumps(matrix))
+                with self.assertRaisesRegex(ValueError, "final verification"):
+                    summarize(self.root)
+
+    def test_unattested_legacy_matrix_is_rejected(self):
+        path = self.root / "matrix.json"
+        matrix = json.loads(path.read_text())
+        matrix.pop("status")
+        path.write_text(json.dumps(matrix))
+        with self.assertRaisesRegex(ValueError, "final verification"):
+            summarize(self.root)
+
+    def duplicate_record(self):
+        path = self.root / "matrix.json"
+        matrix = json.loads(path.read_text())
+        matrix["runs"][-1] = dict(matrix["runs"][0])
+        path.write_text(json.dumps(matrix))
+
+    def test_duplicate_cannot_replace_a_missing_scenario(self):
+        self.duplicate_record()
+        with self.assertRaisesRegex(ValueError, "scenario"):
+            summarize(self.root)
+
+    def test_artifact_names_cannot_alias_another_run(self):
+        path = self.root / "matrix.json"
+        matrix = json.loads(path.read_text())
+        matrix["runs"][0]["name"] = matrix["runs"][1]["name"]
+        path.write_text(json.dumps(matrix))
+        with self.assertRaisesRegex(ValueError, "artifact name"):
+            summarize(self.root)
+
+    def test_retained_audit_also_rejects_duplicate_scenarios(self):
+        self.duplicate_record()
+        output = self.root / "audit.json"
+        result = subprocess.run([
+            sys.executable, str(Path(__file__).with_name("validate_retained.py")),
+            str(self.root), str(output),
+        ], capture_output=True, text=True, timeout=10)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("scenario", result.stderr)
+        self.assertFalse(output.exists())
+
+    def test_successes_produce_expected_comparison_and_audit(self):
+        rows = summarize(self.root)
+        self.assertEqual(len(rows), 2)
+        row = rows[0]
+        self.assertEqual(row["baseline"]["cycles_ms"], {"n": 3, "median": 20, "p90": 30, "max": 30})
+        self.assertEqual(row["candidate"]["cycles_ms"], {"n": 3, "median": 40, "p90": 60, "max": 60})
+        self.assertEqual(row["baseline"]["requests_ms"], {"n": 3, "median": 10, "p90": 15, "max": 15})
+        self.assertEqual(row["pairs"], [{"repetition": 0, "baseline": 20, "candidate": 40,
+                                        "delta_percent": 100}])
+        self.assertEqual(row["baseline"]["session_cpu_seconds"]["median"], 3)
+        self.assertEqual(row["baseline"]["maxrss_mib"]["median"], 8)
+        self.assertEqual(row["phases_us"]["discovery"],
+                         {"n": 2, "median": 200, "p90": 300, "max": 300, "incomplete": 0})
+        self.assertEqual(row["phases_us"]["host_tokens"]["median"], 500)
+        audit = validate(self.root)
+        self.assertEqual(audit["statuses"], {"ok": 18})
+        self.assertEqual(audit["minimum_token_count"], 7)
+
+    def test_complete_multi_document_workloads_remain_comparable(self):
+        self.write_workload(documents=4)
+        rows = summarize(self.root)
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["baseline"]["cycles_ms"]["n"], 3)
+        self.assertEqual(rows[0]["baseline"]["requests_ms"]["n"], 12)
+        self.assertEqual(validate(self.root)["statuses"], {"ok": 72})
+
+    def test_truncated_cycles_cannot_produce_a_comparison(self):
+        self.change_result(lambda result: result["cycle_seconds"].pop())
+        with self.assertRaisesRegex(ValueError, "cycle count"):
+            summarize(self.root)
+
+    def test_truncated_responses_cannot_produce_a_comparison(self):
+        self.change_result(lambda result: result["request_samples"]["textDocument/semanticTokens/full"].pop())
+        with self.assertRaisesRegex(ValueError, "response count"):
+            summarize(self.root)
+
+    def test_document_inventory_cannot_duplicate_a_missing_uri(self):
+        self.write_workload(documents=4)
+        self.change_result(lambda result: result["document_uris"].__setitem__(1, result["document_uris"][0]))
+        with self.assertRaisesRegex(ValueError, "document inventory"):
+            summarize(self.root)
+
+    def test_response_totals_cannot_mask_missing_document_work(self):
+        self.write_workload(documents=4)
+
+        def duplicate_uri(result):
+            first, second = result["document_uris"][:2]
+            for sample in result["request_samples"]["textDocument/semanticTokens/full"]:
+                if sample["uri"] == second:
+                    sample["uri"] = first
+
+        self.change_result(duplicate_uri)
+        with self.assertRaisesRegex(ValueError, "per-document response count"):
+            summarize(self.root)
+
+    def test_profile_workload_must_also_be_complete(self):
+        self.sample_file = self.root / "rust-small-native-d1-candidate-0-profile.json"
+        self.change_result(lambda result: result["cycle_seconds"].pop())
+        with self.assertRaisesRegex(ValueError, "cycle count"):
+            summarize(self.root)
+
+    def test_retained_audit_also_rejects_truncated_workload(self):
+        self.change_result(lambda result: result["cycle_seconds"].pop())
+        output = self.root / "audit.json"
+        result = subprocess.run([
+            sys.executable, str(Path(__file__).with_name("validate_retained.py")),
+            str(self.root), str(output),
+        ], capture_output=True, text=True, timeout=10)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("cycle count", result.stderr)
+        self.assertFalse(output.exists())
+
+    def test_cancellation_cannot_produce_a_comparison(self):
+        self.change_result(lambda result: result["request_samples"]["textDocument/semanticTokens/full"][0].update(status="canceled"))
+        with self.assertRaisesRegex(ValueError, "successful and nonempty"):
+            summarize(self.root)
+
+    def test_empty_success_cannot_produce_a_comparison(self):
+        self.change_result(lambda result: result["request_samples"]["textDocument/semanticTokens/full"][0].update(token_count=0))
+        with self.assertRaisesRegex(ValueError, "successful and nonempty"):
+            summarize(self.root)
+
+    def test_missing_explicit_count_cannot_use_response_size(self):
+        self.change_result(lambda result: result["request_samples"]["textDocument/semanticTokens/full"][0].pop("token_count"))
+        with self.assertRaisesRegex(ValueError, "successful and nonempty"):
+            summarize(self.root)
+
+    def test_profile_empty_response_is_rejected_by_both_consumers(self):
+        self.sample_file = self.root / "rust-small-native-d1-candidate-0-profile.json"
+        self.change_result(lambda result: result["request_samples"]["textDocument/semanticTokens/full"][0].update(token_count=0))
+        for consumer in (summarize, validate):
+            with self.subTest(consumer=consumer.__name__):
+                with self.assertRaisesRegex(ValueError, "successful and nonempty"):
+                    consumer(self.root)
+
+    def test_per_host_bridge_evidence_remains_valid(self):
+        for mode in ("narrow", "wildcard"):
+            with self.subTest(mode=mode):
+                self.write_workload(documents=4, mode=mode)
+                self.assertEqual(len(summarize(self.root)), 2)
+                self.assertEqual(len(validate(self.root)["runs"]), 6)
+
+    def change_markdown_peer(self, mode, change, profile=False):
+        self.write_workload(documents=4, mode=mode)
+        path = self.root / "matrix.json"
+        matrix = json.loads(path.read_text())
+        run = next(run for run in matrix["runs"]
+                   if run["language"] == "markdown" and run["profile"] == profile)
+        change(run)
+        path.write_text(json.dumps(matrix))
+
+    def require_bridge_rejection(self):
+        for consumer in (summarize, validate):
+            with self.subTest(consumer=consumer.__name__):
+                with self.assertRaisesRegex(ValueError, "bridge"):
+                    consumer(self.root)
+
+    def test_one_hosts_injections_cannot_cover_other_hosts(self):
+        def collapse(run):
+            for peer in run["peers"]:
+                for document in peer["opened_documents"]:
+                    if document["language"] == "lua":
+                        document["uri"] = document["uri"].split("?", 1)[0] + "?kakehashi-profile-document=0"
+        for mode in ("narrow", "wildcard"):
+            with self.subTest(mode=mode):
+                self.change_markdown_peer(mode, collapse)
+                self.require_bridge_rejection()
+
+    def test_wildcard_injections_do_not_replace_a_host_open(self):
+        def remove_host(run):
+            for peer in run["peers"]:
+                peer["opened_documents"] = [document for document in peer["opened_documents"]
+                                            if not (document["language"] == "markdown" and
+                                                    document["uri"].endswith("kakehashi-profile-document=1"))]
+        self.change_markdown_peer("wildcard", remove_host)
+        self.require_bridge_rejection()
+
+    def test_profile_run_requires_per_host_bridge_evidence(self):
+        def remove_injections(run):
+            for peer in run["peers"]:
+                peer["opened_documents"] = [document for document in peer["opened_documents"]
+                                            if document["language"] != "lua"]
+        self.change_markdown_peer("narrow", remove_injections, profile=True)
+        self.require_bridge_rejection()
+
+    def test_explicit_token_counts_support_new_binaries(self):
+        def change(result):
+            result["binary_sha256"] = "another-server"
+            for sample in result["request_samples"]["textDocument/semanticTokens/full"]:
+                sample["token_count"] = 1
+        self.change_result(change)
+        matrix_path = self.root / "matrix.json"
+        matrix = json.loads(matrix_path.read_text())
+        matrix["binaries"]["baseline"]["sha256"] = "another-server"
+        matrix_path.write_text(json.dumps(matrix))
+        for run in matrix["runs"]:
+            if run["variant"] == "baseline":
+                path = self.root / (run["name"] + ".json")
+                result = json.loads(path.read_text())
+                result["binary_sha256"] = "another-server"
+                path.write_text(json.dumps(result))
+        self.assertEqual(len(summarize(self.root)), 2)
+
+    def test_relative_matrix_cli_paths_keep_recorded_invocation_identity(self):
+        path = self.root / "matrix.json"
+        matrix = json.loads(path.read_text())
+        matrix["arguments"].update(inputs="../profile", output="results")
+        path.write_text(json.dumps(matrix))
+        self.assertEqual(len(summarize(self.root)), 2)
+        self.assertEqual(validate(self.root)["statuses"], {"ok": 18})
+
+    def test_results_are_bound_to_the_declared_measurement(self):
+        original = self.sample_file.read_text()
+        mutations = [
+            lambda r: r.update(binary_sha256="other-binary"),
+            lambda r: r.update(fixture_sha256="other-fixture"),
+            lambda r: r["arguments"].update(file="/profile/rust-large.rs"),
+            lambda r: r["arguments"].update(server_arg=["--config-file", "/profile/wildcard.toml"]),
+            lambda r: r["arguments"].update(warmup=99),
+            lambda r: r["arguments"].update(json_output="/results/another-run.json"),
+        ]
+        for index, mutate in enumerate(mutations):
+            with self.subTest(mutation=index):
+                self.sample_file.write_text(original)
+                self.change_result(mutate)
+                for consumer in (summarize, validate):
+                    with self.assertRaisesRegex(ValueError, "identity"):
+                        consumer(self.root)
+
+    def test_renamed_results_cannot_replace_another_run(self):
+        for target in ("markdown-small-native-d1-baseline-0",
+                       "rust-small-native-d1-candidate-0-profile"):
+            with self.subTest(target=target):
+                self.write_workload(documents=1)
+                (self.root / (target + ".json")).write_text(self.sample_file.read_text())
+                for consumer in (summarize, validate):
+                    with self.assertRaisesRegex(ValueError, "identity"):
+                        consumer(self.root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benches/results/discovery-2026-09-08/validate_retained.py
+++ b/benches/results/discovery-2026-09-08/validate_retained.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Audit explicit token counts and per-host bridge evidence in the retained matrix."""
+import argparse
+from collections import Counter
+import json
+from pathlib import Path
+
+from matrix_contract import bridge_coverage, load_matrix, require_identity, require_comparable, require_workload
+
+
+def validate(root):
+    matrix = load_matrix(root / "matrix.json")
+    audit = {"nonempty_basis": "Explicit per-response token counts; not a latest-edit token oracle.",
+             "bridge_basis": "Expected host/injection opens for each tagged host URI over the whole session, including warmup.",
+             "runs": []}
+    statuses, warnings = Counter(), Counter()
+    minimum_tokens = None
+    for run in matrix["runs"]:
+        result = json.loads((root / (run["name"] + ".json")).read_text())
+        require_identity(matrix, run, result)
+        require_workload(run, result, matrix["arguments"]["requests"])
+        require_comparable(run["name"], result)
+        coverage = bridge_coverage(run, result)
+        samples = result["request_samples"]["textDocument/semanticTokens/full"]
+        uris = {}
+        for uri in result["document_uris"]:
+            selected = [sample for sample in samples if sample["uri"] == uri]
+            uris[uri] = {"statuses": dict(Counter(sample["status"] for sample in selected)),
+                         "minimum_token_count": min(sample["token_count"] for sample in selected)}
+        statuses.update(sample["status"] for sample in samples)
+        run_minimum = min(sample["token_count"] for sample in samples)
+        minimum_tokens = run_minimum if minimum_tokens is None else min(minimum_tokens, run_minimum)
+        warnings.update(item["message"] for item in result["server_warnings_and_errors"])
+        if any(item["type"] == 1 for item in result["server_warnings_and_errors"]):
+            raise ValueError(f"Server error in {run['name']}")
+        audit["runs"].append({"name": run["name"], "uris": uris, "bridge_coverage": coverage})
+    audit.update(statuses=dict(statuses), minimum_token_count=minimum_tokens, warnings=dict(warnings))
+    return audit
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("results", type=Path)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+    args.output.write_text(json.dumps(validate(args.results), indent=2) + "\n", encoding="utf-8")

--- a/benches/results/discovery-2026-09-08/validation.json
+++ b/benches/results/discovery-2026-09-08/validation.json
@@ -1,0 +1,8583 @@
+{
+  "nonempty_basis": "Explicit per-response token counts; not a latest-edit token oracle.",
+  "bridge_basis": "Expected host/injection opens for each tagged host URI over the whole session, including warmup.",
+  "runs": [
+    {
+      "name": "rust-small-native-d1-baseline-0",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-native-d1-candidate-0",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-native-d1-candidate-1",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-native-d1-baseline-1",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-native-d1-baseline-2",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-native-d1-candidate-2",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-native-d1-candidate-0-profile",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-native-d4-candidate-0",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-native-d4-baseline-0",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-native-d4-baseline-1",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-native-d4-candidate-1",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-native-d4-candidate-2",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-native-d4-baseline-2",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-native-d4-candidate-0-profile",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-narrow-d1-baseline-0",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-narrow-d1-candidate-0",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-narrow-d1-candidate-1",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-narrow-d1-baseline-1",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-narrow-d1-baseline-2",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-narrow-d1-candidate-2",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-narrow-d1-candidate-0-profile",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-narrow-d4-candidate-0",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-narrow-d4-baseline-0",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-narrow-d4-baseline-1",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-narrow-d4-candidate-1",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-narrow-d4-candidate-2",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-narrow-d4-baseline-2",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-narrow-d4-candidate-0-profile",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-small-wildcard-d1-baseline-0",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-small-wildcard-d1-candidate-0",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-small-wildcard-d1-candidate-1",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-small-wildcard-d1-baseline-1",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-small-wildcard-d1-baseline-2",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-small-wildcard-d1-candidate-2",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-small-wildcard-d1-candidate-0-profile",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-small-wildcard-d4-candidate-0",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-small-wildcard-d4-baseline-0",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-small-wildcard-d4-baseline-1",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-small-wildcard-d4-candidate-1",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-small-wildcard-d4-candidate-2",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-small-wildcard-d4-baseline-2",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-small-wildcard-d4-candidate-0-profile",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 275
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-common-native-d1-baseline-0",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-native-d1-candidate-0",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-native-d1-candidate-1",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-native-d1-baseline-1",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-native-d1-baseline-2",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-native-d1-candidate-2",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-native-d1-candidate-0-profile",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-native-d4-candidate-0",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-native-d4-baseline-0",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-native-d4-baseline-1",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-native-d4-candidate-1",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-native-d4-candidate-2",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-native-d4-baseline-2",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-native-d4-candidate-0-profile",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-narrow-d1-baseline-0",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-narrow-d1-candidate-0",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-narrow-d1-candidate-1",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-narrow-d1-baseline-1",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-narrow-d1-baseline-2",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-narrow-d1-candidate-2",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-narrow-d1-candidate-0-profile",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-narrow-d4-candidate-0",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-narrow-d4-baseline-0",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-narrow-d4-baseline-1",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-narrow-d4-candidate-1",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-narrow-d4-candidate-2",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-narrow-d4-baseline-2",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-narrow-d4-candidate-0-profile",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-common-wildcard-d1-baseline-0",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-common-wildcard-d1-candidate-0",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-common-wildcard-d1-candidate-1",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-common-wildcard-d1-baseline-1",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-common-wildcard-d1-baseline-2",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-common-wildcard-d1-candidate-2",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-common-wildcard-d1-candidate-0-profile",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-common-wildcard-d4-candidate-0",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-common-wildcard-d4-baseline-0",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-common-wildcard-d4-baseline-1",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-common-wildcard-d4-candidate-1",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-common-wildcard-d4-candidate-2",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-common-wildcard-d4-baseline-2",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-common-wildcard-d4-candidate-0-profile",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 4280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-large-native-d1-baseline-0",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-native-d1-candidate-0",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-native-d1-candidate-1",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-native-d1-baseline-1",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-native-d1-baseline-2",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-native-d1-candidate-2",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-native-d1-candidate-0-profile",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-native-d4-candidate-0",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-native-d4-baseline-0",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-native-d4-baseline-1",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-native-d4-candidate-1",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-native-d4-candidate-2",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-native-d4-baseline-2",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-native-d4-candidate-0-profile",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-narrow-d1-baseline-0",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-narrow-d1-candidate-0",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-narrow-d1-candidate-1",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-narrow-d1-baseline-1",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-narrow-d1-baseline-2",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-narrow-d1-candidate-2",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-narrow-d1-candidate-0-profile",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-narrow-d4-candidate-0",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-narrow-d4-baseline-0",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-narrow-d4-baseline-1",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-narrow-d4-candidate-1",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-narrow-d4-candidate-2",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-narrow-d4-baseline-2",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-narrow-d4-candidate-0-profile",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "rust-large-wildcard-d1-baseline-0",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-large-wildcard-d1-candidate-0",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-large-wildcard-d1-candidate-1",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-large-wildcard-d1-baseline-1",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-large-wildcard-d1-baseline-2",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-large-wildcard-d1-candidate-2",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-large-wildcard-d1-candidate-0-profile",
+      "uris": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-large-wildcard-d4-candidate-0",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-large-wildcard-d4-baseline-0",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-large-wildcard-d4-baseline-1",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-large-wildcard-d4-candidate-1",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-large-wildcard-d4-candidate-2",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-large-wildcard-d4-baseline-2",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "rust-large-wildcard-d4-candidate-0-profile",
+      "uris": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 135288
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.rs?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-1.rs?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-2.rs?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        },
+        "file:///profile/input-3.rs?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "comment"
+          ],
+          "injected_languages": [
+            "comment",
+            "rust"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-native-d1-baseline-0",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-small-native-d1-candidate-0",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-small-native-d1-candidate-1",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-small-native-d1-baseline-1",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-small-native-d1-baseline-2",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-small-native-d1-candidate-2",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-small-native-d1-candidate-0-profile",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-small-native-d4-candidate-0",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-small-native-d4-baseline-0",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-small-native-d4-baseline-1",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-small-native-d4-candidate-1",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-small-native-d4-candidate-2",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-small-native-d4-baseline-2",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-small-native-d4-candidate-0-profile",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-small-narrow-d1-baseline-0",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-narrow-d1-candidate-0",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-narrow-d1-candidate-1",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-narrow-d1-baseline-1",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-narrow-d1-baseline-2",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-narrow-d1-candidate-2",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-narrow-d1-candidate-0-profile",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-narrow-d4-candidate-0",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-narrow-d4-baseline-0",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-narrow-d4-baseline-1",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-narrow-d4-candidate-1",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-narrow-d4-candidate-2",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-narrow-d4-baseline-2",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-narrow-d4-candidate-0-profile",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-wildcard-d1-baseline-0",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-wildcard-d1-candidate-0",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-wildcard-d1-candidate-1",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-wildcard-d1-baseline-1",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-wildcard-d1-baseline-2",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-wildcard-d1-candidate-2",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-wildcard-d1-candidate-0-profile",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-wildcard-d4-candidate-0",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-wildcard-d4-baseline-0",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-wildcard-d4-baseline-1",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-wildcard-d4-candidate-1",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-wildcard-d4-candidate-2",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-wildcard-d4-baseline-2",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-small-wildcard-d4-candidate-0-profile",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 120
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-native-d1-baseline-0",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-common-native-d1-candidate-0",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-common-native-d1-candidate-1",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-common-native-d1-baseline-1",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-common-native-d1-baseline-2",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-common-native-d1-candidate-2",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-common-native-d1-candidate-0-profile",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-common-native-d4-candidate-0",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-common-native-d4-baseline-0",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-common-native-d4-baseline-1",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-common-native-d4-candidate-1",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-common-native-d4-candidate-2",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-common-native-d4-baseline-2",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-common-native-d4-candidate-0-profile",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-common-narrow-d1-baseline-0",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-narrow-d1-candidate-0",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-narrow-d1-candidate-1",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-narrow-d1-baseline-1",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-narrow-d1-baseline-2",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-narrow-d1-candidate-2",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-narrow-d1-candidate-0-profile",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-narrow-d4-candidate-0",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-narrow-d4-baseline-0",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-narrow-d4-baseline-1",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-narrow-d4-candidate-1",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-narrow-d4-candidate-2",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-narrow-d4-baseline-2",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-narrow-d4-candidate-0-profile",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-wildcard-d1-baseline-0",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-wildcard-d1-candidate-0",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-wildcard-d1-candidate-1",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-wildcard-d1-baseline-1",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-wildcard-d1-baseline-2",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-wildcard-d1-candidate-2",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-wildcard-d1-candidate-0-profile",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-wildcard-d4-candidate-0",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-wildcard-d4-baseline-0",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-wildcard-d4-baseline-1",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-wildcard-d4-candidate-1",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-wildcard-d4-candidate-2",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-wildcard-d4-baseline-2",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-common-wildcard-d4-candidate-0-profile",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 1860
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-native-d1-baseline-0",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-large-native-d1-candidate-0",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-large-native-d1-candidate-1",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-large-native-d1-baseline-1",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-large-native-d1-baseline-2",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-large-native-d1-candidate-2",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-large-native-d1-candidate-0-profile",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-large-native-d4-candidate-0",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-large-native-d4-baseline-0",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-large-native-d4-baseline-1",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-large-native-d4-candidate-1",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-large-native-d4-candidate-2",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-large-native-d4-baseline-2",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-large-native-d4-candidate-0-profile",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {}
+    },
+    {
+      "name": "markdown-large-narrow-d1-baseline-0",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-narrow-d1-candidate-0",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-narrow-d1-candidate-1",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-narrow-d1-baseline-1",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-narrow-d1-baseline-2",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-narrow-d1-candidate-2",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-narrow-d1-candidate-0-profile",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-narrow-d4-candidate-0",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-narrow-d4-baseline-0",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-narrow-d4-baseline-1",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-narrow-d4-candidate-1",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-narrow-d4-candidate-2",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-narrow-d4-baseline-2",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-narrow-d4-candidate-0-profile",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": false,
+          "expected_injected_languages": [
+            "lua"
+          ],
+          "injected_languages": [
+            "lua"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-wildcard-d1-baseline-0",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-wildcard-d1-candidate-0",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-wildcard-d1-candidate-1",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-wildcard-d1-baseline-1",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-wildcard-d1-baseline-2",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-wildcard-d1-candidate-2",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-wildcard-d1-candidate-0-profile",
+      "uris": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-wildcard-d4-candidate-0",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-wildcard-d4-baseline-0",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-wildcard-d4-baseline-1",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-wildcard-d4-candidate-1",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-wildcard-d4-candidate-2",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-wildcard-d4-baseline-2",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    },
+    {
+      "name": "markdown-large-wildcard-d4-candidate-0-profile",
+      "uris": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "statuses": {
+            "ok": 30
+          },
+          "minimum_token_count": 58280
+        }
+      },
+      "bridge_coverage": {
+        "file:///profile/input-0.md?kakehashi-profile-document=0": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-1.md?kakehashi-profile-document=1": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-2.md?kakehashi-profile-document=2": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        },
+        "file:///profile/input-3.md?kakehashi-profile-document=3": {
+          "host_open": true,
+          "expected_injected_languages": [
+            "lua",
+            "markdown_inline"
+          ],
+          "injected_languages": [
+            "lua",
+            "markdown_inline"
+          ]
+        }
+      }
+    }
+  ],
+  "statuses": {
+    "ok": 18900
+  },
+  "minimum_token_count": 120,
+  "warnings": {
+    "Skipped invalid pattern in markdown_inline/highlights.scm (lines 48-50): Invalid arguments to set! predicate. Unexpected second capture name @_url | pattern: ((inline_link (link_destination) @_url) @_label (#set! @_...": 252,
+    "Skipped invalid pattern in markdown_inline/highlights.scm (lines 52-54): Invalid arguments to set! predicate. Unexpected second capture name @_url | pattern: ((image (link_destination) @_url) @_label (#set! @_label ...": 252,
+    "Skipped invalid pattern in markdown_inline/highlights.scm (lines 99-101): Invalid arguments to set! predicate. Unexpected second capture name @_url | pattern: ((uri_autolink) @_url (#offset! @_url 0 1 0 -1) (#set! @_...": 252
+  }
+}

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -339,12 +339,26 @@ impl CacheCoordinator {
         };
 
         // Collect all injection regions from the parsed tree
+        let profile_start = log::log_enabled!(target: "kakehashi::profile", log::Level::Debug)
+            .then(std::time::Instant::now);
         let regions = crate::language::injection::collect_all_injections_cancellable(
             &tree.root_node(),
             text,
             Some(injection_query.as_ref()),
             cancel,
-        )?;
+        );
+        if let Some(start) = profile_start {
+            log::debug!(
+                target: "kakehashi::profile",
+                "phase=discovery elapsed_us={} completed={} regions={} bytes={} uri={}",
+                start.elapsed().as_micros(),
+                regions.is_some(),
+                regions.as_ref().map_or(0, Vec::len),
+                text.len(),
+                uri,
+            );
+        }
+        let regions = regions?;
         if crate::cancel::is_cancelled(cancel) {
             return None;
         }
@@ -448,14 +462,28 @@ impl CacheCoordinator {
             // virtual content: the bridge regions and the whole-document
             // resolved regions below are two views of this single pass.
             let resolved = if build_bridge_regions {
+                let profile_start =
+                    log::log_enabled!(target: "kakehashi::profile", log::Level::Debug)
+                        .then(std::time::Instant::now);
                 let resolved = crate::language::injection::InjectionResolver::resolve_from_prebuilt_cancellable(
                     language,
                     &regions,
                     &cacheable_regions,
                     text,
                     cancel,
-                )?;
-                Some(resolved)
+                );
+                if let Some(start) = profile_start {
+                    log::debug!(
+                        target: "kakehashi::profile",
+                        "phase=resolution elapsed_us={} completed={} regions={} bytes={} uri={}",
+                        start.elapsed().as_micros(),
+                        resolved.is_some(),
+                        regions.len(),
+                        text.len(),
+                        uri,
+                    );
+                }
+                Some(resolved?)
             } else {
                 None
             };

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -397,8 +397,12 @@ impl ParseCoordinator {
     {
         use crate::error::LockResultExt;
 
+        // This is queue + parse + resume time, not isolated parser CPU time.
+        let profile_start = log::log_enabled!(target: "kakehashi::profile", log::Level::Debug)
+            .then(std::time::Instant::now);
         let parser_pool = std::sync::Arc::clone(&self.parser_pool);
         let language_name_owned = language_name.to_string();
+        let profile_uri = profile_start.map(|_| uri.clone());
         let cancel_for_work = cancel.clone();
         let result = tokio::time::timeout(
             PARSE_AWAIT_BACKSTOP,
@@ -447,8 +451,21 @@ impl ParseCoordinator {
                     // tree-less until the next edit). The awaiter above covers
                     // queue + parse with slack, so the result is not dropped.
                     let deadline = std::time::Instant::now() + PARSE_TIMEOUT;
+                    let parse_start = profile_uri.as_ref().map(|_| std::time::Instant::now());
                     let (parser, value) =
                         parse_fn(parser, deadline, attempt != 0, cancel_for_work.as_ref());
+                    if let (Some(start), Some(uri)) = (parse_start, profile_uri.as_ref()) {
+                        log::debug!(
+                            target: "kakehashi::profile",
+                            "phase=parse elapsed_us={} completed={} attempt={} bytes={} language={} uri={}",
+                            start.elapsed().as_micros(),
+                            value.is_some(),
+                            attempt,
+                            text_len,
+                            language_name_owned,
+                            uri,
+                        );
+                    }
                     match parser_pool
                         .lock()
                         .recover_poison("ParseCoordinator::parse_with_pool(release)")
@@ -465,6 +482,17 @@ impl ParseCoordinator {
         )
         .await;
 
+        if let Some(start) = profile_start {
+            log::debug!(
+                target: "kakehashi::profile",
+                "phase=parse_await elapsed_us={} completed={} bytes={} language={} uri={}",
+                start.elapsed().as_micros(),
+                matches!(&result, Ok(Some(Some(_)))),
+                text_len,
+                language_name,
+                uri,
+            );
+        }
         match result {
             // Outer Option: None = the work-unit panicked (logged with its
             // payload by the pool). Inner Option: None = no parser available

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -196,34 +196,54 @@ impl Kakehashi {
         supersede: &crate::cancel::CancelToken,
     ) -> TokenSnapshot {
         use crate::lsp::lsp_impl::snapshot_read::{SnapshotWait, TOKEN_SETTLE_BACKSTOP};
-        let wait = self.wait_for_current_snapshot(uri, TOKEN_SETTLE_BACKSTOP);
-        let outcome = match cancel_rx {
-            Some(rx) => {
-                tokio::select! {
-                    biased;
-                    // Fires on $/cancelRequest (and on forwarder teardown,
-                    // which the compute-race arms below treat as cancel too).
-                    _ = rx => return TokenSnapshot::Cancelled,
-                    // Fires when a newer request for this document flips this
-                    // request's tracker token — release the park (and its
-                    // admission slot) instead of computing a discarded result.
-                    _ = supersede.cancelled() => return TokenSnapshot::Superseded,
-                    outcome = wait => outcome,
+        let profile_start = log::log_enabled!(target: "kakehashi::profile", log::Level::Debug)
+            .then(std::time::Instant::now);
+        let result = async {
+            let wait = self.wait_for_current_snapshot(uri, TOKEN_SETTLE_BACKSTOP);
+            let outcome = match cancel_rx {
+                Some(rx) => {
+                    tokio::select! {
+                        biased;
+                        // Fires on $/cancelRequest (and on forwarder teardown,
+                        // which the compute-race arms below treat as cancel too).
+                        _ = rx => return TokenSnapshot::Cancelled,
+                        // Fires when a newer request for this document flips this
+                        // request's tracker token — release the park (and its
+                        // admission slot) instead of computing a discarded result.
+                        _ = supersede.cancelled() => return TokenSnapshot::Superseded,
+                        outcome = wait => outcome,
+                    }
                 }
-            }
-            None => {
-                tokio::select! {
-                    biased;
-                    _ = supersede.cancelled() => return TokenSnapshot::Superseded,
-                    outcome = wait => outcome,
+                None => {
+                    tokio::select! {
+                        biased;
+                        _ = supersede.cancelled() => return TokenSnapshot::Superseded,
+                        outcome = wait => outcome,
+                    }
                 }
+            };
+            match outcome {
+                SnapshotWait::Current(snapshot) => TokenSnapshot::Current(snapshot),
+                SnapshotWait::Stale => TokenSnapshot::Stale,
+                SnapshotWait::Unparsed | SnapshotWait::Gone => TokenSnapshot::Absent,
             }
-        };
-        match outcome {
-            SnapshotWait::Current(snapshot) => TokenSnapshot::Current(snapshot),
-            SnapshotWait::Stale => TokenSnapshot::Stale,
-            SnapshotWait::Unparsed | SnapshotWait::Gone => TokenSnapshot::Absent,
         }
+        .await;
+        if let Some(start) = profile_start {
+            let outcome = match &result {
+                TokenSnapshot::Current(_) => "current",
+                TokenSnapshot::Stale => "stale",
+                TokenSnapshot::Absent => "absent",
+                TokenSnapshot::Cancelled => "cancelled",
+                TokenSnapshot::Superseded => "superseded",
+            };
+            log::debug!(
+                target: "kakehashi::profile",
+                "phase=snapshot_wait elapsed_us={} outcome={} uri={}",
+                start.elapsed().as_micros(), outcome, uri,
+            );
+        }
+        result
     }
 
     pub(crate) async fn semantic_tokens_full_impl(


### PR DESCRIPTION
Merge note: compacted locally and rebased onto the latest main before merge. No raw archive or archive-adding commit is included in the ancestry introduced to main.

After the correctness fixes in #1072/#1073, discovery still traverses the whole tree, but its priority relative to tokenization needed current evidence. This adds opt-in phase timers and a reproducible edit-cycle matrix with fixed real queries, native/narrow/wildcard bridging, and one/four-document workloads. It changes no parsing or cache policy.

The retained 36-scenario, 252-run measurement found native single-document discovery medians of 31.8 ms for Rust near 1 MiB and 21.1 ms for Markdown; host tokenization was 96.3 ms and 25.7 ms respectively. Common ~32 KiB discovery was 0.94/0.56 ms. Keep host-token profiling under #895 and use #1068 for a bounded, oracle-checked discovery experiment; these measurements do not justify an unqualified discovery-first implementation.

[The report](https://github.com/atusy/kakehashi/blob/f95e0137d17e02dedbc8a0292457116df8814538/benches/results/discovery-2026-09-08/README.md) includes all scenario summaries, absolute latency, paired deltas, CPU/RSS, limitations, hashes, and the SHA-256 of an externally retained raw-data archive. The A/B comparison measures instrumentation overhead, not an optimization. Both variants use tagged host URIs so peer observations prove each document exercised its expected bridge languages; wildcard host opens are checked separately. This establishes session coverage including warmup, not fresh downstream work per edit. This full rerun supersedes the initial aggregate-only measurement using the same exact binaries and runtime. Raw archives are stored outside the repository; no public download URL is currently recorded. The summary, validation audit and provenance remain tracked.

All 18,900 measured responses completed normally with explicit positive token counts. Both report consumers validate complete scenario identities, declared cycles and per-document response counts, successful nonempty responses, and per-host bridge evidence, including logged runs. No legacy byte-size or manifest exceptions remain. The harness verifies runtime inventory, completed discovery attribution, and final input/script hashes before marking the matrix complete. Existing query warnings and mixed instrumentation deltas remain visible.

Validation: `make check`, all-target/all-feature Clippy, 3,752 library tests, 445 E2E tests, 79 integration tests, and 50 Python regression tests passed (2 library and 1 E2E ignored). The externally retained archive was verified to reproduce both summary and validation JSON exactly. Regression tests now use small self-contained synthetic fixtures and run without raw data or network access. An additional 24-run real-LSP smoke covered Rust/Markdown, narrow/wildcard and one/four-document URI association before the full matrix; regression mutations reproduce missing workload and bridge-coverage failures.

Stacked on #1073. Refs #1068 and #895. The follow-up issue remains open for the separately scoped optimization experiment.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added multi-document profiling with configurable edit delays, JSON output, semantic-token metrics, diagnostics, and resource timing.
  - Added discovery benchmark matrix runs with alternating baseline/candidate comparisons, scenario coverage, and bridge-document validation.
  - Added benchmark result summarization and comprehensive identity, workload, and comparability checks.

- **Documentation**
  - Expanded profiling guidance for reproducible measurements, phase timings, attribution fixtures, multi-document runs, and result interpretation.

- **Bug Fixes**
  - Improved retained-result validation to reject incomplete, invalid, or unverifiable benchmark data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
