### PR TITLE
refactor(parse): remove unused progress state

### DIFF
--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -283,9 +283,9 @@ binding above; ordering only governs how often a reusable discovery is *availabl
 when the request runs. In the reparse loop the order is
 `populate_injections` (discovery built, handed out, then the resolution) with the
 first `install_parse` — the tree and the discovery — landing from inside the
-populate work-unit at the hand-off, the second `install_parse` — the same
-version upgraded with the bridge / resolved regions — after the pass returns,
-then `mark_parse_finished` / `advance_watermark`
+populate work-unit at the hand-off, `complete_parse` — the same snapshot
+upgraded with the bridge / resolved regions — after the pass returns,
+then the watermark advance
 (`src/lsp/lsp_impl/coordinator/parse.rs`), and the semantic handler parks on the
 document's snapshot cell until the current version is published
 (`src/lsp/lsp_impl/text_document/semantic_tokens.rs`), so it always sees the discovery the

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -98,8 +98,9 @@ snapshot:
 SnapshotSlot { current_incarnation: u64, snapshot: Option<Arc<ParseSnapshot>> }
 ```
 
-This channel **subsumes** the current `parse_states` and `watermarks` maps, but the
-mapping is not one-to-one and must be stated precisely:
+The snapshot channel supplies parse readiness and tree availability. The unused
+`parse_states` map has been deleted; the separate ingress-ticket `watermarks`
+remain until their callers migrate. The contracts are distinct:
 
 - Two distinct predicates replace the old single `has_tree`: **`resolved`** =
   `slot.snapshot.is_some()` (a parse for this lifetime has completed at least once)
@@ -114,15 +115,16 @@ mapping is not one-to-one and must be stated precisely:
   `parsed_version` and releases first-parse waiters (who then fall through to their
   empty / `null` / `ContentModified` paths), which the old boolean `has_tree` could
   not express.
-- `parsed_version` is the watermark ticket; `current_incarnation` is the
-  per-lifetime guard.
-- `ParseState`'s three fields are each accounted for, none silently dropped:
-  `has_tree` is **replaced** by the two slot predicates above (not re-homed); the
-  **`generation`** (a monotonic parse-run counter that `mark_parse_started` bumps
-  and `mark_parse_finished` checks to reject an out-of-order finish) and the
-  **`in_progress`** flag **re-home** onto `ParseScheduler`'s per-document state
-  (which already owns the parse lifecycle), not onto the read-side slot. Deleting
-  `parse_states` is contingent on those two moves.
+- `parsed_version` is the document content version consumed by the parse;
+  `current_incarnation` is the per-lifetime guard. The separately retained
+  watermark tracks ingress writer tickets, which are not content versions.
+- The former `ParseState` fields (`has_tree`, `generation`, `in_progress`) had
+  no readers outside their own bookkeeping. They are deleted without moving
+  them to the scheduler or adding generation checks (#1063). Snapshot predicates
+  answer tree/readiness questions, and the existing scheduler owns its work.
+  Keeping or relocating the unused state would create a second lifecycle model
+  with no consumer; the existing incarnation, publication and watermark guards
+  remain responsible for their respective contracts.
 
 The store's tree writes are collapsed into `DocumentStore::install_parse` (the
 snapshot publish below inside `send_if_modified`, under the document's entry
@@ -267,7 +269,7 @@ reports currency at completion. A pass without a hand-off installs once.
 Downstream decisions use the appropriate outcome: current-tree follow-ups use
 completion-time currency; settle refresh uses the initial publication/placeholder
 upgrade and its existing live-version check. The scheduler order remains
-`populate → initial publish → optional enrichment → mark finished → downstream`.
+`populate → initial publish → optional enrichment → watermark advance → downstream`.
  A rejected publish (a racing
 edit or reopen advanced the slot) emits nothing and attaches nothing. (Two
 parses of the *same* version — an install reparse racing the edit reparse — may
@@ -625,8 +627,9 @@ inside the existing safety contracts at each step:
 - **Stage 3 — consolidation.** *Done for the tree and the seed:* `Document::tree`
   is derived from the published cell and the incremental seed from the cell plus
   the document's edit log (`Document::incremental_seed`), so the readers that
-  went through `Document::tree` / `snapshot()` read the cell. *Remaining:* delete
-  the watermark waits and `parse_states`, and prune the now-superseded passages
+  went through `Document::tree` / `snapshot()` read the cell. The unused
+  `parse_states` map is deleted without replacement. *Remaining:* delete
+  the watermark waits and prune the now-superseded passages
   (the CAS methods are already collapsed into `install_parse`)
   from per-document-parse-scheduler (its tree-clear-on-edit and watermark/epoch
   sections) per delete-on-supersede — done **here**, when the behavior actually

--- a/docs/architecture-decisions/per-document-parse-scheduler.md
+++ b/docs/architecture-decisions/per-document-parse-scheduler.md
@@ -69,17 +69,13 @@ couples concerns that are hard to reason about independently:
   (`try_parse_and_update_document` and analogues) that *writes the store*, and
   `update_document` **inserts on vacancy** — a second resurrection vector.
 
-Underneath, the store already keeps **two** monotonic counters that are two
-**axes** of one idea: `open_generations` (process-wide, used by the captures
-lineage to detect close-then-reopen — an *incarnation* counter) and
-`ParseState.generation` (per-lifetime, whose `mark_parse_finished` stale-check
-already refuses to record a superseded parse). Neither gates the tree write
-itself. The ingress writer ticket (`IngressOrderGate`,
-`src/lsp/ingress_order.rs`) is a *third* per-document sequence — intra-lifetime
-wire order, which restarts on reopen — and the reader-ordering watermark this
-design needs would be a *fourth*. They are four implementations of two axes:
-*which lifetime* (incarnation) and *where in that lifetime's wire order*
-(ticket).
+The ordering contract has two axes: *which lifetime* (incarnation) and *where
+in that lifetime's wire order* (the ingress writer ticket). The incarnation
+must survive close/reopen without reuse, while the ticket orders work within
+one lifetime. Historical parse-progress bookkeeping did not guard tree writes;
+its unread state has since been deleted without replacement (#1063). The
+[parse-snapshot architecture](parse-snapshot-architecture.md) describes the
+current publication contract and the separately retained reader watermark.
 
 The common root is that a document's parser readiness and parse scheduling have
 **no single owner**.
@@ -93,9 +89,8 @@ the parse-scheduling decision. Pair it with a **single per-document epoch** — 
 pair `(incarnation, ticket)` — that is the one source of truth for ordering,
 resurrection-safety, and parse-staleness: the retained process-wide open
 generation (the incarnation, monotonic across reopen) paired with the ingress
-writer ticket (intra-lifetime wire order), folding `ParseState.generation` and the
-otherwise-new reader watermark into those two axes, and taking over the
-`edit_lock`'s resurrection-guard duty at the tree write.
+writer ticket (intra-lifetime wire order), with publication checking those axes
+rather than relying on the `edit_lock` alone for resurrection safety.
 
 The owner is deliberately a scheduler rather than a mailbox actor that owns the
 document's text (the actor is Option 4, not chosen; see below). Because
@@ -168,10 +163,9 @@ Two derived quantities read off this one pair; the unification is of the
 - **Resurrection-safety (epoch-checked CAS writes).** Every tree write becomes an
   **atomic, non-inserting** store update checked against the full
   `(incarnation, ticket)` pair: it no-ops if the document is gone (`Vacant`), the
-  incarnation differs (a reopen happened), or the ticket moved. This folds both
-  `open_generations` (incarnation mismatch) and `ParseState.generation` (ticket
-  mismatch) into one comparison, generalizing the existing `mark_parse_finished`
-  stale-check from the parse-state to the tree itself. The owner's parse is one
+  incarnation differs (a reopen happened), or the ticket moved. The check
+  belongs to the tree publication itself, not to separate parse-progress
+  bookkeeping. The owner's parse is one
   writer; the reader on-demand fallbacks are the others (see below) — the guarantee
   holds only if **every** store-writing path uses this CAS.
 - **Close-then-reopen detection** is the incarnation half: a reopen draws a fresh
@@ -397,12 +391,11 @@ scheduler keeps the text in the store in the first place.
 - **Burst coalescing.** A run of edits collapses to one parse over the
   accumulated text, saving the per-edit reparse cost on injection-heavy documents
   (the cost force).
-- **One epoch, two axes, not four sequences.** Wire-order readiness,
+- **Explicit ordering axes.** Wire-order readiness,
   resurrection-safety, and parse-staleness key on a single composite epoch
   `(incarnation, ticket)` — the retained process-wide open generation paired with
-  the ingress ticket — into which `ParseState.generation` and the reader watermark
-  fold, and whose per-write check takes over the `edit_lock`'s resurrection-guard
-  duty. The incarnation half keeps the epoch monotonic across a reopen even though
+  the ingress ticket — whose per-write check establishes resurrection safety
+  at publication. The incarnation half keeps the epoch monotonic across a reopen even though
   tickets restart.
 - **The install/parse resurrection path is structurally closed** — a close removes
   the store entry and advances the epoch, so a later parse or shared-install

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -11,7 +11,6 @@ use url::Url;
 // The central store for all document-related information.
 pub struct DocumentStore {
     documents: DashMap<Url, Document>,
-    parse_states: DashMap<Url, watch::Sender<ParseState>>,
     /// Per-document serialization lock for `didChange` application.
     ///
     /// `didChange` handlers read the current text, apply incremental ranges, and
@@ -58,13 +57,6 @@ pub struct DocumentStore {
     watermarks: DashMap<Url, watch::Sender<Watermark>>,
 }
 
-#[derive(Clone, Copy, Debug, Default)]
-struct ParseState {
-    generation: u64,
-    in_progress: bool,
-    has_tree: bool,
-}
-
 /// The value carried by a document's parse-watermark channel: the open
 /// `incarnation` the channel belongs to, and the highest `ticket` whose parse
 /// has resolved for that lifetime. Storing the incarnation **in the channel**
@@ -101,7 +93,6 @@ impl Default for DocumentStore {
     fn default() -> Self {
         Self {
             documents: DashMap::new(),
-            parse_states: DashMap::new(),
             edit_locks: DashMap::new(),
             open_counter: std::sync::atomic::AtomicU64::new(1),
             watermarks: DashMap::new(),
@@ -130,77 +121,7 @@ impl DocumentStore {
             uris.push(entry.key().clone());
             entry.value_mut().invalidate_parse();
         }
-        for uri in &uris {
-            self.update_tree_availability(uri, false);
-        }
         uris
-    }
-
-    /// Update tree availability without affecting parse-in-progress tracking.
-    /// The `in_progress` state is owned exclusively by mark_parse_started/mark_parse_finished.
-    fn update_tree_availability(&self, uri: &Url, has_tree: bool) {
-        let sender = self.parse_sender(uri);
-        let mut state = *sender.borrow();
-        state.has_tree = has_tree;
-        sender.send_replace(state);
-    }
-
-    /// Set `has_tree = true` only if a parse-state entry already exists.
-    ///
-    /// Unlike [`update_tree_availability`] this does **not** create the entry
-    /// (`get`, not `parse_sender`'s get-or-insert). For a live document the entry
-    /// always exists (created on insert), so this is equivalent; but for the
-    /// non-inserting `install_parse` (which may run after a `didClose`) it avoids
-    /// resurrecting a parse-state for a URI that a concurrent `didClose` removed — `remove` drops `parse_states` first, so a
-    /// get-or-insert here would recreate a ghost `has_tree = true` for a closed
-    /// document. Holding the `Ref` serializes against that `remove`.
-    fn mark_tree_available_if_tracked(&self, uri: &Url) {
-        if let Some(sender) = self.parse_states.get(uri) {
-            let mut state = *sender.borrow();
-            state.has_tree = true;
-            sender.send_replace(state);
-        }
-    }
-
-    fn parse_sender(&self, uri: &Url) -> watch::Sender<ParseState> {
-        match self.parse_states.entry(uri.clone()) {
-            Entry::Occupied(entry) => entry.get().clone(),
-            Entry::Vacant(entry) => {
-                let (sender, _receiver) = watch::channel(ParseState::default());
-                entry.insert(sender.clone());
-                sender
-            }
-        }
-    }
-
-    pub fn mark_parse_started(&self, uri: &Url) -> u64 {
-        let sender = self.parse_sender(uri);
-        let mut state = *sender.borrow();
-        state.generation = state.generation.saturating_add(1);
-        state.in_progress = true;
-        state.has_tree = false;
-        sender.send_replace(state);
-        state.generation
-    }
-
-    pub fn mark_parse_finished(&self, uri: &Url, generation: u64, has_tree: bool) {
-        // Non-inserting (`get`, not `parse_sender`'s get-or-insert), mirroring
-        // [`mark_tree_available_if_tracked`]: once the open parse runs off the ingress
-        // ticket (#6) a `didClose` can land between `mark_parse_started` and here, and
-        // `remove` drops `parse_states` first — a get-or-insert would recreate an
-        // orphan default entry for the closed URI. The generation guard already
-        // prevents state corruption; this also stops the resurrection. Holding the
-        // `Ref` serializes against that `remove`.
-        let Some(sender) = self.parse_states.get(uri) else {
-            return;
-        };
-        let mut state = *sender.borrow();
-        if state.generation != generation {
-            return;
-        }
-        state.in_progress = false;
-        state.has_tree = has_tree;
-        sender.send_replace(state);
     }
 
     // Lock safety: Single insert() call - no read lock held before or during write
@@ -211,7 +132,6 @@ impl DocumentStore {
         language_id: Option<String>,
         tree: Option<Tree>,
     ) -> u64 {
-        let has_tree = tree.is_some();
         // didOpen registers a fresh lifetime → a fresh incarnation, so an
         // in-flight parse from a prior open of this URI can't publish against it.
         let incarnation = self.next_incarnation();
@@ -221,13 +141,9 @@ impl DocumentStore {
             _ => Document::new(text, incarnation),
         };
 
-        // The parse-state and watermark maps are independent of `documents`, so seed
-        // them with the borrowed `&uri` first and let `documents.insert` consume the
-        // owned `uri` last — avoiding a `Url` clone on every didOpen.
-        self.update_tree_availability(&uri, has_tree);
-        // Seed the watermark for this lifetime's incarnation so its lifetime tracks
-        // the document's; the advance paths are non-inserting and rely on this
-        // entry being present. A reopen replaces any leftover prior-lifetime channel.
+        // Seed this lifetime's watermark before documents.insert consumes the
+        // URI, avoiding a clone. Non-inserting advance paths rely on this entry;
+        // a reopen replaces any leftover prior-lifetime channel.
         self.ensure_watermark_entry(&uri, incarnation);
         self.documents.insert(uri, document);
         incarnation
@@ -252,30 +168,26 @@ impl DocumentStore {
         // `Url` clone. Only a miss falls back to `entry` (owned key), which re-checks
         // for a document a concurrent insert added between the `get_mut` and here —
         // matching `apply_edit`.
-        let (has_tree, incarnation) = if let Some(mut doc) = self.documents.get_mut(&uri) {
+        let incarnation = if let Some(mut doc) = self.documents.get_mut(&uri) {
             // Update in place, preserving the incarnation (an edit is the same lifetime).
-            let has_tree = if let Some(tree) = new_tree {
+            if let Some(tree) = new_tree {
                 doc.update_tree_and_text(tree, text);
-                true
             } else {
                 // No new tree provided - clear existing tree and update text only.
                 // This path is used when text changes without re-parsing (rare edge case).
                 doc.update_text(text);
-                false
-            };
-            (has_tree, doc.incarnation())
+            }
+            doc.incarnation()
         } else {
             match self.documents.entry(uri.clone()) {
                 Entry::Occupied(mut entry) => {
                     let doc = entry.get_mut();
-                    let has_tree = if let Some(tree) = new_tree {
+                    if let Some(tree) = new_tree {
                         doc.update_tree_and_text(tree, text);
-                        true
                     } else {
                         doc.update_text(text);
-                        false
-                    };
-                    (has_tree, doc.incarnation())
+                    }
+                    doc.incarnation()
                 }
                 Entry::Vacant(entry) => {
                     // Document doesn't exist - create new one (a fresh lifetime →
@@ -283,23 +195,20 @@ impl DocumentStore {
                     // counter, not `documents`, so drawing it while holding this
                     // entry's shard write lock cannot deadlock.
                     let incarnation = self.next_incarnation();
-                    let has_tree = if let Some(tree) = new_tree {
+                    if let Some(tree) = new_tree {
                         entry.insert(Document::with_tree(
                             text,
                             "unknown".to_string(),
                             tree,
                             incarnation,
                         ));
-                        true
                     } else {
                         entry.insert(Document::new(text, incarnation));
-                        false
-                    };
-                    (has_tree, incarnation)
+                    }
+                    incarnation
                 }
             }
         };
-        self.update_tree_availability(&uri, has_tree);
         // Keep the "live document ⟺ watermark entry" invariant: `update_document`
         // can insert on its `Vacant` branch, and a present document with no
         // watermark entry would break the live-document ⟺ watermark invariant.
@@ -310,10 +219,9 @@ impl DocumentStore {
     /// Apply a `didChange`'s new text and log its edits for the **incremental
     /// parse seed** — the per-document-parse-scheduler flip's edit path.
     ///
-    /// The version bump makes the published tree stale (so a reader never sees a
-    /// tree predating this edit); the side effects are tree-availability → false
-    /// and the watermark entry ensured; and the `edits` are logged for the
-    /// off-ingress `reparse_latest`'s incremental seed. With no `edits` (full-text
+    /// The version bump marks the published tree stale. The watermark entry is
+    /// ensured and the `edits` are logged for the off-ingress `reparse_latest`'s
+    /// incremental seed. With no `edits` (full-text
     /// sync) seeding is forbidden until a fresh tree is published (#348).
     /// Coalesced edits accumulate in the log (see [`Document::apply_edit`]).
     ///
@@ -326,7 +234,7 @@ impl DocumentStore {
         // which also re-checks for a document a concurrent open inserted between the
         // `get_mut` and here — mirroring `ParseScheduler::schedule` and the atomicity
         // of the prior `update_document`. The `RefMut` / entry is dropped before the
-        // parse-state and watermark updates below (separate maps), keeping the
+        // watermark update below (a separate map), keeping the
         // `documents` shard lock held no longer than `update_document` did.
         let incarnation = if let Some(mut doc) = self.documents.get_mut(uri) {
             doc.apply_edit(text, edits);
@@ -347,7 +255,6 @@ impl DocumentStore {
                 }
             }
         };
-        self.update_tree_availability(uri, false);
         // Keep the "live document ⟺ watermark entry" invariant (see `update_document`).
         self.ensure_watermark_entry(uri, incarnation);
     }
@@ -538,7 +445,6 @@ impl DocumentStore {
     /// gone. Keeping the map entry makes a fast reopen wait on the same mutex
     /// instead of creating a fresh lock and racing the old lifetime's cleanup.
     pub(crate) fn remove_preserving_edit_lock(&self, uri: &Url) -> Option<Document> {
-        self.parse_states.remove(uri);
         // Dropping the watermark sender wakes any reader still blocked on
         // the watermark for this document, so a reader racing the close
         // proceeds into the empty fallback instead of stalling to the timeout.
@@ -788,9 +694,7 @@ impl DocumentStore {
     /// A stale-but-consistent parse (an edit landed since) still publishes,
     /// which serve-stale readers consume (parse-snapshot ADR); the cell
     /// rejects an out-of-order version on its own; a failed language check
-    /// rejects the install outright. The `parse_states` `has_tree` flip runs
-    /// after the guard is released (a different map); it is non-inserting,
-    /// so a `didClose` between the two leaves no ghost entry.
+    /// rejects the install outright.
     pub(crate) fn install_parse(
         &self,
         uri: &Url,
@@ -862,11 +766,6 @@ impl DocumentStore {
                 target: "kakehashi::snapshot",
                 "publish rejected for {uri}: v{version} inc{incarnation}"
             );
-        }
-        // A different map (`parse_states`): touched only after the document
-        // guard above is released.
-        if outcome.current && has_tree {
-            self.mark_tree_available_if_tracked(uri);
         }
         outcome
     }
@@ -1143,42 +1042,6 @@ mod tests {
         drop(expected_text);
     }
 
-    /// `didClose` drops the parse state before the document; an install that
-    /// lands in that window must not recreate the parse state for a
-    /// document that is going away.
-    #[test]
-    fn install_parse_does_not_recreate_parse_state_dropped_by_a_close() {
-        let store = DocumentStore::new();
-        let uri = Url::parse("file:///closing.md").unwrap();
-        let text = "# doc\n";
-        let incarnation = store.insert(
-            uri.clone(),
-            text.to_string(),
-            Some("markdown".to_string()),
-            None,
-        );
-        let (expected_text, content_version) = {
-            let doc = store.get(&uri).unwrap();
-            (doc.text_arc(), doc.content_version())
-        };
-        store.parse_states.remove(&uri);
-        let installed = store.install_parse(
-            &uri,
-            LanguageCheck::Record,
-            parse_snapshot(
-                &expected_text,
-                Some(markdown_tree(text)),
-                content_version,
-                incarnation,
-            ),
-        );
-        assert!(installed.current, "the document itself is still there");
-        assert!(
-            !store.parse_states.contains_key(&uri),
-            "a parse state the close already dropped must not be recreated"
-        );
-    }
-
     /// An off-ingress reparse names the language it parsed under; a reopen
     /// that relabelled the URI (same text, new lifetime and language) must
     /// not receive the tree, and neither must a same-language reopen with
@@ -1338,8 +1201,8 @@ mod tests {
             ),
         );
         assert!(
-            store.get(&uri).is_none() && !store.parse_states.contains_key(&uri),
-            "an install into a closed document must not resurrect it or its parse state"
+            store.get(&uri).is_none(),
+            "an install into a closed document must not resurrect it"
         );
     }
 

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -517,7 +517,8 @@ impl ParseCoordinator {
     /// rechecks currency after the awaited work; downstream never acts on the
     /// earlier install-time verdict. A skipped/cancelled/panicking resolution
     /// leaves the first snapshot usable and readers fall back inline.
-    /// Awaiting the work unit preserves populate → mark-finished ordering.
+    /// Awaiting the work unit keeps optional enrichment before the caller advances
+    /// its watermark.
     async fn populate_and_install(
         &self,
         uri: &Url,
@@ -732,10 +733,8 @@ impl ParseCoordinator {
         let mut events = Vec::new();
 
         // Read the text the registering didOpen already stored (a refcount bump, not
-        // a copy), together with the open lifetime's **incarnation** — BEFORE marking
-        // the parse started, so a document a `didClose` already removed leaves neither
-        // a resurrected document nor an orphan parse-state entry for the now-closed
-        // URI. A missing document stops **without** touching the watermark: the
+        // a copy), together with the open lifetime's **incarnation**. A missing
+        // document stops **without** touching the watermark: the
         // watermark is per-lifetime, so a plain advance with this prior-lifetime
         // ticket could inflate a reopen's freshly-seeded channel and prematurely
         // release a new-lifetime reader; a genuine close instead drops the channel and
@@ -766,8 +765,6 @@ impl ParseCoordinator {
                     .advance_watermark_for_incarnation(&uri, ticket, incarnation);
             }
         };
-
-        let parse_generation = self.documents.mark_parse_started(&uri);
 
         let language_name = self
             .language
@@ -834,13 +831,6 @@ impl ParseCoordinator {
                         version_cancel.clone(),
                     )
                     .await;
-                if installed.current_at_completion {
-                    // AFTER the install: a downstream task woken by this mark
-                    // on another runtime thread must find the snapshot (and
-                    // its fast-path regions) already in the cell.
-                    self.documents
-                        .mark_parse_finished(&uri, parse_generation, true);
-                }
                 advance_watermark();
                 self.notifier().log_language_events(&events).await;
                 // Carry the producing revision across this await. Admission
@@ -856,40 +846,13 @@ impl ParseCoordinator {
             // through to the no-language path below which would null it out. Host
             // bridging needs only text + language (never a tree), so preserving the
             // language keeps a host-bridged document working after a parse failure.
-            let installed = self
-                .install_and_reconcile(
-                    &uri,
-                    crate::document::LanguageCheck::Record,
-                    std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
-                        text: text.clone(),
-                        tree: None,
-                        language: Some(language_name.clone()),
-                        parsed_version: content_version,
-                        incarnation,
-                        injection_regions: None,
-                        regions: None,
-                        layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
-                    }),
-                )
-                .await;
-            if installed.current {
-                self.documents
-                    .mark_parse_finished(&uri, parse_generation, false);
-            }
-            advance_watermark();
-            self.notifier().log_language_events(&events).await;
-            return None;
-        }
-
-        // No language detected at all → store no language, no tree.
-        let installed = self
-            .install_and_reconcile(
+            self.install_and_reconcile(
                 &uri,
                 crate::document::LanguageCheck::Record,
                 std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
                     text: text.clone(),
                     tree: None,
-                    language: None,
+                    language: Some(language_name.clone()),
                     parsed_version: content_version,
                     incarnation,
                     injection_regions: None,
@@ -898,10 +861,27 @@ impl ParseCoordinator {
                 }),
             )
             .await;
-        if installed.current {
-            self.documents
-                .mark_parse_finished(&uri, parse_generation, false);
+            advance_watermark();
+            self.notifier().log_language_events(&events).await;
+            return None;
         }
+
+        // No language detected at all → store no language, no tree.
+        self.install_and_reconcile(
+            &uri,
+            crate::document::LanguageCheck::Record,
+            std::sync::Arc::new(crate::document::snapshot::ParseSnapshot {
+                text: text.clone(),
+                tree: None,
+                language: None,
+                parsed_version: content_version,
+                incarnation,
+                injection_regions: None,
+                regions: None,
+                layer_trees: std::sync::Arc::new(std::sync::OnceLock::new()),
+            }),
+        )
+        .await;
         advance_watermark();
         self.notifier().log_language_events(&events).await;
         None


### PR DESCRIPTION
Merge note: compacted locally and rebased onto the latest main before merge. No raw archive or archive-adding commit is included in the ancestry introduced to main.

The private `ParseState` watch channel had no readers; parses still updated its generation, progress, and tree-availability fields. This removes that map and its writers without adding generation checks or moving the state into the scheduler.

Snapshot publication and reconciliation, content versions, incarnation checks, edit locks, and ingress watermark channels retain their existing behavior. Architecture documentation now distinguishes content versions from ingress tickets and describes the remaining publication order.

Validation: `make check`, all-target/all-feature Clippy, 3,751 library tests, 445 E2E tests, and 79 integration tests passed (2 library and 1 E2E ignored). The only removed test exercised the deleted map; document-close resurrection coverage remains.

Stacked on #1074. Fixes #1063.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal document parsing and scheduling state management.
  - Updated parse publication and ordering behavior to use clearer snapshot and watermark handling.
  - Removed obsolete parse-progress tracking while preserving document updates and language-service events.

- **Documentation**
  - Updated architecture decision records to reflect the current parsing, snapshot, and scheduling workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->